### PR TITLE
Make `playwright_operations` a fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from playwright.sync_api import sync_playwright
 from requests.auth import HTTPBasicAuth
 
 from libs import CurrentExecution as ce
+from libs.playwright_ops import PlaywrightOperations
 from libs.generic_constants import audit_log_paths
 from libs.mavis_constants import playwright_constants
 from libs.wrappers import get_current_datetime
@@ -97,6 +98,11 @@ def reset_endpoint(base_url) -> str:
 @pytest.fixture(scope="session")
 def skip_reset(request) -> bool:
     return request.config.getoption("skip_reset")
+
+
+@pytest.fixture(scope="session")
+def playwright_operations():
+    return PlaywrightOperations()
 
 
 @pytest.fixture(scope="session")

--- a/libs/playwright_ops.py
+++ b/libs/playwright_ops.py
@@ -23,7 +23,7 @@ from libs.wrappers import (
 )
 
 
-class playwright_operations:
+class PlaywrightOperations:
     """
     A class to handle Playwright operations for web automation.
     """

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -14,55 +14,55 @@ from .vaccines import VaccinesPage
 
 
 @pytest.fixture
-def children_page():
-    return ChildrenPage()
+def children_page(playwright_operations):
+    return ChildrenPage(playwright_operations)
 
 
 @pytest.fixture
-def consent_doubles_page():
-    return ConsentDoublesPage()
+def consent_doubles_page(playwright_operations):
+    return ConsentDoublesPage(playwright_operations)
 
 
 @pytest.fixture
-def consent_hpv_page():
-    return ConsentHPVPage()
+def consent_hpv_page(playwright_operations):
+    return ConsentHPVPage(playwright_operations)
 
 
 @pytest.fixture
-def dashboard_page():
-    return DashboardPage()
+def dashboard_page(playwright_operations):
+    return DashboardPage(playwright_operations)
 
 
 @pytest.fixture
-def import_records_page():
-    return ImportRecordsPage()
+def import_records_page(playwright_operations):
+    return ImportRecordsPage(playwright_operations)
 
 
 @pytest.fixture
-def login_page():
-    return LoginPage()
+def login_page(playwright_operations):
+    return LoginPage(playwright_operations)
 
 
 @pytest.fixture
-def programmes_page():
-    return ProgrammesPage()
+def programmes_page(playwright_operations):
+    return ProgrammesPage(playwright_operations)
 
 
 @pytest.fixture
-def school_moves_page():
-    return SchoolMovesPage()
+def school_moves_page(playwright_operations):
+    return SchoolMovesPage(playwright_operations)
 
 
 @pytest.fixture
-def sessions_page():
-    return SessionsPage()
+def sessions_page(playwright_operations):
+    return SessionsPage(playwright_operations)
 
 
 @pytest.fixture
-def unmatched_page():
-    return UnmatchedPage()
+def unmatched_page(playwright_operations):
+    return UnmatchedPage(playwright_operations)
 
 
 @pytest.fixture
-def vaccines_page():
-    return VaccinesPage()
+def vaccines_page(playwright_operations):
+    return VaccinesPage(playwright_operations)

--- a/pages/children.py
+++ b/pages/children.py
@@ -1,17 +1,13 @@
 from typing import Final
 
-from libs import CurrentExecution, playwright_ops
 from libs.generic_constants import actions, properties, wait_time
 from libs.mavis_constants import test_data_values
+from libs.playwright_ops import PlaywrightOperations
 
 from .dashboard import DashboardPage
 
 
 class ChildrenPage:
-    po = playwright_ops.playwright_operations()
-    ce = CurrentExecution()
-    dashboard_page = DashboardPage()
-
     CHILD1: Final[str] = "CFILTER1, CFilter1"
     LBL_CHILD_RECORD: Final[str] = "1 child"
 
@@ -33,6 +29,10 @@ class ChildrenPage:
     LNK_CHANGE_NHS_NO: Final[str] = "Change   NHS number"
     BTN_CONTINUE: Final[str] = "Continue"
     BTN_REMOVE_FROM_COHORT: Final[str] = "Remove from cohort"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
+        self.dashboard_page = DashboardPage(playwright_operations)
 
     def verify_headers(self):
         self.po.verify(

--- a/pages/consent_doubles.py
+++ b/pages/consent_doubles.py
@@ -1,13 +1,11 @@
 from typing import Final
 
-from libs import playwright_ops
 from libs.generic_constants import actions, properties
 from libs.mavis_constants import programmes, test_data_values
+from libs.playwright_ops import PlaywrightOperations
 
 
 class ConsentDoublesPage:
-    po = playwright_ops.playwright_operations()
-
     BTN_START_NOW: Final[str] = "Start now"
     TXT_CHILD_FIRST_NAME: Final[str] = "First name"
     TXT_CHILD_LAST_NAME: Final[str] = "Last name"
@@ -78,6 +76,9 @@ class ConsentDoublesPage:
     VACCINE_WILL_BE_GIVEN_ELSEWHERE: Final[str] = "vaccine will be given elsewhere"
     MEDICAL_REASONS: Final[str] = "medical reasons"
     PERSONAL_CHOICE: Final[str] = "personal choice"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
 
     def click_start_now(self):
         self.po.act(locator=self.BTN_START_NOW, action=actions.CLICK_BUTTON)

--- a/pages/consent_hpv.py
+++ b/pages/consent_hpv.py
@@ -1,13 +1,11 @@
 from typing import Final
 
-from libs import playwright_ops
 from libs.generic_constants import actions, properties, wait_time
 from libs.mavis_constants import test_data_values
+from libs.playwright_ops import PlaywrightOperations
 
 
 class ConsentHPVPage:
-    po = playwright_ops.playwright_operations()
-
     BTN_START_NOW: Final[str] = "Start now"
     TXT_CHILD_FIRST_NAME: Final[str] = "First name"
     TXT_CHILD_LAST_NAME: Final[str] = "Last name"
@@ -75,6 +73,9 @@ class ConsentHPVPage:
     VACCINE_WILL_BE_GIVEN_ELSEWHERE: Final[str] = "vaccine will be given elsewhere"
     MEDICAL_REASONS: Final[str] = "medical reasons"
     PERSONAL_CHOICE: Final[str] = "personal choice"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
 
     def click_start_now(self):
         self.po.act(locator=self.BTN_START_NOW, action=actions.CLICK_BUTTON)

--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -1,10 +1,8 @@
-from libs import playwright_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
+from libs.playwright_ops import PlaywrightOperations
 
 
 class DashboardPage:
-    po = playwright_ops.playwright_operations()
-
     LNK_PROGRAMMES: str = f"heading{escape_characters.SEPARATOR_CHAR}Programmes"
     LNK_SESSIONS: str = f"heading{escape_characters.SEPARATOR_CHAR}Sessions"
     LNK_CHILDREN: str = f"heading{escape_characters.SEPARATOR_CHAR}Children"
@@ -22,6 +20,9 @@ class DashboardPage:
         f"heading{escape_characters.SEPARATOR_CHAR}Service guidance"
     )
     LNK_NHS_LOGO: str = "Manage vaccinations in schools"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
 
     def click_programmes(self):
         self.po.act(locator=self.LNK_PROGRAMMES, action=actions.CLICK_LINK)

--- a/pages/import_records.py
+++ b/pages/import_records.py
@@ -1,7 +1,8 @@
 from typing import Final, Optional
 
-from libs import CurrentExecution, playwright_ops, testdata_ops
+from libs import CurrentExecution, testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
+from libs.playwright_ops import PlaywrightOperations
 from libs.mavis_constants import mavis_file_types, record_limit
 from libs.wrappers import get_link_formatted_date_time
 
@@ -12,13 +13,8 @@ from .vaccines import VaccinesPage
 
 
 class ImportRecordsPage:
-    po = playwright_ops.playwright_operations()
     ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
-    sessions_page = SessionsPage()
-    dashboard_page = DashboardPage()
-    children_page = ChildrenPage()
-    vaccines_page = VaccinesPage()
 
     LNK_CHILD_MAV_855: Final[str] = "MAV_855, MAV_855"
 
@@ -35,7 +31,12 @@ class ImportRecordsPage:
     LBL_MAIN: Final[str] = "main"
     LNK_IMPORT_CLASS_LIST_RECORDS: Final[str] = "Import class lists"
 
-    def __init__(self):
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
+        self.sessions_page = SessionsPage(playwright_operations)
+        self.dashboard_page = DashboardPage(playwright_operations)
+        self.children_page = ChildrenPage(playwright_operations)
+        self.vaccines_page = VaccinesPage(playwright_operations)
         self.upload_time = ""
 
     def import_child_records(

--- a/pages/login.py
+++ b/pages/login.py
@@ -1,12 +1,12 @@
 from typing import Final
 
-from libs import CurrentExecution, playwright_ops
+from libs import CurrentExecution
 from libs.generic_constants import actions, properties
 from libs.mavis_constants import test_data_values
+from libs.playwright_ops import PlaywrightOperations
 
 
 class LoginPage:
-    po = playwright_ops.playwright_operations()
     ce = CurrentExecution()
 
     LNK_START_NOW: Final[str] = "Start now"
@@ -17,6 +17,9 @@ class LoginPage:
     LBL_BANNER: Final[str] = "banner"
     BTN_ROLE: Final[str] = f"SAIS Organisation 1 ({test_data_values.ORG_CODE})"
     LBL_PARAGRAPH: Final[str] = "paragraph"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
 
     def log_in(self, username: str, password: str):
         self.__login_actions(username=username, password=password)

--- a/pages/programmes.py
+++ b/pages/programmes.py
@@ -2,7 +2,7 @@ from typing import Final
 
 import pandas as pd
 
-from libs import CurrentExecution, playwright_ops, testdata_ops
+from libs import CurrentExecution, testdata_ops
 from libs.generic_constants import actions, properties, wait_time
 from libs.mavis_constants import (
     programmes,
@@ -10,6 +10,7 @@ from libs.mavis_constants import (
     report_headers,
     test_data_file_paths,
 )
+from libs.playwright_ops import PlaywrightOperations
 from libs.wrappers import get_current_datetime, get_link_formatted_date_time
 
 from .children import ChildrenPage
@@ -20,14 +21,8 @@ from .sessions import SessionsPage
 
 
 class ProgrammesPage:
-    po = playwright_ops.playwright_operations()
     ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
-    sessions_page = SessionsPage()
-    dashboard_page = DashboardPage()
-    children_page = ChildrenPage()
-    consent_hpv = ConsentHPVPage()
-    consent_doubles = ConsentDoublesPage()
 
     LNK_DOSE2_CHILD: Final[str] = "DOSE2, Dose2"
     LNK_MAV_854_CHILD: Final[str] = "MAV_854, MAV_854"
@@ -67,6 +62,14 @@ class ProgrammesPage:
     RDO_KEEP_BOTH: Final[str] = "Keep both records"
     BTN_RESOLVE_DUPLICATE: Final[str] = "Resolve duplicate"
     LBL_RECORD_UPDATED: Final[str] = "Record updated"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
+        self.sessions_page = SessionsPage(playwright_operations)
+        self.dashboard_page = DashboardPage(playwright_operations)
+        self.children_page = ChildrenPage(playwright_operations)
+        self.consent_hpv = ConsentHPVPage(playwright_operations)
+        self.consent_doubles = ConsentDoublesPage(playwright_operations)
 
     def click_hpv(self):
         self.po.act(locator=self.LNK_HPV, action=actions.CLICK_LINK)

--- a/pages/school_moves.py
+++ b/pages/school_moves.py
@@ -2,19 +2,15 @@ from typing import Final
 
 import pandas as pd
 
-from libs import CurrentExecution, playwright_ops
 from libs.generic_constants import actions, escape_characters, properties
 from libs.mavis_constants import report_headers, test_data_values
+from libs.playwright_ops import PlaywrightOperations
 from libs.wrappers import get_current_datetime
 
 from .dashboard import DashboardPage
 
 
 class SchoolMovesPage:
-    po = playwright_ops.playwright_operations()
-    ce = CurrentExecution()
-    dashboard_page = DashboardPage()
-
     LBL_HEADERS: Final[str] = "Updated	Full name	Move	Actions"
     LBL_MAIN: Final[str] = "main"
     LBL_PARAGRAPH: Final[str] = "paragraph"
@@ -26,6 +22,10 @@ class SchoolMovesPage:
     LNK_DOWNLOAD_RECORDS: Final[str] = "Download records"
     BTN_CONTINUE: Final[str] = "Continue"
     BTN_DOWNLOAD_CSV: Final[str] = "Download CSV"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
+        self.dashboard_page = DashboardPage(playwright_operations)
 
     def verify_headers(self):
         self.po.verify(

--- a/pages/sessions.py
+++ b/pages/sessions.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-from libs import CurrentExecution, playwright_ops, testdata_ops
+from libs import CurrentExecution, testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
 from libs.mavis_constants import (
     mavis_file_types,
@@ -9,6 +9,7 @@ from libs.mavis_constants import (
     test_data_values,
     vaccines,
 )
+from libs.playwright_ops import PlaywrightOperations
 from libs.wrappers import (
     datetime,
     get_current_datetime,
@@ -22,12 +23,8 @@ from .dashboard import DashboardPage
 
 
 class SessionsPage:
-    po = playwright_ops.playwright_operations()
     ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
-    dashboard_page = DashboardPage()
-    consent_page = ConsentHPVPage()
-    children_page = ChildrenPage()
 
     LNK_SCHOOL_1: Final[str] = test_data_values.SCHOOL_1_NAME
     LNK_SCHOOL_2: Final[str] = test_data_values.SCHOOL_2_NAME
@@ -129,8 +126,12 @@ class SessionsPage:
     BTN_SEARCH: Final[str] = "Search"
     TXT_SEARCH: Final[str] = "Search"
 
-    def __init__(self):
+    def __init__(self, playwright_operations: PlaywrightOperations):
         self.upload_time = ""
+        self.po = playwright_operations
+        self.dashboard_page = DashboardPage(playwright_operations)
+        self.consent_page = ConsentHPVPage(playwright_operations)
+        self.children_page = ChildrenPage(playwright_operations)
 
     def __get_display_formatted_date(self, date_to_format: str) -> str:
         _parsed_date = datetime.strptime(date_to_format, "%Y%m%d")

--- a/pages/unmatched.py
+++ b/pages/unmatched.py
@@ -1,18 +1,13 @@
 from typing import Final
 
-from libs import CurrentExecution, playwright_ops
 from libs.generic_constants import actions, properties, wait_time
+from libs.playwright_ops import PlaywrightOperations
 
 from .children import ChildrenPage
 from .dashboard import DashboardPage
 
 
 class UnmatchedPage:
-    po = playwright_ops.playwright_operations()
-    ce = CurrentExecution()
-    dashboard_page = DashboardPage()
-    children_page = ChildrenPage()
-
     LBL_NO_RECORDS: Final[str] = "!There are currently no unmatched consent responses."
     LBL_MAIN: Final[str] = "main"
     LBL_PARAGRAPH: Final[str] = "paragraph"
@@ -42,6 +37,11 @@ class UnmatchedPage:
     LNK_SELECT_FILTERED_CHILD: Final[str] = "Select"
     BTN_LINK_RESPONSE_WITH_RECORD: Final[str] = "Link response with record"
     LBL_CONSENT_MATCHED: str = f"Consent matched for {LBL_CHILD_NAME_TO_MATCH}"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
+        self.dashboard_page = DashboardPage(playwright_operations)
+        self.children_page = ChildrenPage(playwright_operations)
 
     def verify_records_exist(self):
         self.po.verify(

--- a/pages/vaccines.py
+++ b/pages/vaccines.py
@@ -1,13 +1,11 @@
 from typing import Final
 
-from libs import playwright_ops
 from libs.generic_constants import actions, properties
+from libs.playwright_ops import PlaywrightOperations
 from libs.wrappers import get_current_datetime, get_offset_date
 
 
 class VaccinesPage:
-    po = playwright_ops.playwright_operations()
-
     LBL_VACCINE_NAME: Final[str] = "Gardasil 9 (HPV)"
     LBL_VACCINE_MANUFACTURER: Final[str] = "Merck Sharp & Dohme"
     LBL_MAIN: Final[str] = "main"
@@ -21,6 +19,9 @@ class VaccinesPage:
     BTN_ADD_BATCH: Final[str] = "Add batch"
     BTN_SAVE_CHANGES: Final[str] = "Save changes"
     BTN_CONFIRM_ARCHIVE: Final[str] = "Yes, archive this batch"
+
+    def __init__(self, playwright_operations: PlaywrightOperations):
+        self.po = playwright_operations
 
     def verify_current_vaccine(self):
         self.po.verify(

--- a/tests/helpers/parental_consent_helper_doubles.py
+++ b/tests/helpers/parental_consent_helper_doubles.py
@@ -3,10 +3,9 @@ from libs.mavis_constants import test_data_file_paths, test_data_values
 from pages import ConsentDoublesPage
 
 
-class parental_consent_helper:
+class ParentalConsentHelper:
     ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
-    pc = ConsentDoublesPage()
 
     def __init__(self):
         self.df = self.tdo.read_spreadsheet(
@@ -45,25 +44,25 @@ class parental_consent_helper:
         self.consent_not_given_details = str(_row["ConsentNotGivenDetails"])
         self.expected_message = str(_row["ExpectedFinalMessage"])
 
-    def enter_details_on_mavis(self) -> None:
-        self.pc.click_start_now()
-        self.pc.fill_child_name_details(
+    def enter_details_on_mavis(self, page: ConsentDoublesPage):
+        page.click_start_now()
+        page.fill_child_name_details(
             scenario_id=self.scenario_id,
             child_first_name=self.child_first_name,
             child_last_name=self.child_last_name,
             known_as_first=self.child_aka_first,
             known_as_last=self.child_aka_last,
         )
-        self.pc.fill_child_dob(
+        page.fill_child_dob(
             scenario_id=self.scenario_id,
             dob_day=self.child_dob_day,
             dob_month=self.child_dob_month,
             dob_year=self.child_dob_year,
         )
-        self.pc.select_child_school(
+        page.select_child_school(
             scenario_id=self.scenario_id, school_name=self.school_name
         )
-        self.pc.fill_parent_details(
+        page.fill_parent_details(
             scenario_id=self.scenario_id,
             parent_name=self.parent_name,
             relation=self.relation,
@@ -71,53 +70,53 @@ class parental_consent_helper:
             phone=self.phone,
         )
         if self.phone != test_data_values.EMPTY:
-            self.pc.check_phone_options(
+            page.check_phone_options(
                 scenario_id=self.scenario_id,
             )
-        self.pc.select_consent_for_vaccination(
+        page.select_consent_for_vaccination(
             scenario_id=self.scenario_id, consent_for=self.consent_for
         )
         if self.consent_for.lower() != test_data_values.EMPTY:  # None
-            self.pc.fill_address_details(
+            page.fill_address_details(
                 scenario_id=self.scenario_id,
                 line1=self.addr1,
                 line2=self.addr2,
                 city=self.city,
                 postcode=self.postcode,
             )
-            self.pc.select_bleeding_disorder(
+            page.select_bleeding_disorder(
                 scenario_id=self.scenario_id,
                 bleeding_disorder_details=self.bleeding_disorder_details,
             )
-            self.pc.select_severe_allergies(
+            page.select_severe_allergies(
                 scenario_id=self.scenario_id,
                 allergy_details=self.severe_allergy_details,
             )
-            self.pc.select_severe_reaction(
+            page.select_severe_reaction(
                 scenario_id=self.scenario_id, reaction_details=self.reaction_details
             )
-            self.pc.select_extra_support(
+            page.select_extra_support(
                 scenario_id=self.scenario_id,
                 extra_support_details=self.extra_support_details,
             )
-            self.pc.vaccinated_in_past(
+            page.vaccinated_in_past(
                 scenario_id=self.scenario_id,
                 vaccs_in_past_details=self.vaccinated_in_past_details,
             )
         if self.consent_for.lower() == "both":
-            self.pc.other_vaccs_in_past(
+            page.other_vaccs_in_past(
                 scenario_id=self.scenario_id,
                 other_vaccs_in_past_details=self.other_vaccs_in_past_details,
             )
         if self.consent_for.lower() != "both":
-            self.pc.select_consent_not_given_reason(
+            page.select_consent_not_given_reason(
                 scenario_id=self.scenario_id,
                 reason=self.consent_not_given_reason,
                 reason_details=self.consent_not_given_details,
             )
-        self.pc.click_confirm_details(
+        page.click_confirm_details(
             scenario_id=self.scenario_id,
         )
-        self.pc.verify_final_message(
+        page.verify_final_message(
             scenario_id=self.scenario_id, expected_message=self.expected_message
         )

--- a/tests/helpers/parental_consent_helper_hpv.py
+++ b/tests/helpers/parental_consent_helper_hpv.py
@@ -1,12 +1,10 @@
-from libs import CurrentExecution, testdata_ops
+from libs import testdata_ops
 from libs.mavis_constants import test_data_file_paths, test_data_values
 from pages import ConsentHPVPage
 
 
-class parental_consent_helper:
-    ce = CurrentExecution()
+class ParentalConsentHelper:
     tdo = testdata_ops.testdata_operations()
-    pc = ConsentHPVPage()
 
     def __init__(self):
         self.df = self.tdo.read_spreadsheet(
@@ -43,25 +41,25 @@ class parental_consent_helper:
         self.consent_not_given_details = str(_row["ConsentNotGivenDetails"])
         self.expected_message = str(_row["ExpectedFinalMessage"])
 
-    def enter_details_on_mavis(self) -> None:
-        self.pc.click_start_now()
-        self.pc.fill_child_name_details(
+    def enter_details_on_mavis(self, page: ConsentHPVPage) -> None:
+        page.click_start_now()
+        page.fill_child_name_details(
             scenario_id=self.scenario_id,
             child_first_name=self.child_first_name,
             child_last_name=self.child_last_name,
             known_as_first=self.child_aka_first,
             known_as_last=self.child_aka_last,
         )
-        self.pc.fill_child_dob(
+        page.fill_child_dob(
             scenario_id=self.scenario_id,
             dob_day=self.child_dob_day,
             dob_month=self.child_dob_month,
             dob_year=self.child_dob_year,
         )
-        self.pc.select_child_school(
+        page.select_child_school(
             scenario_id=self.scenario_id, school_name=self.school_name
         )
-        self.pc.fill_parent_details(
+        page.fill_parent_details(
             scenario_id=self.scenario_id,
             parent_name=self.parent_name,
             relation=self.relation,
@@ -69,44 +67,43 @@ class parental_consent_helper:
             phone=self.phone,
         )
         if self.phone != test_data_values.EMPTY:
-            self.pc.check_phone_options(
+            page.check_phone_options(
                 scenario_id=self.scenario_id,
             )
-        self.pc.select_consent_for_vaccination(
+        page.select_consent_for_vaccination(
             scenario_id=self.scenario_id, consented=self.consent
         )
         if self.consent:
-            # self.pc.fill_gp_details(gp_name=self.gp)  # Removed on 04/12/2024 as GP details are to be retrieved from PDS now.
-            self.pc.fill_address_details(
+            page.fill_address_details(
                 scenario_id=self.scenario_id,
                 line1=self.addr1,
                 line2=self.addr2,
                 city=self.city,
                 postcode=self.postcode,
             )
-            self.pc.select_severe_allergies(
+            page.select_severe_allergies(
                 scenario_id=self.scenario_id, allergy_details=self.allergy_details
             )
-            self.pc.select_medical_condition(
+            page.select_medical_condition(
                 scenario_id=self.scenario_id,
                 medical_condition_details=self.medical_condition_details,
             )
-            self.pc.select_severe_reaction(
+            page.select_severe_reaction(
                 scenario_id=self.scenario_id, reaction_details=self.reaction_details
             )
-            self.pc.select_extra_support(
+            page.select_extra_support(
                 scenario_id=self.scenario_id,
                 extra_support_details=self.extra_support_details,
             )
         else:
-            self.pc.select_consent_not_given_reason(
+            page.select_consent_not_given_reason(
                 scenario_id=self.scenario_id,
                 reason=self.consent_not_given_reason,
                 reason_details=self.consent_not_given_details,
             )
-        self.pc.click_confirm_details(
+        page.click_confirm_details(
             scenario_id=self.scenario_id,
         )
-        self.pc.verify_final_message(
+        page.verify_final_message(
             scenario_id=self.scenario_id, expected_message=self.expected_message
         )

--- a/tests/test_00_smoke.py
+++ b/tests/test_00_smoke.py
@@ -3,11 +3,7 @@ import subprocess
 
 import pytest
 
-from libs import playwright_ops
 from libs.generic_constants import properties
-
-
-po = playwright_ops.playwright_operations()
 
 
 @pytest.mark.smoke
@@ -33,8 +29,8 @@ def test_verify_packages():
 
 @pytest.mark.smoke
 @pytest.mark.order(3)
-def test_homepage_loads(start_mavis):
-    po.verify(
+def test_homepage_loads(start_mavis, playwright_operations):
+    playwright_operations.verify(
         locator="heading",
         property=properties.TEXT,
         expected_value="Manage vaccinations in schools (Mavis)",

--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -1,14 +1,12 @@
-from typing import Hashable, Iterable
-
 import pytest
-from pandas.core.series import Series
 
 from libs import CurrentExecution
-from tests.helpers import parental_consent_helper_doubles
+
+from .helpers.parental_consent_helper_doubles import ParentalConsentHelper
 
 
 ce = CurrentExecution()
-helper = parental_consent_helper_doubles.parental_consent_helper()
+helper = ParentalConsentHelper()
 
 
 @pytest.fixture(scope="function")
@@ -36,10 +34,7 @@ def get_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_pa
     helper.df.iterrows(),
     ids=[tc[0] for tc in helper.df.iterrows()],
 )
-def test_workflow(
-    get_session_link: str,
-    scenario_data: Iterable[tuple[Hashable, Series]],
-):
-    ce.page.goto(get_session_link)
+def test_workflow(get_session_link, scenario_data, consent_doubles_page):
     helper.read_data_for_scenario(scenario_data=scenario_data)
-    helper.enter_details_on_mavis()
+    ce.page.goto(get_session_link)
+    helper.enter_details_on_mavis(consent_doubles_page)

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -1,19 +1,17 @@
-from typing import Hashable, Iterable
-
 import pytest
-from pandas.core.series import Series
 
 from libs import CurrentExecution
 from libs.mavis_constants import test_data_file_paths
-from tests.helpers import parental_consent_helper_hpv
+
+from .helpers.parental_consent_helper_hpv import ParentalConsentHelper
 
 
 ce = CurrentExecution()
-helper = parental_consent_helper_hpv.parental_consent_helper()
+helper = ParentalConsentHelper()
 
 
 @pytest.fixture(scope="function")
-def get_hpv_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_page):
+def get_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -161,13 +159,10 @@ def setup_mavis_1818(start_mavis, nurse, login_page, dashboard_page, sessions_pa
     helper.df.iterrows(),
     ids=[tc[0] for tc in helper.df.iterrows()],
 )
-def test_consent_workflow_hpv(
-    get_hpv_session_link: str,
-    scenario_data: Iterable[tuple[Hashable, Series]],
-):
-    ce.page.goto(get_hpv_session_link)
+def test_consent_workflow_hpv(get_session_link, scenario_data, consent_hpv_page):
     helper.read_data_for_scenario(scenario_data=scenario_data)
-    helper.enter_details_on_mavis()
+    ce.page.goto(get_session_link)
+    helper.enter_details_on_mavis(consent_hpv_page)
 
 
 @pytest.mark.consent

--- a/tests/test_10_unmatched_consent_responses.py
+++ b/tests/test_10_unmatched_consent_responses.py
@@ -1,10 +1,7 @@
 import pytest
 
-from libs import CurrentExecution
 from libs.mavis_constants import test_data_file_paths
 
-
-ce = CurrentExecution()
 
 # ALL OF THE TESTS IN THIS CLASS DEPEND ON THE CONSENT WORKFLOW TESTS (HPV) TO HAVE RUN FIRST
 # RUN THE CONSENT WORKFLOW TESTS OR THE FULL PACK BEFORE RUNNING THESE TESTS


### PR DESCRIPTION
This refactors how the playwright operations class is used to make it a fixture, allowing us to make it depend on a dynamic `page` and `browser` fixture in the future to support switching to `pytest-playwright` and removing the global singleton object `CurrentExecution`.