### PR TITLE
Refactor waiting for background imports

### DIFF
--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -9,18 +9,9 @@ class CurrentExecution:
     session_screenshots_dir: str = ""
     capture_screenshot_flag: bool = False
     screenshot_sequence: int = 0
-    file_record_count: int = 0
 
     @classmethod
     def get_env_values(cls):
         cls.capture_screenshot_flag = (
             os.environ.get("CAPTURE_SCREENSHOTS", "").lower() == "true"
         )
-
-    @classmethod
-    def set_file_record_count(cls, record_count: int):
-        cls.file_record_count = record_count
-
-    @classmethod
-    def get_file_record_count(cls) -> int:
-        return cls.file_record_count

--- a/libs/mavis_constants.py
+++ b/libs/mavis_constants.py
@@ -42,11 +42,6 @@ class mavis_file_types(Enum):
     VACCS_SYSTMONE = auto()
 
 
-class record_limit:
-    FILE_RECORD_MIN_THRESHOLD: Final[int] = 15
-    FILE_RECORD_MAX_THRESHOLD: Final[int] = 15
-
-
 class test_data_file_paths:
     PARENTAL_CONSENT_HPV: Final[str] = "test_data/ParentalConsent_HPV.xlsx"
     PARENTAL_CONSENT_DOUBLES: Final[str] = "test_data/ParentalConsent_Doubles.xlsx"

--- a/libs/testdata_ops.py
+++ b/libs/testdata_ops.py
@@ -86,8 +86,6 @@ class testdata_operations:
             _file_text.append(line)
             _ctr += 1
 
-        self.ce.set_file_record_count(record_count=_ctr)
-
         filename = f"{file_name_prefix}{get_current_datetime()}.csv"
 
         path = pathlib.Path("working") / filename

--- a/pages/import_records.py
+++ b/pages/import_records.py
@@ -3,7 +3,7 @@ from typing import Final, Optional
 from libs import CurrentExecution, testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
 from libs.playwright_ops import PlaywrightOperations
-from libs.mavis_constants import mavis_file_types, record_limit
+from libs.mavis_constants import mavis_file_types, test_data_values
 from libs.wrappers import get_link_formatted_date_time
 
 from .children import ChildrenPage
@@ -39,6 +39,14 @@ class ImportRecordsPage:
         self.vaccines_page = VaccinesPage(playwright_operations)
         self.upload_time = ""
 
+    @property
+    def alert_success(self):
+        return self.ce.page.get_by_text("Import processing started")
+
+    def is_processing_in_background(self):
+        self.ce.page.wait_for_load_state()
+        return self.alert_success.is_visible()
+
     def import_child_records(
         self, file_paths: str, verify_on_children_page: bool = False
     ):
@@ -62,9 +70,11 @@ class ImportRecordsPage:
         )
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
         self._record_upload_time()
-        self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
-        if self.ce.get_file_record_count() > record_limit.FILE_RECORD_MAX_THRESHOLD:
+
+        if self.is_processing_in_background():
+            self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
             self._click_uploaded_file_datetime(truncated=True)
+
         self._verify_upload_output(file_path=_output_file_path)
         if verify_on_children_page:
             self.children_page.verify_child_has_been_uploaded(child_list=_cl)
@@ -94,7 +104,7 @@ class ImportRecordsPage:
         self.po.act(
             locator=self.LBL_SCHOOL_NAME,
             action=actions.SELECT_FROM_LIST,
-            value=self.sessions_page.LNK_SCHOOL_1,
+            value=test_data_values.SCHOOL_1_NAME,
         )
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
         self._select_year_groups(*year_groups)
@@ -105,9 +115,11 @@ class ImportRecordsPage:
         )
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
         self._record_upload_time()
-        self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
-        if self.ce.get_file_record_count() > record_limit.FILE_RECORD_MAX_THRESHOLD:
+
+        if self.is_processing_in_background():
+            self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
             self._click_uploaded_file_datetime(truncated=True)
+
         self._verify_upload_output(file_path=_output_file_path)
         if verify_on_children_page:
             self.children_page.verify_child_has_been_uploaded(child_list=_cl)
@@ -127,9 +139,11 @@ class ImportRecordsPage:
         )
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
         self._record_upload_time()
-        self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
-        if self.ce.get_file_record_count() > record_limit.FILE_RECORD_MAX_THRESHOLD:
+
+        if self.is_processing_in_background():
+            self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
             self._click_uploaded_file_datetime(truncated=True)
+
         self._verify_upload_output(file_path=_output_file_path)
 
     def import_vaccination_records(
@@ -158,9 +172,11 @@ class ImportRecordsPage:
         )
         self.po.act(locator=self.BTN_CONTINUE, action=actions.CLICK_BUTTON)
         self._record_upload_time()
-        self.po.act(locator=None, action=actions.WAIT, value=wait_time.MAX)
-        if self.ce.get_file_record_count() > record_limit.FILE_RECORD_MAX_THRESHOLD:
+
+        if self.is_processing_in_background():
+            self.po.act(locator=None, action=actions.WAIT, value=wait_time.MAX)
             self._click_uploaded_file_datetime(truncated=True)
+
         self._verify_upload_output(file_path=_output_file_path)
         if verify_on_children_page:
             self.children_page.verify_child_has_been_uploaded(child_list=_cl)
@@ -213,5 +229,5 @@ class ImportRecordsPage:
         self.po.verify(
             locator=self.LBL_MAIN,
             property=properties.TEXT,
-            expected_value=self.sessions_page.LNK_SCHOOL_1,
+            expected_value=test_data_values.SCHOOL_1_NAME,
         )

--- a/pages/sessions.py
+++ b/pages/sessions.py
@@ -2,12 +2,7 @@ from typing import Final
 
 from libs import CurrentExecution, testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
-from libs.mavis_constants import (
-    mavis_file_types,
-    record_limit,
-    test_data_values,
-    Programme,
-)
+from libs.mavis_constants import mavis_file_types, test_data_values, Programme
 from libs.playwright_ops import PlaywrightOperations
 from libs.wrappers import (
     datetime,
@@ -19,6 +14,7 @@ from libs.wrappers import (
 from .children import ChildrenPage
 from .consent_hpv import ConsentHPVPage
 from .dashboard import DashboardPage
+from .import_records import ImportRecordsPage
 
 
 class SessionsPage:
@@ -130,6 +126,7 @@ class SessionsPage:
         self.dashboard_page = DashboardPage(playwright_operations)
         self.consent_page = ConsentHPVPage(playwright_operations)
         self.children_page = ChildrenPage(playwright_operations)
+        self.import_records_page = ImportRecordsPage(playwright_operations)
 
     def __get_display_formatted_date(self, date_to_format: str) -> str:
         _parsed_date = datetime.strptime(date_to_format, "%Y%m%d")
@@ -705,9 +702,11 @@ class SessionsPage:
         self.choose_file_child_records_for_school_1(file_path=_input_file_path)
         self.click_continue()
         self._record_upload_time()
-        if self.ce.get_file_record_count() > record_limit.FILE_RECORD_MIN_THRESHOLD:
+
+        if self.import_records_page.is_processing_in_background():
             self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
             self.click_uploaded_file_datetime()
+
         self.verify_upload_output(file_path=_output_file_path)
         if verify_on_children:
             self.children_page.verify_child_has_been_uploaded(child_list=_cl)
@@ -727,9 +726,11 @@ class SessionsPage:
         self.choose_file_child_records_for_school_2(file_path=_input_file_path)
         self.click_continue()
         self._record_upload_time()
-        if self.ce.get_file_record_count() > record_limit.FILE_RECORD_MIN_THRESHOLD:
+
+        if self.import_records_page.is_processing_in_background():
             self.po.act(locator=None, action=actions.WAIT, value=wait_time.MED)
             self.click_uploaded_file_datetime()
+
         self.verify_upload_output(file_path=_output_file_path)
         if verify_on_children:
             self.children_page.verify_child_has_been_uploaded(child_list=_cl)


### PR DESCRIPTION
This refactors how the tests wait for background imports to check for the alert banner rather than checking on the length of the file being uploaded. This should make the tests less brittle in case the rules on when to process a file in the background or not changes.