### PR TITLE
Flatten test structures

### DIFF
--- a/tests/test_00_smoke.py
+++ b/tests/test_00_smoke.py
@@ -7,35 +7,35 @@ from libs import playwright_ops
 from libs.generic_constants import properties
 
 
-class Test_Smoke:
-    po = playwright_ops.playwright_operations()
+po = playwright_ops.playwright_operations()
 
-    # SELF TEST
-    @pytest.mark.smoke
-    @pytest.mark.order(1)
-    def test_smoke_files_and_paths(self):
-        folder_paths_to_verify = ["screenshots", "test_data", "working"]
-        for folder_path in folder_paths_to_verify:
-            if not pathlib.Path(folder_path).is_dir():
-                assert False, f"{folder_path} not found on project root"
 
-    @pytest.mark.smoke
-    @pytest.mark.order(2)
-    def test_smoke_verify_packages(self):
-        packages_installed = subprocess.run(
-            args=["pip", "list"], capture_output=True, text=True
-        ).stdout.strip()
-        packages_to_verify = ["dotenv", "playwright", "requests"]
-        for package in packages_to_verify:
-            if package not in packages_installed:
-                assert False, f"{package} not installed"
+@pytest.mark.smoke
+@pytest.mark.order(1)
+def test_files_and_paths():
+    folder_paths_to_verify = ["screenshots", "test_data", "working"]
+    for folder_path in folder_paths_to_verify:
+        if not pathlib.Path(folder_path).is_dir():
+            assert False, f"{folder_path} not found on project root"
 
-    # CHECK APPLICATION ACCESS
-    @pytest.mark.smoke
-    @pytest.mark.order(3)
-    def test_smoke_homepage_loads(self, start_mavis: None):
-        self.po.verify(
-            locator="heading",
-            property=properties.TEXT,
-            expected_value="Manage vaccinations in schools (Mavis)",
-        )
+
+@pytest.mark.smoke
+@pytest.mark.order(2)
+def test_verify_packages():
+    packages_installed = subprocess.run(
+        args=["pip", "list"], capture_output=True, text=True
+    ).stdout.strip()
+    packages_to_verify = ["dotenv", "playwright", "requests"]
+    for package in packages_to_verify:
+        if package not in packages_installed:
+            assert False, f"{package} not installed"
+
+
+@pytest.mark.smoke
+@pytest.mark.order(3)
+def test_homepage_loads(start_mavis):
+    po.verify(
+        locator="heading",
+        property=properties.TEXT,
+        expected_value="Manage vaccinations in schools (Mavis)",
+    )

--- a/tests/test_01_login.py
+++ b/tests/test_01_login.py
@@ -3,49 +3,52 @@ import pytest
 from pages import DashboardPage, LoginPage
 
 
-class Test_Login:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
 
-    @pytest.fixture(scope="function", autouse=True)
-    def setup_tests(self, start_mavis: None):
-        yield
 
-    test_parameters = [
-        ("invalid_user", "invalid_password", "Invalid Email or password."),
-        ("invalid_user", "", "Invalid Email or password."),
-        ("", "invalid_password", "Invalid Email or password."),
-        ("", "", "Invalid Email or password."),
-    ]
+@pytest.fixture(scope="function", autouse=True)
+def setup_tests(start_mavis):
+    yield
 
-    @pytest.mark.login
-    @pytest.mark.order(101)
-    @pytest.mark.parametrize("user,pwd,expected_message", test_parameters)
-    def test_invalid_login(self, user, pwd, expected_message):
-        self.login_page.try_invalid_login(
-            user=user, pwd=pwd, expected_message=expected_message
-        )
 
-    @pytest.mark.login
-    @pytest.mark.order(102)
-    def test_home_page_links_for_nurse(self, nurse):
-        self.login_page.go_to_login_page()
-        self.login_page.log_in(**nurse)
-        self.dashboard_page.verify_all_expected_links_for_nurse()
-        self.login_page.log_out()
+test_parameters = [
+    ("invalid_user", "invalid_password", "Invalid Email or password."),
+    ("invalid_user", "", "Invalid Email or password."),
+    ("", "invalid_password", "Invalid Email or password."),
+    ("", "", "Invalid Email or password."),
+]
 
-    @pytest.mark.login
-    @pytest.mark.order(103)
-    def test_home_page_links_for_superuser(self, superuser):
-        self.login_page.go_to_login_page()
-        self.login_page.log_in(**superuser)
-        self.dashboard_page.verify_all_expected_links_for_superuser()
-        self.login_page.log_out()
 
-    @pytest.mark.login
-    @pytest.mark.order(104)
-    def test_home_page_links_for_admin(self, admin):
-        self.login_page.go_to_login_page()
-        self.login_page.log_in(**admin)
-        self.dashboard_page.verify_all_expected_links_for_admin()
-        self.login_page.log_out()
+@pytest.mark.login
+@pytest.mark.order(101)
+@pytest.mark.parametrize("user,pwd,expected_message", test_parameters)
+def test_invalid(user, pwd, expected_message):
+    login_page.try_invalid_login(user=user, pwd=pwd, expected_message=expected_message)
+
+
+@pytest.mark.login
+@pytest.mark.order(102)
+def test_home_page_links_for_nurse(nurse):
+    login_page.go_to_login_page()
+    login_page.log_in(**nurse)
+    dashboard_page.verify_all_expected_links_for_nurse()
+    login_page.log_out()
+
+
+@pytest.mark.login
+@pytest.mark.order(103)
+def test_home_page_links_for_superuser(superuser):
+    login_page.go_to_login_page()
+    login_page.log_in(**superuser)
+    dashboard_page.verify_all_expected_links_for_superuser()
+    login_page.log_out()
+
+
+@pytest.mark.login
+@pytest.mark.order(104)
+def test_home_page_links_for_admin(admin):
+    login_page.go_to_login_page()
+    login_page.log_in(**admin)
+    dashboard_page.verify_all_expected_links_for_admin()
+    login_page.log_out()

--- a/tests/test_02_sessions.py
+++ b/tests/test_02_sessions.py
@@ -4,89 +4,95 @@ from libs.mavis_constants import test_data_file_paths
 from pages import DashboardPage, LoginPage, SessionsPage
 
 
-class Test_Sessions:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    sessions_page = SessionsPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+sessions_page = SessionsPage()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_tests(self, start_mavis, nurse):
-        self.login_page.log_in(**nurse)
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_tests(start_mavis, nurse):
+    login_page.log_in(**nurse)
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_mavis_1822(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.CLASS_POSITIVE
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_today()
+        sessions_page.click_school1()
         yield
-        self.login_page.log_out()
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mavis_1822(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.CLASS_POSITIVE
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_today()
-            self.sessions_page.click_school1()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mav_1018(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.CLASS_SESSION_ID
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_today()
-            self.sessions_page.click_school1()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
+@pytest.fixture(scope="function", autouse=False)
+def setup_mav_1018(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.CLASS_SESSION_ID
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_today()
+        sessions_page.click_school1()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.sessions
-    @pytest.mark.order(201)
-    def test_session_lifecycle(self, setup_tests: None):
-        self.sessions_page.schedule_a_valid_session_in_school_1()
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
-        self.sessions_page.edit_a_session_to_today()
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
-        self.sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.mark.sessions
-    @pytest.mark.order(202)
-    def test_invalid_session(self, setup_tests: None):
-        self.sessions_page.create_invalid_session()
+@pytest.mark.sessions
+@pytest.mark.order(201)
+def test_lifecycle(setup_tests: None):
+    sessions_page.schedule_a_valid_session_in_school_1()
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    sessions_page.edit_a_session_to_today()
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.mark.sessions
-    @pytest.mark.bug
-    @pytest.mark.order(203)
-    def test_verify_attendance_filters(self, setup_mavis_1822: None):
-        self.sessions_page.verify_attendance_filters()  # MAVIS-1822
 
-    @pytest.mark.sessions
-    @pytest.mark.bug
-    @pytest.mark.order(204)
-    def test_verify_search(self, setup_mav_1018):
-        self.sessions_page.verify_search()  # MAV-1018
+@pytest.mark.sessions
+@pytest.mark.order(202)
+def test_invalid(setup_tests: None):
+    sessions_page.create_invalid_session()
+
+
+@pytest.mark.sessions
+@pytest.mark.bug
+@pytest.mark.order(203)
+def test_verify_attendance_filters(setup_mavis_1822: None):
+    sessions_page.verify_attendance_filters()  # MAVIS-1822
+
+
+@pytest.mark.sessions
+@pytest.mark.bug
+@pytest.mark.order(204)
+def test_verify_search(setup_mav_1018):
+    sessions_page.verify_search()  # MAV-1018

--- a/tests/test_03_import_records.py
+++ b/tests/test_03_import_records.py
@@ -7,288 +7,321 @@ from libs.mavis_constants import (
 from pages import DashboardPage, ImportRecordsPage, LoginPage, SessionsPage
 
 
-class Test_ImportRecords:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    import_records_page = ImportRecordsPage()
-    sessions_page = SessionsPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+import_records_page = ImportRecordsPage()
+sessions_page = SessionsPage()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_tests(self, start_mavis, nurse):
-        self.login_page.log_in(**nurse)
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_tests(start_mavis, nurse):
+    login_page.log_in(**nurse)
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_child_list(setup_tests: None):
+    dashboard_page.click_import_records()
+    yield
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_class_list(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_import_records()
         yield
-        self.login_page.log_out()
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_child_list(self, setup_tests: None):
-        self.dashboard_page.click_import_records()
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_vaccs(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        import_records_page.import_class_list_records_from_school_session(
+            file_paths=test_data_file_paths.CLASS_SESSION_ID
+        )
+        sessions_page.click_school1()
+        sessions_page.save_session_id_from_offline_excel()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_import_records()
         yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_class_list(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_import_records()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_vaccs(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.import_records_page.import_class_list_records_from_school_session(
-                file_paths=test_data_file_paths.CLASS_SESSION_ID
-            )
-            self.sessions_page.click_school1()
-            self.sessions_page.save_session_id_from_offline_excel()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_import_records()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
+@pytest.fixture(scope="function", autouse=False)
+def setup_vaccs_systmone(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_import_records()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_vaccs_systmone(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_import_records()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
 
-    ########################################### CHILD LIST ###########################################
-    @pytest.mark.childlist
-    @pytest.mark.order(301)
-    def test_child_list_file_upload_positive(self, setup_child_list):
-        self.import_records_page.import_child_records(
-            file_paths=test_data_file_paths.CHILD_POSITIVE
-        )
+########################################### CHILD LIST ###########################################
+@pytest.mark.childlist
+@pytest.mark.order(301)
+def test_child_list_file_upload_positive(setup_child_list):
+    import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_POSITIVE
+    )
 
-    @pytest.mark.childlist
-    @pytest.mark.order(302)
-    def test_child_list_file_upload_negative(self, setup_child_list):
-        self.import_records_page.import_child_records(
-            file_paths=test_data_file_paths.CHILD_NEGATIVE
-        )
 
-    @pytest.mark.childlist
-    @pytest.mark.order(303)
-    def test_child_list_file_structure(self, setup_child_list):
-        self.import_records_page.import_child_records(
-            file_paths=test_data_file_paths.CHILD_INVALID_STRUCTURE
-        )
+@pytest.mark.childlist
+@pytest.mark.order(302)
+def test_child_list_file_upload_negative(setup_child_list):
+    import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_NEGATIVE
+    )
 
-    @pytest.mark.childlist
-    @pytest.mark.order(304)
-    def test_child_list_no_record(self, setup_child_list):
-        self.import_records_page.import_child_records(
-            file_paths=test_data_file_paths.CHILD_HEADER_ONLY
-        )
 
-    @pytest.mark.childlist
-    @pytest.mark.order(305)
-    def test_child_list_empty_file(self, setup_child_list):
-        self.import_records_page.import_child_records(
-            file_paths=test_data_file_paths.CHILD_EMPTY_FILE
-        )
+@pytest.mark.childlist
+@pytest.mark.order(303)
+def test_child_list_file_structure(setup_child_list):
+    import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_INVALID_STRUCTURE
+    )
 
-    @pytest.mark.childlist
-    @pytest.mark.bug
-    @pytest.mark.order(306)
-    def test_child_list_space_normalization(self, setup_child_list):
-        self.import_records_page.import_child_records(
-            file_paths=test_data_file_paths.CHILD_MAV_1080, verify_on_children_page=True
-        )
 
-    ########################################### CLASS LIST ###########################################
+@pytest.mark.childlist
+@pytest.mark.order(304)
+def test_child_list_no_record(setup_child_list):
+    import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_HEADER_ONLY
+    )
 
-    @pytest.mark.classlist
-    @pytest.mark.order(326)
-    def test_class_list_file_upload_positive(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_POSITIVE
-        )
 
-    @pytest.mark.classlist
-    @pytest.mark.order(327)
-    def test_class_list_file_upload_negative(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_NEGATIVE
-        )
+@pytest.mark.childlist
+@pytest.mark.order(305)
+def test_child_list_empty_file(setup_child_list):
+    import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_EMPTY_FILE
+    )
 
-    @pytest.mark.classlist
-    @pytest.mark.order(328)
-    def test_class_list_file_structure(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_INVALID_STRUCTURE
-        )
 
-    @pytest.mark.classlist
-    @pytest.mark.order(329)
-    def test_class_list_no_record(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_HEADER_ONLY
-        )
+@pytest.mark.childlist
+@pytest.mark.bug
+@pytest.mark.order(306)
+def test_child_list_space_normalization(setup_child_list):
+    import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_MAV_1080, verify_on_children_page=True
+    )
 
-    @pytest.mark.classlist
-    @pytest.mark.order(330)
-    def test_class_list_empty_file(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_EMPTY_FILE
-        )
 
-    @pytest.mark.classlist
-    @pytest.mark.order(331)
-    def test_class_list_year_group(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_YEAR_GROUP,
-            year_groups=[8],
-        )
+########################################### CLASS LIST ###########################################
 
-    @pytest.mark.classlist
-    @pytest.mark.bug
-    @pytest.mark.order(332)
-    def test_class_list_space_normalization(self, setup_class_list: None):
-        self.import_records_page.import_class_list_records(
-            file_paths=test_data_file_paths.CLASS_MAV_1080, verify_on_children_page=True
-        )
 
-    ########################################### VACCINATIONS ###########################################
+@pytest.mark.classlist
+@pytest.mark.order(326)
+def test_class_list_file_upload_positive(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_POSITIVE
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(351)
-    def test_vaccs_positive_file_upload(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_POSITIVE,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(352)
-    def test_vaccs_negative_file_upload(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_NEGATIVE,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
+@pytest.mark.classlist
+@pytest.mark.order(327)
+def test_class_list_file_upload_negative(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_NEGATIVE
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(353)
-    def test_vaccs_duplicate_record_upload(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_DUP_1,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_import_records()
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_DUP_2,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(354)
-    def test_vaccs_file_structure(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_INVALID_STRUCTURE,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
+@pytest.mark.classlist
+@pytest.mark.order(328)
+def test_class_list_file_structure(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_INVALID_STRUCTURE
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(355)
-    def test_vaccs_no_record(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_HEADER_ONLY,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(356)
-    def test_vaccs_empty_file(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_EMPTY_FILE,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
+@pytest.mark.classlist
+@pytest.mark.order(329)
+def test_class_list_no_record(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_HEADER_ONLY
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(357)
-    def test_vaccs_historic_positive_file_upload(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_HIST_POSITIVE,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(358)
-    def test_vaccs_historic_negative_file_upload(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_HIST_NEGATIVE,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
+@pytest.mark.classlist
+@pytest.mark.order(330)
+def test_class_list_empty_file(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_EMPTY_FILE
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.bug
-    @pytest.mark.order(359)
-    def test_vaccs_historic_no_urn_mav_855(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_HPV_MAV_855,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_children()
-        self.import_records_page.verify_mav_855()
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(360)
-    def test_vaccs_systmone_positive_file_upload(self, setup_vaccs_systmone):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_SYSTMONE_POSITIVE,
-            file_type=mavis_file_types.VACCS_SYSTMONE,
-        )
+@pytest.mark.classlist
+@pytest.mark.order(331)
+def test_class_list_year_group(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_YEAR_GROUP,
+        year_groups=[8],
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(361)
-    def test_vaccs_systmone_negative_file_upload(self, setup_vaccs_systmone):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_SYSTMONE_NEGATIVE,
-            file_type=mavis_file_types.VACCS_SYSTMONE,
-        )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.order(362)
-    def test_vaccs_systmone_negative_historical_file_upload(self, setup_vaccs_systmone):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_SYSTMONE_HIST_NEGATIVE,
-            file_type=mavis_file_types.VACCS_SYSTMONE,
-        )
+@pytest.mark.classlist
+@pytest.mark.bug
+@pytest.mark.order(332)
+def test_class_list_space_normalization(setup_class_list: None):
+    import_records_page.import_class_list_records(
+        file_paths=test_data_file_paths.CLASS_MAV_1080, verify_on_children_page=True
+    )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.bug
-    @pytest.mark.order(363)
-    def test_vaccs_hpv_space_normalization(self, setup_vaccs):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_MAV_1080,
-            verify_on_children_page=True,
-            file_type=mavis_file_types.VACCS_MAVIS,
-        )
 
-    @pytest.mark.vaccinations
-    @pytest.mark.bug
-    @pytest.mark.order(364)
-    def test_vaccs_systmone_space_normalization(self, setup_vaccs_systmone):
-        self.import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_SYSTMONE_MAV_1080,
-            verify_on_children_page=False,
-            file_type=mavis_file_types.VACCS_SYSTMONE,
-        )
+########################################### VACCINATIONS ###########################################
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(351)
+def test_vaccs_positive_file_upload(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_POSITIVE,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(352)
+def test_vaccs_negative_file_upload(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_NEGATIVE,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(353)
+def test_vaccs_duplicate_record_upload(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_DUP_1,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_import_records()
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_DUP_2,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(354)
+def test_vaccs_file_structure(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_INVALID_STRUCTURE,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(355)
+def test_vaccs_no_record(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_HEADER_ONLY,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(356)
+def test_vaccs_empty_file(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_EMPTY_FILE,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(357)
+def test_vaccs_historic_positive_file_upload(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_HIST_POSITIVE,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(358)
+def test_vaccs_historic_negative_file_upload(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_HIST_NEGATIVE,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.bug
+@pytest.mark.order(359)
+def test_vaccs_historic_no_urn_mav_855(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_HPV_MAV_855,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_children()
+    import_records_page.verify_mav_855()
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(360)
+def test_vaccs_systmone_positive_file_upload(setup_vaccs_systmone):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_POSITIVE,
+        file_type=mavis_file_types.VACCS_SYSTMONE,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(361)
+def test_vaccs_systmone_negative_file_upload(setup_vaccs_systmone):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_NEGATIVE,
+        file_type=mavis_file_types.VACCS_SYSTMONE,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.order(362)
+def test_vaccs_systmone_negative_historical_file_upload(setup_vaccs_systmone):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_HIST_NEGATIVE,
+        file_type=mavis_file_types.VACCS_SYSTMONE,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.bug
+@pytest.mark.order(363)
+def test_vaccs_hpv_space_normalization(setup_vaccs):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_MAV_1080,
+        verify_on_children_page=True,
+        file_type=mavis_file_types.VACCS_MAVIS,
+    )
+
+
+@pytest.mark.vaccinations
+@pytest.mark.bug
+@pytest.mark.order(364)
+def test_vaccs_systmone_space_normalization(setup_vaccs_systmone):
+    import_records_page.import_vaccination_records(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_MAV_1080,
+        verify_on_children_page=False,
+        file_type=mavis_file_types.VACCS_SYSTMONE,
+    )

--- a/tests/test_04_school_moves.py
+++ b/tests/test_04_school_moves.py
@@ -4,93 +4,96 @@ from libs.mavis_constants import test_data_file_paths
 from pages import DashboardPage, LoginPage, SchoolMovesPage, SessionsPage
 
 
-class Test_School_Moves:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    sessions_page = SessionsPage()
-    school_moves_page = SchoolMovesPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+sessions_page = SessionsPage()
+school_moves_page = SchoolMovesPage()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_tests(self, start_mavis, reset_environment, nurse):
-        reset_environment()
 
-        self.login_page.log_in(**nurse)
+@pytest.fixture(scope="function", autouse=False)
+def setup_tests(start_mavis, reset_environment, nurse):
+    reset_environment()
+
+    login_page.log_in(**nurse)
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_move_and_ignore(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_2()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school2()
+        sessions_page.upload_class_list_to_school_2(
+            file_paths=test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
+        )
         yield
-        self.login_page.log_out()
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_2()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_move_and_ignore(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_2()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school2()
-            self.sessions_page.upload_class_list_to_school_2(
-                file_paths=test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
-            )
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_2()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_move_to_homeschool_and_unknown(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.CLASS_MOVES_UNKNOWN_HOMESCHOOLED
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school2()
-            self.sessions_page.upload_class_list_to_school_2(
-                file_paths=test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
-            )
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_2()
+@pytest.fixture(scope="function", autouse=False)
+def setup_move_to_homeschool_and_unknown(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.CLASS_MOVES_UNKNOWN_HOMESCHOOLED
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school2()
+        sessions_page.upload_class_list_to_school_2(
+            file_paths=test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
+        )
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_2()
 
-    @pytest.mark.schoolmoves
-    @pytest.mark.order(401)
-    def test_school_moves_confirm_and_ignore(self, setup_move_and_ignore: None):
-        self.school_moves_page.confirm_and_ignore_moves()
 
-    # Add tests for school moves to Homeschool or Unknown school
-    @pytest.mark.schoolmoves
-    @pytest.mark.order(402)
-    @pytest.mark.skip(reason="Test under construction")
-    def test_school_moves_to_homeschool_and_unknown(
-        self, setup_move_to_homeschool_and_unknown: None
-    ):
-        pass
+@pytest.mark.schoolmoves
+@pytest.mark.order(401)
+def test_confirm_and_ignore(setup_move_and_ignore):
+    school_moves_page.confirm_and_ignore_moves()
 
-    @pytest.mark.schoolmoves
-    @pytest.mark.order(403)
-    def test_school_moves_download_report(self, setup_move_and_ignore: None):
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_school_moves()
-        self.school_moves_page.download_and_verify_report()
+
+# Add tests for school moves to Homeschool or Unknown school
+@pytest.mark.schoolmoves
+@pytest.mark.order(402)
+@pytest.mark.skip(reason="Test under construction")
+def test_to_homeschool_and_unknown(setup_move_to_homeschool_and_unknown):
+    pass
+
+
+@pytest.mark.schoolmoves
+@pytest.mark.order(403)
+def test_download_report(setup_move_and_ignore):
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_school_moves()
+    school_moves_page.download_and_verify_report()

--- a/tests/test_05_programmes.py
+++ b/tests/test_05_programmes.py
@@ -16,226 +16,220 @@ from pages import (
 )
 
 
-class Test_Programmes:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    sessions_page = SessionsPage()
-    programmes_page = ProgrammesPage()
-    import_records_page = ImportRecordsPage()
-    vaccines_page = VaccinesPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+sessions_page = SessionsPage()
+programmes_page = ProgrammesPage()
+import_records_page = ImportRecordsPage()
+vaccines_page = VaccinesPage()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_cohort_upload_and_reports(self, start_mavis, nurse):
-        self.login_page.log_in(**nurse)
-        self.dashboard_page.click_programmes()
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_cohort_upload_and_reports(start_mavis, nurse):
+    login_page.log_in(**nurse)
+    dashboard_page.click_programmes()
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_record_a_vaccine(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
         yield
-        self.login_page.log_out()
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_record_a_vaccine(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mavis_1729(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.import_records_page.import_class_list_records_from_school_session(
-                file_paths=test_data_file_paths.CLASS_SESSION_ID
-            )
-            self.sessions_page.click_school1()
-            self.sessions_page.save_session_id_from_offline_excel()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_import_records()
-            self.import_records_page.import_vaccination_records(
-                file_paths=test_data_file_paths.VACCS_HPV_DOSE_TWO,
-                file_type=mavis_file_types.VACCS_MAVIS,
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_programmes()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
-
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mav_854(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_vaccines()
-            self.vaccines_page.add_batch(vaccine_name=vaccines.GARDASIL9)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.import_records_page.import_class_list_records_from_school_session(
-                file_paths=test_data_file_paths.CLASS_MAV_854
-            )
-            self.sessions_page.click_school1()
-            self.sessions_page.save_session_id_from_offline_excel()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_community_clinics(
-                for_today=True
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_children()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
-
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mav_nnn(self, start_mavis, admin):
-        try:
-            self.login_page.log_in(**admin)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.import_records_page.import_class_list_records_from_school_session(
-                file_paths=test_data_file_paths.CLASS_SINGLE_VACC
-            )
-            self.sessions_page.click_school1()
-            self.sessions_page.save_session_id_from_offline_excel()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
-
-    @pytest.mark.cohorts
-    @pytest.mark.order(501)
-    def test_cohort_upload_positive(self, setup_cohort_upload_and_reports):
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_POSITIVE
+@pytest.fixture(scope="function", autouse=False)
+def setup_mavis_1729(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        import_records_page.import_class_list_records_from_school_session(
+            file_paths=test_data_file_paths.CLASS_SESSION_ID
         )
-
-    @pytest.mark.cohorts
-    @pytest.mark.order(502)
-    def test_cohort_upload_negative(self, setup_cohort_upload_and_reports):
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_NEGATIVE
+        sessions_page.click_school1()
+        sessions_page.save_session_id_from_offline_excel()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_import_records()
+        import_records_page.import_vaccination_records(
+            file_paths=test_data_file_paths.VACCS_HPV_DOSE_TWO,
+            file_type=mavis_file_types.VACCS_MAVIS,
         )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_programmes()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.cohorts
-    @pytest.mark.order(503)
-    def test_cohorts_file_structure(self, setup_cohort_upload_and_reports):
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_INVALID_STRUCTURE
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_mav_854(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_vaccines()
+        vaccines_page.add_batch(vaccine_name=vaccines.GARDASIL9)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        import_records_page.import_class_list_records_from_school_session(
+            file_paths=test_data_file_paths.CLASS_MAV_854
         )
+        sessions_page.click_school1()
+        sessions_page.save_session_id_from_offline_excel()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_community_clinics(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_children()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.cohorts
-    @pytest.mark.order(504)
-    def test_cohorts_no_record(self, setup_cohort_upload_and_reports):
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_HEADER_ONLY
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_mav_nnn(start_mavis, admin):
+    try:
+        login_page.log_in(**admin)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        import_records_page.import_class_list_records_from_school_session(
+            file_paths=test_data_file_paths.CLASS_SINGLE_VACC
         )
+        sessions_page.click_school1()
+        sessions_page.save_session_id_from_offline_excel()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.cohorts
-    @pytest.mark.order(505)
-    def test_cohorts_empty_file(self, setup_cohort_upload_and_reports):
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_EMPTY_FILE
-        )
 
-    @pytest.mark.cohorts
-    @pytest.mark.bug
-    @pytest.mark.order(506)
-    def test_cohorts_readd_to_cohort(self, setup_cohort_upload_and_reports):  # MAV-909
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_MAV_909
-        )
-        self.programmes_page.verify_mav_909()
+@pytest.mark.cohorts
+@pytest.mark.order(501)
+def test_cohort_upload_positive(setup_cohort_upload_and_reports):
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_POSITIVE)
 
-    @pytest.mark.rav
-    @pytest.mark.order(526)
-    def test_programmes_rav_triage_positive(self, setup_record_a_vaccine):
-        self.sessions_page.update_triage_outcome_positive(
-            file_paths=test_data_file_paths.COHORTS_FULL_NAME
-        )
 
-    @pytest.mark.rav
-    @pytest.mark.order(527)
-    def test_programmes_rav_triage_consent_refused(self, setup_record_a_vaccine):
-        self.sessions_page.update_triage_outcome_consent_refused(
-            file_paths=test_data_file_paths.COHORTS_FULL_NAME
-        )
+@pytest.mark.cohorts
+@pytest.mark.order(502)
+def test_cohort_upload_negative(setup_cohort_upload_and_reports):
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_NEGATIVE)
 
-    @pytest.mark.rav
-    @pytest.mark.bug
-    @pytest.mark.order(528)
-    def test_programmes_rav_edit_dose_to_not_given(self, setup_mavis_1729):
-        self.programmes_page.edit_dose_to_not_given()  # MAVIS-1729
 
-    @pytest.mark.rav
-    @pytest.mark.bug
-    @pytest.mark.order(529)
-    def test_programmes_rav_verify_excel_mav_854(self, setup_mav_854):
-        self.programmes_page.verify_mav_854()  # MAV-854
+@pytest.mark.cohorts
+@pytest.mark.order(503)
+def test_cohorts_file_structure(setup_cohort_upload_and_reports):
+    programmes_page.upload_cohorts(
+        file_paths=test_data_file_paths.COHORTS_INVALID_STRUCTURE
+    )
 
-    @pytest.mark.rav
-    @pytest.mark.order(530)
-    @pytest.mark.skip(reason="Test under construction")
-    def test_programmes_rav_verify_banners(self, setup_mav_nnn):
-        # self.programmes_page.verify_mav_nnn()
-        pass
 
-    @pytest.mark.reports
-    @pytest.mark.order(551)
-    def test_programmes_verify_careplus_report_for_hpv(
-        self, setup_cohort_upload_and_reports
-    ):
-        self.programmes_page.verify_careplus_report_format(for_programme=programmes.HPV)
+@pytest.mark.cohorts
+@pytest.mark.order(504)
+def test_cohorts_no_record(setup_cohort_upload_and_reports):
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_HEADER_ONLY)
 
-    @pytest.mark.reports
-    @pytest.mark.order(552)
-    def test_programmes_verify_careplus_report_for_doubles(
-        self, setup_cohort_upload_and_reports
-    ):
-        self.programmes_page.verify_careplus_report_format(
-            for_programme=programmes.MENACWY
-        )
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_programmes()
-        self.programmes_page.verify_careplus_report_format(
-            for_programme=programmes.TDIPV
-        )
 
-    @pytest.mark.reports
-    @pytest.mark.order(553)
-    def test_programmes_verify_csv_report_for_hpv(
-        self, setup_cohort_upload_and_reports
-    ):
-        self.programmes_page.verify_csv_report_format(for_programme=programmes.HPV)
+@pytest.mark.cohorts
+@pytest.mark.order(505)
+def test_cohorts_empty_file(setup_cohort_upload_and_reports):
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_EMPTY_FILE)
 
-    @pytest.mark.reports
-    @pytest.mark.order(554)
-    def test_programmes_verify_csv_report_for_doubles(
-        self, setup_cohort_upload_and_reports
-    ):
-        self.programmes_page.verify_csv_report_format(for_programme=programmes.MENACWY)
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_programmes()
-        self.programmes_page.verify_csv_report_format(for_programme=programmes.TDIPV)
 
-    @pytest.mark.reports
-    @pytest.mark.order(555)
-    def test_programmes_verify_systmone_report_for_hpv(
-        self, setup_cohort_upload_and_reports
-    ):
-        self.programmes_page.verify_systmone_report_format(for_programme=programmes.HPV)
+@pytest.mark.cohorts
+@pytest.mark.bug
+@pytest.mark.order(506)
+def test_cohorts_readd_to_cohort(setup_cohort_upload_and_reports):  # MAV-909
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_MAV_909)
+    programmes_page.verify_mav_909()
+
+
+@pytest.mark.rav
+@pytest.mark.order(526)
+def test_rav_triage_positive(setup_record_a_vaccine):
+    sessions_page.update_triage_outcome_positive(
+        file_paths=test_data_file_paths.COHORTS_FULL_NAME
+    )
+
+
+@pytest.mark.rav
+@pytest.mark.order(527)
+def test_rav_triage_consent_refused(setup_record_a_vaccine):
+    sessions_page.update_triage_outcome_consent_refused(
+        file_paths=test_data_file_paths.COHORTS_FULL_NAME
+    )
+
+
+@pytest.mark.rav
+@pytest.mark.bug
+@pytest.mark.order(528)
+def test_rav_edit_dose_to_not_given(setup_mavis_1729):
+    programmes_page.edit_dose_to_not_given()  # MAVIS-1729
+
+
+@pytest.mark.rav
+@pytest.mark.bug
+@pytest.mark.order(529)
+def test_rav_verify_excel_mav_854(setup_mav_854):
+    programmes_page.verify_mav_854()  # MAV-854
+
+
+@pytest.mark.rav
+@pytest.mark.order(530)
+@pytest.mark.skip(reason="Test under construction")
+def test_rav_verify_banners(setup_mav_nnn):
+    # programmes_page.verify_mav_nnn()
+    pass
+
+
+@pytest.mark.reports
+@pytest.mark.order(551)
+def test_verify_careplus_report_for_hpv(setup_cohort_upload_and_reports):
+    programmes_page.verify_careplus_report_format(for_programme=programmes.HPV)
+
+
+@pytest.mark.reports
+@pytest.mark.order(552)
+def test_verify_careplus_report_for_doubles(setup_cohort_upload_and_reports):
+    programmes_page.verify_careplus_report_format(for_programme=programmes.MENACWY)
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_programmes()
+    programmes_page.verify_careplus_report_format(for_programme=programmes.TDIPV)
+
+
+@pytest.mark.reports
+@pytest.mark.order(553)
+def test_verify_csv_report_for_hpv(setup_cohort_upload_and_reports):
+    programmes_page.verify_csv_report_format(for_programme=programmes.HPV)
+
+
+@pytest.mark.reports
+@pytest.mark.order(554)
+def test_verify_csv_report_for_doubles(setup_cohort_upload_and_reports):
+    programmes_page.verify_csv_report_format(for_programme=programmes.MENACWY)
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_programmes()
+    programmes_page.verify_csv_report_format(for_programme=programmes.TDIPV)
+
+
+@pytest.mark.reports
+@pytest.mark.order(555)
+def test_verify_systmone_report_for_hpv(setup_cohort_upload_and_reports):
+    programmes_page.verify_systmone_report_format(for_programme=programmes.HPV)

--- a/tests/test_06_vaccs_batch.py
+++ b/tests/test_06_vaccs_batch.py
@@ -4,39 +4,42 @@ from libs.mavis_constants import vaccines
 from pages import DashboardPage, LoginPage, VaccinesPage
 
 
-class Test_Regression_Vaccines:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    vaccines_page = VaccinesPage()
-    doubles_vaccines = [
-        vaccines.MENQUADFI,
-        vaccines.MENVEO,
-        vaccines.NIMENRIX,
-        vaccines.REVAXIS,
-    ]
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+vaccines_page = VaccinesPage()
 
-    @pytest.fixture(scope="function", autouse=True)
-    def setup_tests(self, start_mavis, nurse):
-        self.login_page.log_in(**nurse)
-        self.dashboard_page.click_vaccines()
-        yield
-        self.login_page.log_out()
+doubles_vaccines = [
+    vaccines.MENQUADFI,
+    vaccines.MENVEO,
+    vaccines.NIMENRIX,
+    vaccines.REVAXIS,
+]
 
-    @pytest.mark.vaccsbatch
-    @pytest.mark.order(601)
-    def test_batch_add_change_archive_hpv(self):
-        self.vaccines_page.add_batch(vaccine_name=vaccines.GARDASIL9)
-        self.vaccines_page.change_batch(vaccine_name=vaccines.GARDASIL9)
-        self.vaccines_page.archive_batch(vaccine_name=vaccines.GARDASIL9)
 
-    @pytest.mark.vaccsbatch
-    @pytest.mark.order(602)
-    @pytest.mark.parametrize(
-        "vaccine",
-        doubles_vaccines,
-        ids=[id[0] for id in doubles_vaccines],
-    )
-    def test_batch_add_change_archive_doubles(self, vaccine):
-        self.vaccines_page.add_batch(vaccine_name=vaccine)
-        self.vaccines_page.change_batch(vaccine_name=vaccine)
-        self.vaccines_page.archive_batch(vaccine_name=vaccine)
+@pytest.fixture(scope="function", autouse=True)
+def setup_tests(start_mavis, nurse):
+    login_page.log_in(**nurse)
+    dashboard_page.click_vaccines()
+    yield
+    login_page.log_out()
+
+
+@pytest.mark.vaccsbatch
+@pytest.mark.order(601)
+def test_batch_add_change_archive_hpv():
+    vaccines_page.add_batch(vaccine_name=vaccines.GARDASIL9)
+    vaccines_page.change_batch(vaccine_name=vaccines.GARDASIL9)
+    vaccines_page.archive_batch(vaccine_name=vaccines.GARDASIL9)
+
+
+@pytest.mark.vaccsbatch
+@pytest.mark.order(602)
+@pytest.mark.parametrize(
+    "vaccine",
+    doubles_vaccines,
+    ids=[id[0] for id in doubles_vaccines],
+)
+def test_batch_add_change_archive_doubles(vaccine):
+    vaccines_page.add_batch(vaccine_name=vaccine)
+    vaccines_page.change_batch(vaccine_name=vaccine)
+    vaccines_page.archive_batch(vaccine_name=vaccine)

--- a/tests/test_07_children.py
+++ b/tests/test_07_children.py
@@ -11,101 +11,105 @@ from pages import (
 )
 
 
-class Test_Children:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    children_page = ChildrenPage()
-    sessions_page = SessionsPage()
-    import_records_page = ImportRecordsPage()
-    programmes_page = ProgrammesPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+children_page = ChildrenPage()
+sessions_page = SessionsPage()
+import_records_page = ImportRecordsPage()
+programmes_page = ProgrammesPage()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_tests(self, start_mavis, nurse):
-        self.login_page.log_in(**nurse)
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_tests(start_mavis, nurse):
+    login_page.log_in(**nurse)
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_children_page(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.CLASS_CHILDREN_FILTER
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_children()
         yield
-        self.login_page.log_out()
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_children_page(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.CLASS_CHILDREN_FILTER
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_children()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_change_nhsno(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.CLASS_CHANGE_NHSNO
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_children()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
+@pytest.fixture(scope="function", autouse=False)
+def setup_change_nhsno(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.CLASS_CHANGE_NHSNO
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_children()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mav_853(self, setup_tests: None):
-        try:
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.import_records_page.import_class_list_records_from_school_session(
-                file_paths=test_data_file_paths.CLASS_SESSION_ID
-            )
-            self.sessions_page.click_school1()
-            self.sessions_page.save_session_id_from_offline_excel()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_programmes()
-            self.programmes_page.upload_cohorts(
-                file_paths=test_data_file_paths.COHORTS_MAV_853
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_import_records()
-            self.import_records_page.import_vaccination_records(
-                file_paths=test_data_file_paths.VACCS_MAV_853,
-                file_type=mavis_file_types.VACCS_MAVIS,
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_children()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.mark.children
-    @pytest.mark.order(701)
-    def test_children_headers_and_filter(self, setup_children_page: None):
-        self.children_page.verify_headers()
-        self.children_page.verify_filter()
+@pytest.fixture(scope="function", autouse=False)
+def setup_mav_853(setup_tests: None):
+    try:
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        import_records_page.import_class_list_records_from_school_session(
+            file_paths=test_data_file_paths.CLASS_SESSION_ID
+        )
+        sessions_page.click_school1()
+        sessions_page.save_session_id_from_offline_excel()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_programmes()
+        programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_MAV_853)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_import_records()
+        import_records_page.import_vaccination_records(
+            file_paths=test_data_file_paths.VACCS_MAV_853,
+            file_type=mavis_file_types.VACCS_MAVIS,
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_children()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
 
-    @pytest.mark.children
-    @pytest.mark.bug
-    @pytest.mark.order(702)
-    def test_children_details_mav_853(self, setup_mav_853: None):
-        self.children_page.verify_mav_853()  # MAV-853
 
-    @pytest.mark.children
-    @pytest.mark.bug
-    @pytest.mark.order(703)
-    def test_children_change_nhsno(self, setup_change_nhsno: None):
-        self.children_page.change_nhs_no()
+@pytest.mark.children
+@pytest.mark.order(701)
+def test_headers_and_filter(setup_children_page: None):
+    children_page.verify_headers()
+    children_page.verify_filter()
+
+
+@pytest.mark.children
+@pytest.mark.bug
+@pytest.mark.order(702)
+def test_details_mav_853(setup_mav_853: None):
+    children_page.verify_mav_853()  # MAV-853
+
+
+@pytest.mark.children
+@pytest.mark.bug
+@pytest.mark.order(703)
+def test_change_nhsno(setup_change_nhsno: None):
+    children_page.change_nhs_no()

--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -9,43 +9,43 @@ from tests.helpers import parental_consent_helper_doubles
 from pages import ConsentHPVPage, DashboardPage, LoginPage, SessionsPage
 
 
-class Test_Consent_Doubles:
-    ce = CurrentExecution()
-    pc = ConsentHPVPage()
-    helper = parental_consent_helper_doubles.parental_consent_helper()
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    sessions_page = SessionsPage()
+ce = CurrentExecution()
+pc = ConsentHPVPage()
+helper = parental_consent_helper_doubles.parental_consent_helper()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+sessions_page = SessionsPage()
 
-    @pytest.fixture(scope="function")
-    def get_doubles_session_link(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1()
-            link = self.sessions_page.get_doubles_consent_url()
-            self.login_page.log_out()
-            yield link
-        finally:
-            self.login_page.go_to_login_page()
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
 
-    @pytest.mark.consent
-    @pytest.mark.mobile
-    @pytest.mark.order(801)
-    @pytest.mark.parametrize(
-        "scenario_data",
-        helper.df.iterrows(),
-        ids=[tc[0] for tc in helper.df.iterrows()],
-    )
-    def test_consent_workflow_doubles(
-        self,
-        get_doubles_session_link: str,
-        scenario_data: Iterable[tuple[Hashable, Series]],
-    ):
-        self.ce.page.goto(get_doubles_session_link)
-        self.helper.read_data_for_scenario(scenario_data=scenario_data)
-        self.helper.enter_details_on_mavis()
+@pytest.fixture(scope="function")
+def get_session_link(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1()
+        link = sessions_page.get_doubles_consent_url()
+        login_page.log_out()
+        yield link
+    finally:
+        login_page.go_to_login_page()
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
+
+
+@pytest.mark.consent
+@pytest.mark.mobile
+@pytest.mark.order(801)
+@pytest.mark.parametrize(
+    "scenario_data",
+    helper.df.iterrows(),
+    ids=[tc[0] for tc in helper.df.iterrows()],
+)
+def test_workflow(
+    get_session_link: str,
+    scenario_data: Iterable[tuple[Hashable, Series]],
+):
+    ce.page.goto(get_session_link)
+    helper.read_data_for_scenario(scenario_data=scenario_data)
+    helper.enter_details_on_mavis()

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -9,183 +9,193 @@ from pages import ConsentHPVPage, DashboardPage, LoginPage, SessionsPage
 from tests.helpers import parental_consent_helper_hpv
 
 
-class Test_Consent_HPV:
-    ce = CurrentExecution()
-    pc = ConsentHPVPage()
-    helper = parental_consent_helper_hpv.parental_consent_helper()
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    sessions_page = SessionsPage()
+ce = CurrentExecution()
+pc = ConsentHPVPage()
+helper = parental_consent_helper_hpv.parental_consent_helper()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+sessions_page = SessionsPage()
 
-    @pytest.fixture(scope="function")
-    def get_hpv_session_link(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1()
-            link = self.sessions_page.get_hpv_consent_url()
-            self.login_page.log_out()
-            yield link
-        finally:
-            self.login_page.go_to_login_page()
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_gillick(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.COHORTS_FULL_NAME
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
+@pytest.fixture(scope="function")
+def get_hpv_session_link(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1()
+        link = sessions_page.get_hpv_consent_url()
+        login_page.log_out()
+        yield link
+    finally:
+        login_page.go_to_login_page()
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_invalidated_consent(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1()
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.COHORTS_NO_CONSENT
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school1()
-            self.sessions_page.click_consent_tab()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mavis_1696(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.COHORTS_CONFLICTING_CONSENT
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school1()
-            self.sessions_page.click_consent_tab()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
+@pytest.fixture(scope="function", autouse=False)
+def setup_gillick(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.COHORTS_FULL_NAME
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mavis_1864(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.COHORTS_CONSENT_TWICE
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school1()
-            self.sessions_page.click_consent_tab()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mavis_1818(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.click_sessions()
-            self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_school1()
-            self.sessions_page.upload_class_list_to_school_1(
-                file_paths=test_data_file_paths.COHORTS_CONFLICTING_GILLICK
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.click_scheduled()
-            self.sessions_page.click_school1()
-            self.sessions_page.click_consent_tab()
-            yield
-        finally:
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_sessions()
-            self.sessions_page.delete_all_sessions_for_school_1()
-            self.login_page.log_out()
+@pytest.fixture(scope="function", autouse=False)
+def setup_invalidated_consent(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1()
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.COHORTS_NO_CONSENT
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school1()
+        sessions_page.click_consent_tab()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.consent
-    @pytest.mark.mobile
-    @pytest.mark.order(901)
-    @pytest.mark.parametrize(
-        "scenario_data",
-        helper.df.iterrows(),
-        ids=[tc[0] for tc in helper.df.iterrows()],
-    )
-    def test_consent_workflow_hpv(
-        self,
-        get_hpv_session_link: str,
-        scenario_data: Iterable[tuple[Hashable, Series]],
-    ):
-        self.ce.page.goto(get_hpv_session_link)
-        self.helper.read_data_for_scenario(scenario_data=scenario_data)
-        self.helper.enter_details_on_mavis()
 
-    @pytest.mark.consent
-    @pytest.mark.order(902)
-    def test_gillick_competence(self, setup_gillick: None):
-        self.sessions_page.set_gillick_competence_for_student()
+@pytest.fixture(scope="function", autouse=False)
+def setup_mavis_1696(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.COHORTS_CONFLICTING_CONSENT
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school1()
+        sessions_page.click_consent_tab()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.consent
-    @pytest.mark.bug
-    @pytest.mark.order(903)
-    def test_invalid_consent(self, setup_mavis_1696: None):
-        self.sessions_page.bug_mavis_1696()  # MAVIS-1696
 
-    @pytest.mark.consent
-    @pytest.mark.bug
-    @pytest.mark.order(905)
-    def test_parent_provides_consent_twice(self, setup_mavis_1864: None):
-        self.sessions_page.bug_mavis_1864()  # MAVIS-1864
+@pytest.fixture(scope="function", autouse=False)
+def setup_mavis_1864(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.COHORTS_CONSENT_TWICE
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school1()
+        sessions_page.click_consent_tab()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
 
-    @pytest.mark.consent
-    @pytest.mark.bug
-    @pytest.mark.order(906)
-    def test_conflicting_consent_with_gillick_consent(self, setup_mavis_1818: None):
-        self.sessions_page.bug_mavis_1818()  # MAVIS-1818
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_mavis_1818(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.click_sessions()
+        sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_school1()
+        sessions_page.upload_class_list_to_school_1(
+            file_paths=test_data_file_paths.COHORTS_CONFLICTING_GILLICK
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.click_scheduled()
+        sessions_page.click_school1()
+        sessions_page.click_consent_tab()
+        yield
+    finally:
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_sessions()
+        sessions_page.delete_all_sessions_for_school_1()
+        login_page.log_out()
+
+
+@pytest.mark.consent
+@pytest.mark.mobile
+@pytest.mark.order(901)
+@pytest.mark.parametrize(
+    "scenario_data",
+    helper.df.iterrows(),
+    ids=[tc[0] for tc in helper.df.iterrows()],
+)
+def test_consent_workflow_hpv(
+    self,
+    get_hpv_session_link: str,
+    scenario_data: Iterable[tuple[Hashable, Series]],
+):
+    ce.page.goto(get_hpv_session_link)
+    helper.read_data_for_scenario(scenario_data=scenario_data)
+    helper.enter_details_on_mavis()
+
+
+@pytest.mark.consent
+@pytest.mark.order(902)
+def test_gillick_competence(setup_gillick: None):
+    sessions_page.set_gillick_competence_for_student()
+
+
+@pytest.mark.consent
+@pytest.mark.bug
+@pytest.mark.order(903)
+def test_invalid_consent(setup_mavis_1696: None):
+    sessions_page.bug_mavis_1696()  # MAVIS-1696
+
+
+@pytest.mark.consent
+@pytest.mark.bug
+@pytest.mark.order(905)
+def test_parent_provides_consent_twice(setup_mavis_1864: None):
+    sessions_page.bug_mavis_1864()  # MAVIS-1864
+
+
+@pytest.mark.consent
+@pytest.mark.bug
+@pytest.mark.order(906)
+def test_conflicting_consent_with_gillick_consent(setup_mavis_1818: None):
+    sessions_page.bug_mavis_1818()  # MAVIS-1818

--- a/tests/test_10_unmatched_consent_responses.py
+++ b/tests/test_10_unmatched_consent_responses.py
@@ -5,66 +5,72 @@ from libs.mavis_constants import test_data_file_paths
 from pages import DashboardPage, LoginPage, ProgrammesPage, UnmatchedPage
 
 
-class Test_Unmatched_Consent_Responses:
-    ce = CurrentExecution()
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    unmatched_page = UnmatchedPage()
-    programmes_page = ProgrammesPage()
+ce = CurrentExecution()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+unmatched_page = UnmatchedPage()
+programmes_page = ProgrammesPage()
 
-    # ALL OF THE TESTS IN THIS CLASS DEPEND ON THE CONSENT WORKFLOW TESTS (HPV) TO HAVE RUN FIRST
-    # RUN THE CONSENT WORKFLOW TESTS OR THE FULL PACK BEFORE RUNNING THESE TESTS
-    # RUN WITH '--skip-reset' IF RUNNING ONLY CONSENT TESTS
+# ALL OF THE TESTS IN THIS CLASS DEPEND ON THE CONSENT WORKFLOW TESTS (HPV) TO HAVE RUN FIRST
+# RUN THE CONSENT WORKFLOW TESTS OR THE FULL PACK BEFORE RUNNING THESE TESTS
+# RUN WITH '--skip-reset' IF RUNNING ONLY CONSENT TESTS
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_tests(self, start_mavis, nurse):
-        self.login_page.log_in(**nurse)
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_unmatched_consent_responses()
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_tests(start_mavis, nurse):
+    login_page.log_in(**nurse)
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_unmatched_consent_responses()
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_ucr_match(start_mavis, nurse):
+    try:
+        login_page.log_in(**nurse)
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_programmes()
+        programmes_page.upload_cohorts(
+            file_paths=test_data_file_paths.COHORTS_UCR_MATCH
+        )
+        dashboard_page.go_to_dashboard()
+        dashboard_page.click_unmatched_consent_responses()
         yield
-        self.login_page.log_out()
+    finally:
+        login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_ucr_match(self, start_mavis, nurse):
-        try:
-            self.login_page.log_in(**nurse)
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_programmes()
-            self.programmes_page.upload_cohorts(
-                file_paths=test_data_file_paths.COHORTS_UCR_MATCH
-            )
-            self.dashboard_page.go_to_dashboard()
-            self.dashboard_page.click_unmatched_consent_responses()
-            yield
-        finally:
-            self.login_page.log_out()
 
-    @pytest.mark.unmatchedconsentresponses
-    @pytest.mark.order(1001)
-    @pytest.mark.dependency(name="ucr_records_exist")
-    def test_ucr_check_records_exist(self, setup_tests):
-        self.unmatched_page.verify_records_exist()
+@pytest.mark.unmatchedconsentresponses
+@pytest.mark.order(1001)
+@pytest.mark.dependency(name="ucr_records_exist")
+def test_check_records_exist(setup_tests):
+    unmatched_page.verify_records_exist()
 
-    @pytest.mark.unmatchedconsentresponses
-    @pytest.mark.order(1002)
-    @pytest.mark.dependency(depends=["ucr_records_exist"])
-    def test_ucr_archive_record(self, setup_tests):
-        self.unmatched_page.archive_record()  # Covers MAVIS-1782
 
-    @pytest.mark.unmatchedconsentresponses
-    @pytest.mark.order(1003)
-    @pytest.mark.dependency(depends=["ucr_records_exist"])
-    def test_ucr_create_record(self, setup_tests):
-        self.unmatched_page.create_record()  # Covers MAVIS-1812
+@pytest.mark.unmatchedconsentresponses
+@pytest.mark.order(1002)
+@pytest.mark.dependency(depends=["ucr_records_exist"])
+def test_archive_record(setup_tests):
+    unmatched_page.archive_record()  # Covers MAVIS-1782
 
-    @pytest.mark.unmatchedconsentresponses
-    @pytest.mark.order(1004)
-    @pytest.mark.dependency(depends=["ucr_records_exist"])
-    def test_ucr_match_record(self, setup_ucr_match):
-        self.unmatched_page.match_with_record()  # Covers MAVIS-1812
 
-    @pytest.mark.unmatchedconsentresponses
-    @pytest.mark.order(1005)
-    @pytest.mark.dependency(depends=["ucr_records_exist"])
-    def test_ucr_create_record_with_no_nhs_number(self, setup_tests):
-        self.unmatched_page.create_record_with_no_nhs_number()  # MAVIS-1781
+@pytest.mark.unmatchedconsentresponses
+@pytest.mark.order(1003)
+@pytest.mark.dependency(depends=["ucr_records_exist"])
+def test_create_record(setup_tests):
+    unmatched_page.create_record()  # Covers MAVIS-1812
+
+
+@pytest.mark.unmatchedconsentresponses
+@pytest.mark.order(1004)
+@pytest.mark.dependency(depends=["ucr_records_exist"])
+def test_match_record(setup_ucr_match):
+    unmatched_page.match_with_record()  # Covers MAVIS-1812
+
+
+@pytest.mark.unmatchedconsentresponses
+@pytest.mark.order(1005)
+@pytest.mark.dependency(depends=["ucr_records_exist"])
+def test_create_record_with_no_nhs_number(setup_tests):
+    unmatched_page.create_record_with_no_nhs_number()  # MAVIS-1781

--- a/tests/test_50_e2e.py
+++ b/tests/test_50_e2e.py
@@ -4,31 +4,30 @@ from libs.mavis_constants import test_data_file_paths
 from pages import DashboardPage, LoginPage, ProgrammesPage, SessionsPage
 
 
-class Test_E2E:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    programmes_page = ProgrammesPage()
-    sessions_page = SessionsPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+programmes_page = ProgrammesPage()
+sessions_page = SessionsPage()
 
-    @pytest.fixture(scope="function", autouse=True)
-    def setup_tests(self, start_mavis, reset_environment, nurse):
-        reset_environment()
 
-        self.login_page.log_in(**nurse)
-        yield
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
-        self.sessions_page.delete_all_sessions_for_school_1()
-        self.login_page.log_out()
+@pytest.fixture(scope="function", autouse=True)
+def setup_tests(start_mavis, reset_environment, nurse):
+    reset_environment()
 
-    @pytest.mark.e2e
-    @pytest.mark.order(5001)
-    def test_e2e(self):
-        self.dashboard_page.click_programmes()
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_E2E_1
-        )
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
-        self.sessions_page.schedule_a_valid_session_in_school_1()
-        self.sessions_page.give_consent_for_e2e1_child_by_parent_1()
+    login_page.log_in(**nurse)
+    yield
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    sessions_page.delete_all_sessions_for_school_1()
+    login_page.log_out()
+
+
+@pytest.mark.e2e
+@pytest.mark.order(5001)
+def test_e2e():
+    dashboard_page.click_programmes()
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_E2E_1)
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    sessions_page.schedule_a_valid_session_in_school_1()
+    sessions_page.give_consent_for_e2e1_child_by_parent_1()

--- a/tests/test_99_reset.py
+++ b/tests/test_99_reset.py
@@ -11,57 +11,59 @@ from pages import (
 )
 
 
-class Test_Reset:
-    login_page = LoginPage()
-    dashboard_page = DashboardPage()
-    programmes_page = ProgrammesPage()
-    sessions_page = SessionsPage()
-    vaccines_page = VaccinesPage()
-    import_records_page = ImportRecordsPage()
+login_page = LoginPage()
+dashboard_page = DashboardPage()
+programmes_page = ProgrammesPage()
+sessions_page = SessionsPage()
+vaccines_page = VaccinesPage()
+import_records_page = ImportRecordsPage()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_tests(self, start_mavis, reset_environment, nurse):
-        reset_environment()
 
-        self.login_page.log_in(**nurse)
-        yield
-        self.login_page.log_out()
+@pytest.fixture(scope="function", autouse=False)
+def setup_tests(start_mavis, reset_environment, nurse):
+    reset_environment()
 
-        reset_environment()
+    login_page.log_in(**nurse)
+    yield
+    login_page.log_out()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_mav_965(self, setup_tests: None):
-        self.dashboard_page.click_vaccines()
-        self.vaccines_page.add_batch(vaccine_name=vaccines.GARDASIL9)  # HPV
-        self.vaccines_page.add_batch(vaccine_name=vaccines.MENQUADFI)  # MenACWY
-        self.vaccines_page.add_batch(vaccine_name=vaccines.REVAXIS)  # Td/IPV
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
-        self.sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
-        self.import_records_page.import_class_list_records_from_school_session(
-            file_paths=test_data_file_paths.CLASS_MAV_965
-        )
-        self.dashboard_page.go_to_dashboard()
-        self.dashboard_page.click_sessions()
-        yield
+    reset_environment()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def setup_cohort_upload_and_reports(self, setup_tests: None):
-        self.dashboard_page.click_programmes()
-        yield
 
-    @pytest.mark.rav
-    @pytest.mark.bug
-    @pytest.mark.order(9901)
-    def test_programmes_rav_prescreening_questions(self, setup_mav_965):
-        self.programmes_page.verify_mav_965()
+@pytest.fixture(scope="function", autouse=False)
+def setup_mav_965(setup_tests: None):
+    dashboard_page.click_vaccines()
+    vaccines_page.add_batch(vaccine_name=vaccines.GARDASIL9)  # HPV
+    vaccines_page.add_batch(vaccine_name=vaccines.MENQUADFI)  # MenACWY
+    vaccines_page.add_batch(vaccine_name=vaccines.REVAXIS)  # Td/IPV
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
+    import_records_page.import_class_list_records_from_school_session(
+        file_paths=test_data_file_paths.CLASS_MAV_965
+    )
+    dashboard_page.go_to_dashboard()
+    dashboard_page.click_sessions()
+    yield
 
-    @pytest.mark.cohorts
-    @pytest.mark.order(9902)
-    @pytest.mark.skip(reason="Covered in performance testing")
-    def test_cohort_upload_performance(
-        self, setup_cohort_upload_and_reports
-    ):  # MAV-927
-        self.programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_MAV_927_PERF, wait_long=True
-        )
+
+@pytest.fixture(scope="function", autouse=False)
+def setup_cohort_upload_and_reports(setup_tests: None):
+    dashboard_page.click_programmes()
+    yield
+
+
+@pytest.mark.rav
+@pytest.mark.bug
+@pytest.mark.order(9901)
+def test_programmes_rav_prescreening_questions(setup_mav_965):
+    programmes_page.verify_mav_965()
+
+
+@pytest.mark.cohorts
+@pytest.mark.order(9902)
+@pytest.mark.skip(reason="Covered in performance testing")
+def test_cohort_upload_performance(setup_cohort_upload_and_reports):  # MAV-927
+    programmes_page.upload_cohorts(
+        file_paths=test_data_file_paths.COHORTS_MAV_927_PERF, wait_long=True
+    )


### PR DESCRIPTION
This flattens the structure of the tests by removing the `class` definition in each test file. This is done to simplify the usability of running individual tests, for example:

```shell
$ pytest tests/test_01_login.py::test_home_page_links_for_superuser
```

vs 

```shell
$ pytest tests/test_01_login.py::Test_Login::test_home_page_links_for_superuser
```

And also helps to avoid line wrapping as we lose the 4 spaces at the start of each line.

Best [reviewed ignoring whitespace changes](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/pull/233/files?diff=unified&w=1).