### PR TITLE
Use pytest-dotenv

### DIFF
--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-from dotenv import load_dotenv
 from playwright.sync_api import Browser, Page
 
 
@@ -16,8 +15,6 @@ class CurrentExecution:
 
     @classmethod
     def get_env_values(cls):
-        load_dotenv()
-
         cls.capture_screenshot_flag = (
             os.environ.get("CAPTURE_SCREENSHOTS", "").lower() == "true"
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ pyee==13.0.0
 Pygments==2.19.1
 pytest==8.3.5
 pytest-dependency==0.6.0
+pytest-dotenv==0.5.2
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0


### PR DESCRIPTION
This will automatically load the environment variables for us without needing to call `load_dotenv` explicitly.