### PR TITLE
Remove `child_list`

### DIFF
--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -11,7 +11,6 @@ class CurrentExecution:
     capture_screenshot_flag: bool = False
 
     screenshot_sequence: int = 0
-    child_list: list[str] = []
     file_record_count: int = 0
     session_id: str = ""
 

--- a/pages/sessions.py
+++ b/pages/sessions.py
@@ -852,19 +852,6 @@ class SessionsPage:
         self.po.verify(
             locator=self.LBL_MAIN, property=properties.TEXT, expected_value="6 children"
         )
-        # Check name filters
-        if len(self.ce.child_list) >= 1:
-            for child_name in self.ce.child_list:
-                self.po.act(
-                    locator=self.TXT_FILTER_NAME, action=actions.FILL, value=child_name
-                )
-                self.po.act(locator=None, action=actions.WAIT, value=wait_time.MIN)
-                self.po.verify(
-                    locator=self.LBL_MAIN,
-                    property=properties.TEXT,
-                    expected_value=child_name,
-                )
-                self.po.act(locator=self.TXT_FILTER_NAME, action=actions.FILL, value="")
 
     def bug_mavis_1818(self):
         self.select_no_response()


### PR DESCRIPTION
This is a variable on the `CurrentExecution` class, but it's not being assigned at any point so it can be safely removed.

Instead, I think the method `verify_child_has_been_uploaded` has replaced this, which takes in a list of children.