### PR TITLE
Ensure linting action checks formatting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -41,4 +41,6 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Check formatting
+        run: ruff format --check
+      - name: Check linting
         run: ruff check


### PR DESCRIPTION
The linting job was missing the `ruff format --check` command which checks the formatting of the code as well as the existing check on the static analysis rules.