### PR TITLE
Refactor how year groups are handled

### DIFF
--- a/libs/mavis_constants.py
+++ b/libs/mavis_constants.py
@@ -7,14 +7,6 @@ class playwright_constants:
     DEFAULT_TIMEOUT: Final[int] = 60000
 
 
-class child_year_group:
-    YEAR_8: Final[str] = "YEAR_8"
-    YEAR_9: Final[str] = "YEAR_9"
-    YEAR_10: Final[str] = "YEAR_10"
-    YEAR_11: Final[str] = "YEAR_11"
-    ALL: Final[str] = "ALL"
-
-
 class programmes:
     HPV: Final[str] = "HPV"
     MENACWY: Final[str] = "MenACWY"

--- a/libs/testdata_ops.py
+++ b/libs/testdata_ops.py
@@ -7,7 +7,7 @@ from libs.wrappers import (
     get_current_datetime,
     get_current_time,
     get_offset_date,
-    get_dob_from_year,
+    get_date_of_birth_for_year_group,
 )
 
 
@@ -55,12 +55,13 @@ class testdata_operations:
             "<<VACCS_DATE>>": _dt[:8],
             "<<VACCS_TIME>>": get_current_time(),
             "<<HIST_VACCS_DATE>>": _hist_dt,
-            "<<DOB_YEAR_8>>": get_dob_from_year(year_group=8),
-            "<<DOB_YEAR_9>>": get_dob_from_year(year_group=9),
-            "<<DOB_YEAR_10>>": get_dob_from_year(year_group=10),
-            "<<DOB_YEAR_11>>": get_dob_from_year(year_group=11),
             "<<SESSION_ID>>": _session_id,
         }
+
+        for year_group in range(8, 12):
+            replacements[f"<<DOB_YEAR_{year_group}>>"] = (
+                get_date_of_birth_for_year_group(year_group)
+            )
 
         _file_text = []
         _ctr = 0

--- a/libs/testdata_ops.py
+++ b/libs/testdata_ops.py
@@ -2,7 +2,7 @@ import nhs_number
 import pandas as pd
 
 from libs import CurrentExecution, file_ops
-from libs.mavis_constants import child_year_group, mavis_file_types, test_data_values
+from libs.mavis_constants import mavis_file_types, test_data_values
 from libs.wrappers import (
     get_current_datetime,
     get_current_time,
@@ -55,10 +55,10 @@ class testdata_operations:
             "<<VACCS_DATE>>": _dt[:8],
             "<<VACCS_TIME>>": get_current_time(),
             "<<HIST_VACCS_DATE>>": _hist_dt,
-            "<<DOB_YEAR_8>>": get_dob_from_year(year_group=child_year_group.YEAR_8),
-            "<<DOB_YEAR_9>>": get_dob_from_year(year_group=child_year_group.YEAR_9),
-            "<<DOB_YEAR_10>>": get_dob_from_year(year_group=child_year_group.YEAR_10),
-            "<<DOB_YEAR_11>>": get_dob_from_year(year_group=child_year_group.YEAR_11),
+            "<<DOB_YEAR_8>>": get_dob_from_year(year_group=8),
+            "<<DOB_YEAR_9>>": get_dob_from_year(year_group=9),
+            "<<DOB_YEAR_10>>": get_dob_from_year(year_group=10),
+            "<<DOB_YEAR_11>>": get_dob_from_year(year_group=11),
             "<<SESSION_ID>>": _session_id,
         }
 

--- a/libs/wrappers.py
+++ b/libs/wrappers.py
@@ -2,7 +2,6 @@ import random
 from datetime import datetime, timedelta
 
 from libs.generic_constants import escape_characters
-from libs.mavis_constants import child_year_group
 
 
 def convert_time_units_to_seconds(time_unit: str) -> int:
@@ -122,23 +121,8 @@ def get_dob_from_year(year_group: str) -> str:
     Returns:
         str: A random date of birth for the specified year group in the "YYYYMMDD" format.
     """
-    match year_group:
-        case child_year_group.YEAR_8:
-            year_offset = (
-                8  # In 2025, outputs a random date between 2011-09-01 and 2012-08-31
-            )
-        case child_year_group.YEAR_9:
-            year_offset = (
-                9  # In 2025, outputs a random date between 2010-09-01 and 2011-08-31
-            )
-        case child_year_group.YEAR_10:
-            year_offset = (
-                10  # In 2025, Outputs a random date between 2009-09-01 and 2010-08-31
-            )
-        case child_year_group.YEAR_11:
-            year_offset = (
-                11  # In 2025, outputs a random date between 2008-09-01 and 2009-08-31
-            )
+
+    year_offset = year_group
 
     # Determine the academic year offset
     current_year = datetime.now().year

--- a/libs/wrappers.py
+++ b/libs/wrappers.py
@@ -1,7 +1,11 @@
-import random
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
+
+from faker import Faker
 
 from libs.generic_constants import escape_characters
+
+
+faker = Faker()
 
 
 def convert_time_units_to_seconds(time_unit: str) -> int:
@@ -111,31 +115,10 @@ def get_offset_date(offset_days: int) -> str:
     return _offset_date.strftime("%Y%m%d")
 
 
-def get_dob_from_year(year_group: str) -> str:
-    """
-    Get a random date as a date of birth for the specified year group.
+def get_date_of_birth_for_year_group(year_group: int) -> str:
+    academic_year = date.today().year - year_group - 6
 
-    Args:
-        year_group (str): Child year group.
+    start_date = date(academic_year, 9, 1)
+    end_date = date(academic_year + 1, 8, 31)
 
-    Returns:
-        str: A random date of birth for the specified year group in the "YYYYMMDD" format.
-    """
-
-    year_offset = year_group
-
-    # Determine the academic year offset
-    current_year = datetime.now().year
-    base_year = current_year - 15  # Base year is 15 years ago
-    start_year = base_year + (9 - year_offset)  # Adjust range for each year
-    end_year = start_year + 1
-
-    # Define the start and end dates for the range
-    start_date = datetime(start_year, 9, 1)  # Start date for each year group
-    end_date = datetime(end_year, 8, 31)  # End date for each year group
-
-    # Generate a random date between start_date and end_date
-    random_date = start_date + timedelta(
-        days=random.randint(0, (end_date - start_date).days)
-    )
-    return random_date.strftime("%Y-%m-%d")
+    return faker.date_between(start_date, end_date)

--- a/pages/pg_import_records.py
+++ b/pages/pg_import_records.py
@@ -1,8 +1,8 @@
-from typing import Final
+from typing import Final, Optional
 
 from libs import CurrentExecution, file_ops, playwright_ops, testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
-from libs.mavis_constants import child_year_group, mavis_file_types, record_limit
+from libs.mavis_constants import mavis_file_types, record_limit
 from libs.wrappers import get_link_formatted_date_time
 from pages import pg_children, pg_dashboard, pg_sessions, pg_vaccines
 
@@ -30,10 +30,6 @@ class pg_import_records:
     LBL_CLASS_LIST_RECORDS_FOR_SCHOOL1: Final[str] = "Upload file"
     LBL_SCHOOL_NAME: Final[str] = "Which school is this class"
     LBL_MAIN: Final[str] = "main"
-    CHK_YEAR8: Final[str] = "Year 8"
-    CHK_YEAR9: Final[str] = "Year 9"
-    CHK_YEAR10: Final[str] = "Year 10"
-    CHK_YEAR11: Final[str] = "Year 11"
     LNK_IMPORT_CLASS_LIST_RECORDS: Final[str] = "Import class lists"
 
     def __init__(self):
@@ -72,9 +68,12 @@ class pg_import_records:
     def import_class_list_records(
         self,
         file_paths: str,
-        year_group: str = child_year_group.ALL,
+        year_groups: Optional[int] = None,
         verify_on_children_page: bool = False,
     ):
+        if year_groups is None:
+            year_groups = [8, 9, 10, 11]
+
         _input_file_path, _output_file_path = self.tdo.get_file_paths(
             file_paths=file_paths
         )
@@ -94,7 +93,7 @@ class pg_import_records:
             value=self.sessions_page.LNK_SCHOOL_1,
         )
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
-        self._select_year_group(year_group=year_group)
+        self._select_year_groups(*year_groups)
         self.po.act(
             locator=self.LBL_CLASS_LIST_RECORDS,
             action=actions.SELECT_FILE,
@@ -116,7 +115,7 @@ class pg_import_records:
         self.po.act(
             locator=self.LNK_IMPORT_CLASS_LIST_RECORDS, action=actions.CLICK_LINK
         )
-        self._select_year_group(year_group=child_year_group.ALL)
+        self._select_year_groups(8, 9, 10, 11)
         self.po.act(
             locator=self.LBL_CLASS_LIST_RECORDS_FOR_SCHOOL1,
             action=actions.SELECT_FILE,
@@ -195,21 +194,9 @@ class pg_import_records:
                 exact=False,
             )
 
-    def _select_year_group(self, year_group: str) -> None:
-        match year_group:
-            case child_year_group.YEAR_8:
-                self.po.act(locator=self.CHK_YEAR8, action=actions.CHECKBOX_CHECK)
-            case child_year_group.YEAR_9:
-                self.po.act(locator=self.CHK_YEAR9, action=actions.CHECKBOX_CHECK)
-            case child_year_group.YEAR_10:
-                self.po.act(locator=self.CHK_YEAR10, action=actions.CHECKBOX_CHECK)
-            case child_year_group.YEAR_11:
-                self.po.act(locator=self.CHK_YEAR11, action=actions.CHECKBOX_CHECK)
-            case _:
-                self.po.act(locator=self.CHK_YEAR8, action=actions.CHECKBOX_CHECK)
-                self.po.act(locator=self.CHK_YEAR9, action=actions.CHECKBOX_CHECK)
-                self.po.act(locator=self.CHK_YEAR10, action=actions.CHECKBOX_CHECK)
-                self.po.act(locator=self.CHK_YEAR11, action=actions.CHECKBOX_CHECK)
+    def _select_year_groups(self, *year_groups: int) -> None:
+        for year_group in year_groups:
+            self.po.act(locator=f"Year {year_group}", action=actions.CHECKBOX_CHECK)
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
 
     def verify_mav_855(self):

--- a/pages/pg_sessions.py
+++ b/pages/pg_sessions.py
@@ -3,7 +3,6 @@ from typing import Final
 from libs import CurrentExecution, file_ops, playwright_ops, testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
 from libs.mavis_constants import (
-    child_year_group,
     mavis_file_types,
     programmes,
     record_limit,
@@ -551,7 +550,7 @@ class pg_sessions:
         self.click_scheduled()
         self.click_school1()
         self.click_import_class_list()
-        self.select_year_group(year_group=child_year_group.ALL)
+        self.select_year_groups(8, 9, 10, 11)
         self.choose_file_child_records_for_school_1(file_path=_input_file_path)
         self.click_continue()
         self.dashboard_page.go_to_dashboard()
@@ -599,7 +598,7 @@ class pg_sessions:
         self.click_scheduled()
         self.click_school1()
         self.click_import_class_list()
-        self.select_year_group(year_group=child_year_group.ALL)
+        self.select_year_groups(8, 9, 10, 11)
         self.choose_file_child_records_for_school_1(file_path=_input_file_path)
         self.click_continue()
         self.dashboard_page.go_to_dashboard()
@@ -699,7 +698,6 @@ class pg_sessions:
         self,
         file_paths: str,
         verify_on_children: bool = False,
-        year_group: str = child_year_group.ALL,
     ):
         _input_file_path, _output_file_path = self.tdo.get_file_paths(
             file_paths=file_paths
@@ -709,7 +707,7 @@ class pg_sessions:
                 file_path=_input_file_path, file_type=mavis_file_types.CLASS_LIST
             )
         self.click_import_class_list()
-        self.select_year_group(year_group=year_group)
+        self.select_year_groups([8, 9, 10, 11])
         self.choose_file_child_records_for_school_1(file_path=_input_file_path)
         self.click_continue()
         self._record_upload_time()
@@ -721,10 +719,7 @@ class pg_sessions:
             self.children_page.verify_child_has_been_uploaded(child_list=_cl)
 
     def upload_class_list_to_school_2(
-        self,
-        file_paths: str,
-        verify_on_children: bool = False,
-        year_group: str = child_year_group.ALL,
+        self, file_paths: str, verify_on_children: bool = False
     ):
         _input_file_path, _output_file_path = self.tdo.get_file_paths(
             file_paths=file_paths
@@ -734,7 +729,7 @@ class pg_sessions:
                 file_path=_input_file_path, file_type=mavis_file_types.CLASS_LIST
             )
         self.click_import_class_list()
-        self.select_year_group(year_group=year_group)
+        self.select_year_groups(8, 9, 10, 11)
         self.choose_file_child_records_for_school_2(file_path=_input_file_path)
         self.click_continue()
         self._record_upload_time()
@@ -936,21 +931,9 @@ class pg_sessions:
         self.click_get_consent_response()
         self.consent_page.parent_1_verbal_positive(change_phone=False)
 
-    def select_year_group(self, year_group: str) -> None:
-        match year_group:
-            case child_year_group.YEAR_8:
-                self.po.act(locator=self.CHK_YEAR8, action=actions.CHECKBOX_CHECK)
-            case child_year_group.YEAR_9:
-                self.po.act(locator=self.CHK_YEAR9, action=actions.CHECKBOX_CHECK)
-            case child_year_group.YEAR_10:
-                self.po.act(locator=self.CHK_YEAR10, action=actions.CHECKBOX_CHECK)
-            case child_year_group.YEAR_11:
-                self.po.act(locator=self.CHK_YEAR11, action=actions.CHECKBOX_CHECK)
-            case _:
-                self.po.act(locator=self.CHK_YEAR8, action=actions.CHECKBOX_CHECK)
-                self.po.act(locator=self.CHK_YEAR9, action=actions.CHECKBOX_CHECK)
-                self.po.act(locator=self.CHK_YEAR10, action=actions.CHECKBOX_CHECK)
-                self.po.act(locator=self.CHK_YEAR11, action=actions.CHECKBOX_CHECK)
+    def select_year_groups(self, *year_groups: int) -> None:
+        for year_group in year_groups:
+            self.po.act(locator=f"Year {year_group}", action=actions.CHECKBOX_CHECK)
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
 
     def _answer_hpv_prescreening_questions(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ et-xmlfile==1.1.0
 exceptiongroup==1.2.2
 execnet==2.1.1
 executing==2.1.0
+faker==37.3.0
 greenlet==3.1.1
 idna==3.10
 iniconfig==2.1.0

--- a/tests/test_03_import_records.py
+++ b/tests/test_03_import_records.py
@@ -1,7 +1,6 @@
 import pytest
 
 from libs.mavis_constants import (
-    child_year_group,
     mavis_file_types,
     test_data_file_paths,
 )
@@ -155,7 +154,7 @@ class Test_ImportRecords:
     def test_class_list_year_group(self, setup_class_list: None):
         self.import_records_page.import_class_list_records(
             file_paths=test_data_file_paths.CLASS_YEAR_GROUP,
-            year_group=child_year_group.YEAR_8,
+            year_groups=[8],
         )
 
     @pytest.mark.classlist


### PR DESCRIPTION
This simplifies the code related to handling different year groups and date of births. By making it more dynamic it opens up the possibility in the future to select different combinations of year groups, and also making it easier when we come to support the Flu programme that includes far more year groups than we support currently.