### PR TITLE
Specify Python version using `.tool-versions`

### DIFF
--- a/.github/workflows/MAVIS_TEST.yml
+++ b/.github/workflows/MAVIS_TEST.yml
@@ -21,10 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version-file: .tool-versions
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,5 @@
-# This file is for you! Please, updated to the versions agreed by your team.
-
 editorconfig-checker 3.2.1
+python 3.13.3
 
 # ==============================================================================
 # The section below is reserved for Docker image versions.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ It is currently configured to run on the QA environment.  The project utilizes t
 
 ## Installation
 
-This test pack requires Python 3.10 installed on the system or greater to run.
-
-To execute the tests from your system, please follow the 4 easy steps below:
+To execute the tests from your system, please follow the steps below:
 
 1. Clone the repository to any local folder
 
    ```console
    git clone https://github.com/NHSDigital/manage-vaccinations-in-schools-testing.git
+   ```
+
+1. Install Python
+
+   The version of Python is specified in the `.tool-versions` file meaning it can be managed automatically using tools
+   such as [Mise](https://mise.jdx.dev) or [Asdf](https://asdf-vm.com).
+
+   ```console
+   mise install
    ```
 
 1. Create a virtual environment


### PR DESCRIPTION
This file is a fairly standard approach to managing different versions of Python and it ensures that our CI environment stays in sync with the local version of Python.