### PR TITLE
Remove unused `playwright_ops` instances

### DIFF
--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -3,14 +3,13 @@ from typing import Hashable, Iterable
 import pytest
 from pandas.core.series import Series
 
-from libs import CurrentExecution, playwright_ops
+from libs import CurrentExecution
 from pages import pg_consent_hpv, pg_dashboard, pg_login, pg_sessions
 from tests.helpers import parental_consent_helper_doubles
 
 
 class Test_Consent_Doubles:
     ce = CurrentExecution()
-    po = playwright_ops.playwright_operations()
     pc = pg_consent_hpv.pg_consent_hpv()
     helper = parental_consent_helper_doubles.parental_consent_helper()
     login_page = pg_login.pg_login()

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -3,7 +3,7 @@ from typing import Hashable, Iterable
 import pytest
 from pandas.core.series import Series
 
-from libs import CurrentExecution, playwright_ops
+from libs import CurrentExecution
 from libs.mavis_constants import test_data_file_paths
 from pages import pg_consent_hpv, pg_dashboard, pg_login, pg_sessions
 from tests.helpers import parental_consent_helper_hpv
@@ -11,7 +11,6 @@ from tests.helpers import parental_consent_helper_hpv
 
 class Test_Consent_HPV:
     ce = CurrentExecution()
-    po = playwright_ops.playwright_operations()
     pc = pg_consent_hpv.pg_consent_hpv()
     helper = parental_consent_helper_hpv.parental_consent_helper()
     login_page = pg_login.pg_login()


### PR DESCRIPTION
These were being set on the classes but not used in the classes themselves so they can be safely removed.