### PR TITLE
Add `base_url` fixture

### DIFF
--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -7,7 +7,6 @@ from playwright.sync_api import Browser, Page
 class CurrentExecution:
     page: Page = None
     browser: Browser = None
-    service_url: str = ""
     current_browser_name: str = ""
     headless_mode: bool = False
     session_screenshots_dir: str = ""
@@ -29,9 +28,7 @@ class CurrentExecution:
     @staticmethod
     def get_env_values():
         load_dotenv()
-        CurrentExecution.service_url = CurrentExecution.get_env_value(
-            var_name="BASE_URL"
-        )
+
         CurrentExecution.nurse_username = CurrentExecution.get_env_value(
             var_name="NURSE_USERNAME"
         )

--- a/libs/playwright_ops.py
+++ b/libs/playwright_ops.py
@@ -706,20 +706,6 @@ class playwright_operations:
         if "Sorry, there’s a problem with the service" in _actual_title:
             assert False, f"Application has crashed after: {locator_info}"
 
-    def go_to_url(self, url: str) -> None:
-        """
-        Navigate to a specified URL.
-
-        Args:
-            url (str): URL to navigate to.
-        """
-        _full_url = (
-            f"{self.ce.service_url.replace('/start', '')}{url}"
-            if url.startswith("/")
-            else url
-        )
-        self.ce.page.goto(_full_url)
-
     def get_table_cell_location_for_value(
         self, table_locator: str, col_header: str, row_value: str
     ):

--- a/pages/pg_login.py
+++ b/pages/pg_login.py
@@ -66,5 +66,4 @@ class pg_login:
         self.po.act(locator=self.BTN_LOGIN, action=actions.CLICK_BUTTON)
 
     def go_to_login_page(self) -> None:
-        self.ce.page.goto(self.ce.service_url)
-        # self.ce.page.wait_for_url(self.ce.service_url)
+        self.ce.page.goto("/")

--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -46,6 +46,6 @@ class Test_Consent_Doubles:
         get_doubles_session_link: str,
         scenario_data: Iterable[tuple[Hashable, Series]],
     ):
-        self.po.go_to_url(url=get_doubles_session_link)
+        self.ce.page.goto(get_doubles_session_link)
         self.helper.read_data_for_scenario(scenario_data=scenario_data)
         self.helper.enter_details_on_mavis()

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -164,7 +164,7 @@ class Test_Consent_HPV:
         get_hpv_session_link: str,
         scenario_data: Iterable[tuple[Hashable, Series]],
     ):
-        self.po.go_to_url(url=get_hpv_session_link)
+        self.ce.page.goto(get_hpv_session_link)
         self.helper.read_data_for_scenario(scenario_data=scenario_data)
         self.helper.enter_details_on_mavis()
 


### PR DESCRIPTION
This moves the logic related to the base URL in to a fixture, allowing it to be used in tests directly without needing to go via the `CurrentExecution` global singleton object. This will allow us to migrate to using the `pytest-playwright` plugin in the future avoiding the need for us to manage Playwright itself in our code.

I've also set up the contexts with a `base_url` allowing us to call `page.goto("/")` without needing the full URL, which also allows us to remove the `go_to_url` method which was just calling `page.goto`.