### PR TITLE
Replace `--browser_or_device` option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::Chromium"
-          pytest --browser_or_device chromium
+          pytest --browser chromium
           echo "::endgroup::"
       - name: Test on Chrome
         if: always()
@@ -70,7 +70,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::Chrome"
-          pytest --browser_or_device chrome
+          pytest --browser chromium --browser-channel chrome
           echo "::endgroup::"
       - name: Test on Firefox
         env:
@@ -91,7 +91,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::Firefox"
-          pytest --browser_or_device firefox
+          pytest --browser firefox
           echo "::endgroup::"
       - name: Test on Edge
         if: always()
@@ -113,7 +113,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::Edge"
-          pytest --browser_or_device msedge
+          pytest --browser chromium --browser-channel msedge
           echo "::endgroup::"
       - name: Test on iPhone 14
         if: always()
@@ -135,7 +135,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::iPhone 14"
-          pytest -m mobile --browser_or_device iphone_14
+          pytest -m mobile --browser webkit --device "iPhone 14"
           echo "::endgroup::"
       - name: Test on iPhone 15
         if: always()
@@ -157,7 +157,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::iPhone 15"
-          pytest -m mobile --browser_or_device iphone_15
+          pytest -m mobile --browser webkit --device "iPhone 15"
           echo "::endgroup::"
       - name: Test on iPad Gen 7
         if: always()
@@ -179,7 +179,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::iPad Gen 7"
-          pytest -m mobile --browser_or_device ipad_7
+          pytest -m mobile --browser webkit --device "iPad (gen 7) landscape"
           echo "::endgroup::"
       - name: Test on Samsung Galaxy S9+
         if: always()
@@ -201,7 +201,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::Samsung Galaxy S9+"
-          pytest -m mobile --browser_or_device s9+
+          pytest -m mobile --browser chromimum --device "Galaxy S9+"
           echo "::endgroup::"
       - name: Test on Google Pixel 7
         if: always()
@@ -223,7 +223,7 @@ jobs:
           API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           echo "::group::Google Pixel 7"
-          pytest -m mobile --browser_or_device pixel_7
+          pytest -m mobile --browser chromimum --device "Pixel 7"
           echo "::endgroup::"
       - name: Upload report
         if: always()

--- a/README.md
+++ b/README.md
@@ -60,12 +60,46 @@ $ ruff check
 
 ## Running
 
-Once the self test passes, you are good to go.
+```shell
+$ pytest
+```
 
-Tests for individual endpoints can be executed using individual markers.  For example:
+### Browsers and devices
 
-```console
-pytest -m regression
+By default, the tests will run using `Chromium` with no particular device,
+however it's possible to run the tests in different browsers and devices.
+Some examples are listed below.
+
+#### iPhone 15
+
+```shell
+$ pytest --browser webkit --device "iPhone 15"
+```
+
+#### Firefox
+
+```shell
+$ pytest --browser firefox
+```
+
+#### Google Pixel 7
+
+```shell
+$ pytest --browser chromium --device "Pixel 7"
+```
+
+#### Microsoft Edge
+
+```shell
+$ pytest --browser chromium --browser-channel msedge
+```
+
+### Markers
+
+Tests for individual endpoints can be executed using individual markers. For example:
+
+```shell
+$ pytest -m regression
 ```
 
 ## More information

--- a/conftest.py
+++ b/conftest.py
@@ -6,24 +6,38 @@ from playwright.sync_api import sync_playwright
 from libs import CurrentExecution as ce
 from libs import file_ops as fo
 from libs.generic_constants import audit_log_paths, file_mode
-from libs.mavis_constants import browsers_and_devices, playwright_constants
-from libs.wrappers import (
-    get_current_datetime,
-)
+from libs.mavis_constants import playwright_constants
+from libs.wrappers import get_current_datetime
 
 
 def pytest_addoption(parser):
-    parser.addoption(
-        "--browser_or_device", action="store", default=browsers_and_devices.CHROMIUM
-    )
+    parser.addoption("--browser", default="chromium")
+    parser.addoption("--browser-channel", default=None)
+    parser.addoption("--device", default=None)
 
 
 @pytest.fixture(scope="session")
-def start_playwright_session(request):
+def browser_name(request):
+    return request.config.getoption("browser")
+
+
+@pytest.fixture(scope="session")
+def browser_channel(request):
+    return request.config.getoption("browser_channel")
+
+
+@pytest.fixture(scope="session")
+def device(request):
+    return request.config.getoption("device")
+
+
+@pytest.fixture(scope="session")
+def start_playwright_session(browser_name):
     ce.get_env_values()
     ce.reset_environment()
-    ce.current_browser_name = request.config.getoption("browser_or_device")
-    ce.session_screenshots_dir = create_session_screenshot_dir()
+
+    ce.session_screenshots_dir = create_session_screenshot_dir(browser_name)
+
     with sync_playwright() as _playwright:
         _playwright.selectors.set_test_id_attribute(
             playwright_constants.TEST_ID_ATTRIBUTE
@@ -33,10 +47,11 @@ def start_playwright_session(request):
 
 
 @pytest.fixture(scope="function")
-def start_mavis(start_playwright_session):
+def start_mavis(start_playwright_session, browser_name, browser_channel, device):
     _browser, _context = start_browser(
-        pw=start_playwright_session, browser_or_device=ce.current_browser_name
+        start_playwright_session, browser_name, browser_channel, device
     )
+
     ce.browser = _browser
     ce.page = _context.new_page()
     # ce.page.set_default_timeout(playwright_constants.DEFAULT_TIMEOUT)
@@ -45,83 +60,33 @@ def start_mavis(start_playwright_session):
     close_browser(browser=_browser, page=ce.page)
 
 
-def create_session_screenshot_dir() -> str:
+def create_session_screenshot_dir(browser_name: str) -> str:
     if ce.capture_screenshot_flag:
-        _session_name = f"{get_current_datetime()}-{ce.current_browser_name}"
+        _session_name = f"{get_current_datetime()}-{browser_name}"
         fo.file_operations().create_dir(dir_path=f"screenshots/{_session_name}")
         return f"screenshots/{_session_name}"
     else:
         return ""
 
 
-def start_browser(pw, browser_or_device: str):
+def start_browser(playwright, browser_name, browser_channel, device):
     _http_credentials = {
         "username": ce.base_auth_username,
         "password": ce.base_auth_password,
     }
-    try:
-        match browser_or_device.lower():
-            case browsers_and_devices.IPHONE_14:
-                _browser = pw.webkit.launch(
-                    headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(
-                    **pw.devices["iPhone 14"], http_credentials=_http_credentials
-                )
-            case browsers_and_devices.IPHONE_15:
-                _browser = pw.chromium.launch(
-                    channel="chrome", headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(
-                    **pw.devices["iPhone 15"], http_credentials=_http_credentials
-                )
-            case browsers_and_devices.IPAD_7:
-                _browser = pw.chromium.launch(
-                    headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(
-                    **pw.devices["iPad (gen 7) landscape"],
-                    http_credentials=_http_credentials,
-                )
-            case browsers_and_devices.PIXEL_7:
-                _browser = pw.webkit.launch(
-                    headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(
-                    **pw.devices["Pixel 7"], http_credentials=_http_credentials
-                )
-            case browsers_and_devices.GALAXY_S9_PLUS:
-                _browser = pw.chromium.launch(
-                    channel="chromium",
-                    headless=ce.headless_mode,
-                    slow_mo=ce.slow_motion,
-                )
-                _context = _browser.new_context(
-                    **pw.devices["Galaxy S9+"], http_credentials=_http_credentials
-                )
-            case browsers_and_devices.CHROME:
-                _browser = pw.chromium.launch(
-                    channel="chrome", headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(http_credentials=_http_credentials)
-            case browsers_and_devices.MSEDGE:
-                _browser = pw.chromium.launch(
-                    channel="msedge", headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(http_credentials=_http_credentials)
-            case browsers_and_devices.FIREFOX:
-                _browser = pw.firefox.launch(
-                    headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(http_credentials=_http_credentials)
-            case _:  # Desktop Chromium for all other cases
-                _browser = pw.chromium.launch(
-                    headless=ce.headless_mode, slow_mo=ce.slow_motion
-                )
-                _context = _browser.new_context(http_credentials=_http_credentials)
-        return _browser, _context
-    except Exception as e:
-        raise AssertionError(f"Error launching {browser_or_device}: {e}")
+
+    browser_type = getattr(playwright, browser_name)
+    browser = browser_type.launch(
+        channel=browser_channel, headless=ce.headless_mode, slow_mo=ce.slow_motion
+    )
+
+    kwargs = {}
+    if device:
+        kwargs = playwright.devices[device]
+
+    context = browser.new_context(**kwargs, http_credentials=_http_credentials)
+
+    return [browser, context]
 
 
 def close_browser(browser, page):

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -14,7 +14,6 @@ class CurrentExecution:
     service_url: str = ""
     base_auth_username: str = ""
     base_auth_password: str = ""
-    current_browser_name: str = ""
     headless_mode: bool = False
     session_screenshots_dir: str = ""
 

--- a/libs/mavis_constants.py
+++ b/libs/mavis_constants.py
@@ -7,19 +7,6 @@ class playwright_constants:
     DEFAULT_TIMEOUT: Final[int] = 60000
 
 
-class browsers_and_devices:
-    CHROMIUM: Final[str] = "chromium"
-    FIREFOX: Final[str] = "firefox"
-    MSEDGE: Final[str] = "msedge"
-    CHROME: Final[str] = "chrome"
-    GALAXY_S20: Final[str] = "s20"
-    PIXEL_7: Final[str] = "pixel_7"
-    GALAXY_S9_PLUS: Final[str] = "s9+"
-    IPAD_7: Final[str] = "ipad_7"
-    IPHONE_15: Final[str] = "iphone_15"
-    IPHONE_14: Final[str] = "iphone_14"
-
-
 class child_year_group:
     YEAR_8: Final[str] = "YEAR_8"
     YEAR_9: Final[str] = "YEAR_9"


### PR DESCRIPTION
This replaces the command line option `--browser_or_device` with the following three options:
- `--browser`
- `--browser-channel`
- `--device`

The reason for this is to align this project with the default command line options used by `pytest-playwright` to being able to use this plugin in the future (and simplify most of our Playwright configuration code).

https://playwright.dev/python/docs/test-runners#cli-arguments

It also means we don't need to maintain our own list of browsers and devices, which gives us more flexibility allowing the tests to be run in various different combinations easily without needing to make a change to the code.