### PR TITLE
Remove terraform and pre-commit from tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,8 +1,5 @@
 # This file is for you! Please, updated to the versions agreed by your team.
 
-terraform 1.7.0
-pre-commit 3.6.0
-
 # ==============================================================================
 # The section below is reserved for Docker image versions.
 


### PR DESCRIPTION
Neither of these are used by this project., and having these here triggers messages in my shell that I don't have the right version installed.
