### PR TITLE
Remove `CurrentExecution`

### DIFF
--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,6 +1,0 @@
-from playwright.sync_api import Browser, Page
-
-
-class CurrentExecution:
-    page: Page = None
-    browser: Browser = None

--- a/libs/playwright_ops.py
+++ b/libs/playwright_ops.py
@@ -5,8 +5,8 @@ import time
 from typing import Optional
 
 import allure
+from playwright.sync_api import Page
 
-from libs import CurrentExecution
 from libs.generic_constants import (
     actions,
     aria_roles,
@@ -24,10 +24,8 @@ class PlaywrightOperations:
     A class to handle Playwright operations for web automation.
     """
 
-    ce = CurrentExecution()
-    PAGE_ELEMENT_PATH = "self.ce.page."
-
-    def __init__(self, screenshots_path: Optional[Path]):
+    def __init__(self, page: Page, screenshots_path: Optional[Path]):
+        self.page = page
         self.screenshots_path = screenshots_path
 
     def capture_screenshot(self, identifier: str, action: str) -> None:
@@ -47,7 +45,7 @@ class PlaywrightOperations:
 
         path = self.screenshots_path / file_name
 
-        self.ce.page.screenshot(path=path, type="png", full_page=True)
+        self.page.screenshot(path=path, type="png", full_page=True)
 
     def verify(
         self, locator: str, property: properties, expected_value: str, **kwargs
@@ -132,9 +130,9 @@ class PlaywrightOperations:
                     locator=locator, index=index, chain_locator=chain_locator
                 )
             case properties.ELEMENT_EXISTS:
-                return str(self.ce.page.query_selector(locator) is not None)
+                return str(self.page.query_selector(locator) is not None)
             case properties.PAGE_URL:
-                return self.ce.page.url
+                return self.page.url
 
     def act(
         self, locator: str | None, action: actions, value: str | None = None, **kwargs
@@ -191,9 +189,9 @@ class PlaywrightOperations:
                     locator=locator, value=value, index=index
                 )
             case actions.CLICK_WILDCARD:
-                self.ce.page.click(f"text={locator}")
+                self.page.click(f"text={locator}")
             case actions.CHAIN_LOCATOR_ACTION:
-                eval(f"{self.PAGE_ELEMENT_PATH}{locator}")
+                eval(f"self.page.{locator}")
             case actions.WAIT:
                 self._wait(time_out=value)
         if locator is not None:
@@ -212,11 +210,11 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(
-                    _location, name=_locator, exact=exact
-                ).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator, exact=exact).nth(
+                    index
+                )
             else:
-                elem = self.ce.page.get_by_role(
+                elem = self.page.get_by_role(
                     aria_roles.LINK, name=locator, exact=exact
                 ).nth(index)
             elem.click()
@@ -235,9 +233,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_role(
+                elem = self.page.get_by_role(
                     aria_roles.BUTTON, name=locator, exact=exact
                 ).nth(index)
             elem.click()
@@ -256,9 +254,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_label(locator, exact=exact).nth(index)
+                elem = self.page.get_by_label(locator, exact=exact).nth(index)
             elem.click()
 
     def _click_text(self, locator: str, exact: bool, index: int):
@@ -274,9 +272,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_text(_location, name=_locator).nth(index)
+                elem = self.page.get_by_text(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_text(locator, exact=exact).nth(index)
+                elem = self.page.get_by_text(locator, exact=exact).nth(index)
             elem.click()
 
     def _fill(self, locator: str, value: Optional[str], exact: bool, index: int):
@@ -294,9 +292,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_label(locator, exact=exact).nth(index)
+                elem = self.page.get_by_label(locator, exact=exact).nth(index)
             elem.click()
 
             if value:
@@ -315,9 +313,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_label(locator, exact=exact).nth(index)
+                elem = self.page.get_by_label(locator, exact=exact).nth(index)
             elem.click()
 
     def _select_file(self, locator: str, value: str, exact: bool, index: int):
@@ -334,9 +332,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_label(locator, exact=exact).nth(index)
+                elem = self.page.get_by_label(locator, exact=exact).nth(index)
             elem.set_input_files(value)
 
     def _select_from_list(self, locator: str, value: str, index: int):
@@ -354,9 +352,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_role(aria_roles.OPTION, name=value)
+                elem = self.page.get_by_role(aria_roles.OPTION, name=value)
             elem.click()
 
     def _checkbox_check(self, locator: str, index: int):
@@ -371,9 +369,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_label(locator).nth(index)
+                elem = self.page.get_by_label(locator).nth(index)
             elem.check()
 
     def _checkbox_uncheck(self, locator: str, index: int):
@@ -388,9 +386,9 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
-                elem = self.ce.page.get_by_label(locator).nth(0)
+                elem = self.page.get_by_label(locator).nth(0)
             elem.uncheck()
 
     def _click_index_for_row(self, locator: str, value: str, index: int):
@@ -406,10 +404,10 @@ class PlaywrightOperations:
             if escape_characters.SEPARATOR_CHAR in locator:
                 _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                 _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+                elem = self.page.get_by_role(_location, name=_locator).nth(index)
             else:
                 elem = (
-                    self.ce.page.get_by_role(
+                    self.page.get_by_role(
                         aria_roles.ROW,
                         name=locator,
                     )
@@ -429,7 +427,7 @@ class PlaywrightOperations:
             index (int): Index of the link if multiple matches are found.
         """
         with allure.step(title=f"Downloading file [{value}] from [{locator}]"):
-            with self.ce.page.expect_download() as download_info:
+            with self.page.expect_download() as download_info:
                 self.act(locator=locator, action=actions.CLICK_LINK, index=index)
             download = download_info.value
             download.save_as(value)
@@ -445,7 +443,7 @@ class PlaywrightOperations:
             index (int): Index of the button if multiple matches are found.
         """
         with allure.step(title=f"Downloading file [{value}] from [{locator}]"):
-            with self.ce.page.expect_download() as download_info:
+            with self.page.expect_download() as download_info:
                 self.act(locator=locator, action=actions.CLICK_BUTTON, index=index)
             download = download_info.value
             download.save_as(value)
@@ -589,19 +587,19 @@ class PlaywrightOperations:
             str: Text content of the element.
         """
         if by_test_id:
-            elem = self.ce.page.get_by_test_id(locator)
+            elem = self.page.get_by_test_id(locator)
         else:
             if chain_locator:
-                elem = eval(f"{self.PAGE_ELEMENT_PATH}{locator}")
+                elem = eval(f"self.page.{locator}")
             else:
                 if escape_characters.SEPARATOR_CHAR in locator:
                     _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
                     _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-                    elem = self.ce.page.get_by_role(_location, name=_locator).locator(
+                    elem = self.page.get_by_role(_location, name=_locator).locator(
                         aria_roles.SPAN
                     )
                 else:
-                    elem = self.ce.page.get_by_role(locator).nth(index)
+                    elem = self.page.get_by_role(locator).nth(index)
         elem.scroll_into_view_if_needed()
         return "".join(elem.all_text_contents()).strip()
 
@@ -622,13 +620,13 @@ class PlaywrightOperations:
         if escape_characters.SEPARATOR_CHAR in locator:
             _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
             _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-            elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+            elem = self.page.get_by_role(_location, name=_locator).nth(index)
         else:
             if chain_locator:
                 self.act(locator=None, action=actions.WAIT, value=wait_time.MIN)
-                elem = eval(f"{self.PAGE_ELEMENT_PATH}{locator}")
+                elem = eval(f"self.page.{locator}")
             else:
-                elem = self.ce.page.get_by_role(locator).nth(0)
+                elem = self.page.get_by_role(locator).nth(0)
         return elem.is_visible()
 
     def _get_checkbox_state(self, locator: str, index: int, chain_locator: bool) -> str:
@@ -646,15 +644,13 @@ class PlaywrightOperations:
         if escape_characters.SEPARATOR_CHAR in locator:
             _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
             _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-            elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+            elem = self.page.get_by_role(_location, name=_locator).nth(index)
         else:
             if chain_locator:
                 self.act(locator=None, action=actions.WAIT, value=wait_time.MIN)
-                elem = eval(f"{self.PAGE_ELEMENT_PATH}{locator}")
+                elem = eval(f"self.page.{locator}")
             else:
-                elem = self.ce.page.get_by_role(aria_roles.CHECKBOX, name=locator).nth(
-                    0
-                )
+                elem = self.page.get_by_role(aria_roles.CHECKBOX, name=locator).nth(0)
         return elem.is_checked()
 
     def _get_element_href(self, locator: str, index: int, chain_locator: bool) -> str:
@@ -672,14 +668,12 @@ class PlaywrightOperations:
         if escape_characters.SEPARATOR_CHAR in locator:
             _location = locator.split(escape_characters.SEPARATOR_CHAR)[0]
             _locator = locator.split(escape_characters.SEPARATOR_CHAR)[1]
-            elem = self.ce.page.get_by_role(_location, name=_locator).nth(index)
+            elem = self.page.get_by_role(_location, name=_locator).nth(index)
         else:
             if chain_locator:
-                elem = eval(f"{self.PAGE_ELEMENT_PATH}{locator}")
+                elem = eval(f"self.page.{locator}")
             else:
-                elem = self.ce.page.get_by_role(aria_roles.LINK, name=locator).nth(
-                    index
-                )
+                elem = self.page.get_by_role(aria_roles.LINK, name=locator).nth(index)
         return elem.get_attribute(properties.HREF.name)
 
     def _wait(self, time_out: str):
@@ -700,7 +694,7 @@ class PlaywrightOperations:
         Args:
             locator_info (str): Information about the locator that caused the crash.
         """
-        _actual_title = self.ce.page.title()
+        _actual_title = self.page.title()
         if "Sorry, there’s a problem with the service" in _actual_title:
             assert False, f"Application has crashed after: {locator_info}"
 
@@ -719,7 +713,7 @@ class PlaywrightOperations:
             tuple: Row and column indices of the cell.
         """
         self.act(locator=None, action=actions.WAIT, value=wait_time.MED)
-        table = self.ce.page.locator(table_locator)
+        table = self.page.locator(table_locator)
 
         # Get the column index
         col_index = self._get_column_index(table, col_header)

--- a/libs/testdata_ops.py
+++ b/libs/testdata_ops.py
@@ -4,7 +4,6 @@ from typing import Optional
 import nhs_number
 import pandas as pd
 
-from libs import CurrentExecution
 from libs.mavis_constants import mavis_file_types, test_data_values
 from libs.wrappers import (
     get_current_datetime,
@@ -18,8 +17,6 @@ class testdata_operations:
     """
     A class to handle operations related to test data.
     """
-
-    ce = CurrentExecution()
 
     def __init__(self):
         """

--- a/pages/import_records.py
+++ b/pages/import_records.py
@@ -1,6 +1,6 @@
 from typing import Final, Optional
 
-from libs import CurrentExecution, testdata_ops
+from libs import testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
 from libs.playwright_ops import PlaywrightOperations
 from libs.mavis_constants import mavis_file_types, test_data_values
@@ -12,7 +12,6 @@ from .vaccines import VaccinesPage
 
 
 class ImportRecordsPage:
-    ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
 
     LNK_CHILD_MAV_855: Final[str] = "MAV_855, MAV_855"
@@ -39,10 +38,10 @@ class ImportRecordsPage:
 
     @property
     def alert_success(self):
-        return self.ce.page.get_by_text("Import processing started")
+        return self.po.page.get_by_text("Import processing started")
 
     def is_processing_in_background(self):
-        self.ce.page.wait_for_load_state()
+        self.po.page.wait_for_load_state()
         return self.alert_success.is_visible()
 
     def import_child_records(

--- a/pages/login.py
+++ b/pages/login.py
@@ -1,14 +1,11 @@
 from typing import Final
 
-from libs import CurrentExecution
 from libs.generic_constants import actions, properties
 from libs.mavis_constants import test_data_values
 from libs.playwright_ops import PlaywrightOperations
 
 
 class LoginPage:
-    ce = CurrentExecution()
-
     LNK_START_NOW: Final[str] = "Start now"
     TXT_EMAIL_ADDRESS: Final[str] = "Email address"
     TXT_PASSWORD: Final[str] = "Password"
@@ -46,4 +43,4 @@ class LoginPage:
         self.po.act(locator=self.BTN_LOGIN, action=actions.CLICK_BUTTON)
 
     def go_to_login_page(self) -> None:
-        self.ce.page.goto("/")
+        self.po.page.goto("/")

--- a/pages/programmes.py
+++ b/pages/programmes.py
@@ -2,7 +2,7 @@ from typing import Final
 
 import pandas as pd
 
-from libs import CurrentExecution, testdata_ops
+from libs import testdata_ops
 from libs.generic_constants import actions, properties, wait_time
 from libs.mavis_constants import report_headers, test_data_file_paths, Programme
 from libs.playwright_ops import PlaywrightOperations
@@ -17,7 +17,6 @@ from .sessions import SessionsPage
 
 
 class ProgrammesPage:
-    ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
 
     LNK_DOSE2_CHILD: Final[str] = "DOSE2, Dose2"

--- a/pages/sessions.py
+++ b/pages/sessions.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-from libs import CurrentExecution, testdata_ops
+from libs import testdata_ops
 from libs.generic_constants import actions, escape_characters, properties, wait_time
 from libs.mavis_constants import mavis_file_types, test_data_values, Programme
 from libs.playwright_ops import PlaywrightOperations
@@ -18,7 +18,6 @@ from .import_records import ImportRecordsPage
 
 
 class SessionsPage:
-    ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
 
     LNK_SCHOOL_1: Final[str] = test_data_values.SCHOOL_1_NAME

--- a/pages/vaccines.py
+++ b/pages/vaccines.py
@@ -52,7 +52,7 @@ class VaccinesPage:
             expected_value=vaccine,
         )
 
-        self.po.ce.page.get_by_role("link", name=f"Add a new {vaccine} batch").click()
+        self.po.page.get_by_role("link", name=f"Add a new {vaccine} batch").click()
 
         self.po.verify(
             locator=self.LBL_MAIN,

--- a/tests/helpers/parental_consent_helper_doubles.py
+++ b/tests/helpers/parental_consent_helper_doubles.py
@@ -1,10 +1,9 @@
-from libs import CurrentExecution, testdata_ops
+from libs import testdata_ops
 from libs.mavis_constants import test_data_file_paths
 from pages import ConsentDoublesPage
 
 
 class ParentalConsentHelper:
-    ce = CurrentExecution()
     tdo = testdata_ops.testdata_operations()
 
     def __init__(self):

--- a/tests/test_00_smoke.py
+++ b/tests/test_00_smoke.py
@@ -29,7 +29,7 @@ def test_verify_packages():
 
 @pytest.mark.smoke
 @pytest.mark.order(3)
-def test_homepage_loads(start_mavis, playwright_operations):
+def test_homepage_loads(playwright_operations):
     playwright_operations.verify(
         locator="heading",
         property=properties.TEXT,

--- a/tests/test_01_login.py
+++ b/tests/test_01_login.py
@@ -1,11 +1,6 @@
 import pytest
 
 
-@pytest.fixture(scope="function", autouse=True)
-def setup_tests(start_mavis):
-    yield
-
-
 test_parameters = [
     ("invalid_user", "invalid_password", "Invalid Email or password."),
     ("invalid_user", "", "Invalid Email or password."),

--- a/tests/test_02_sessions.py
+++ b/tests/test_02_sessions.py
@@ -4,7 +4,7 @@ from libs.mavis_constants import test_data_file_paths
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_tests(start_mavis, nurse, login_page, dashboard_page):
+def setup_tests(nurse, login_page, dashboard_page):
     login_page.log_in(**nurse)
     dashboard_page.go_to_dashboard()
     dashboard_page.click_sessions()
@@ -13,7 +13,7 @@ def setup_tests(start_mavis, nurse, login_page, dashboard_page):
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1822(start_mavis, nurse, login_page, dashboard_page, sessions_page):
+def setup_mavis_1822(nurse, login_page, dashboard_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -37,7 +37,7 @@ def setup_mavis_1822(start_mavis, nurse, login_page, dashboard_page, sessions_pa
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_mav_1018(start_mavis, nurse, login_page, dashboard_page, sessions_page):
+def setup_mav_1018(nurse, login_page, dashboard_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()

--- a/tests/test_03_import_records.py
+++ b/tests/test_03_import_records.py
@@ -7,7 +7,7 @@ from libs.mavis_constants import (
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_tests(start_mavis, nurse, login_page):
+def setup_tests(nurse, login_page):
     login_page.log_in(**nurse)
     yield
     login_page.log_out()

--- a/tests/test_04_school_moves.py
+++ b/tests/test_04_school_moves.py
@@ -4,7 +4,7 @@ from libs.mavis_constants import test_data_file_paths
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_tests(start_mavis, reset_environment, nurse, login_page):
+def setup_tests(reset_environment, nurse, login_page):
     reset_environment()
 
     login_page.log_in(**nurse)

--- a/tests/test_05_programmes.py
+++ b/tests/test_05_programmes.py
@@ -9,7 +9,7 @@ from libs.mavis_constants import (
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_cohort_upload_and_reports(start_mavis, nurse, dashboard_page, login_page):
+def setup_cohort_upload_and_reports(nurse, dashboard_page, login_page):
     login_page.log_in(**nurse)
     dashboard_page.click_programmes()
     yield
@@ -17,9 +17,7 @@ def setup_cohort_upload_and_reports(start_mavis, nurse, dashboard_page, login_pa
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_record_a_vaccine(
-    start_mavis, nurse, dashboard_page, login_page, sessions_page
-):
+def setup_record_a_vaccine(nurse, dashboard_page, login_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -36,7 +34,7 @@ def setup_record_a_vaccine(
 
 @pytest.fixture(scope="function", autouse=False)
 def setup_mavis_1729(
-    start_mavis, nurse, dashboard_page, import_records_page, login_page, sessions_page
+    nurse, dashboard_page, import_records_page, login_page, sessions_page
 ):
     try:
         login_page.log_in(**nurse)
@@ -66,7 +64,6 @@ def setup_mavis_1729(
 
 @pytest.fixture(scope="function", autouse=False)
 def setup_mav_854(
-    start_mavis,
     nurse,
     dashboard_page,
     import_records_page,
@@ -100,7 +97,7 @@ def setup_mav_854(
 
 @pytest.fixture(scope="function", autouse=False)
 def setup_mav_nnn(
-    start_mavis, admin, dashboard_page, login_page, import_records_page, sessions_page
+    admin, dashboard_page, login_page, import_records_page, sessions_page
 ):
     try:
         login_page.log_in(**admin)

--- a/tests/test_06_vaccines.py
+++ b/tests/test_06_vaccines.py
@@ -4,7 +4,7 @@ from libs.mavis_constants import Vaccine
 
 
 @pytest.fixture(scope="function", autouse=True)
-def setup_tests(start_mavis, nurse, login_page, dashboard_page):
+def setup_tests(nurse, login_page, dashboard_page):
     login_page.log_in(**nurse)
     dashboard_page.click_vaccines()
     yield

--- a/tests/test_07_children.py
+++ b/tests/test_07_children.py
@@ -4,7 +4,7 @@ from libs.mavis_constants import mavis_file_types, test_data_file_paths
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_tests(start_mavis, nurse, login_page):
+def setup_tests(nurse, login_page):
     login_page.log_in(**nurse)
     yield
     login_page.log_out()

--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -1,16 +1,13 @@
 import pytest
 
-from libs import CurrentExecution
-
 from .helpers.parental_consent_helper_doubles import ParentalConsentHelper
 
 
-ce = CurrentExecution()
 helper = ParentalConsentHelper()
 
 
 @pytest.fixture(scope="function")
-def get_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_page):
+def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -34,7 +31,7 @@ def get_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_pa
     helper.df.iterrows(),
     ids=[tc[0] for tc in helper.df.iterrows()],
 )
-def test_workflow(get_session_link, scenario_data, consent_doubles_page):
+def test_workflow(get_session_link, scenario_data, page, consent_doubles_page):
     helper.read_data_for_scenario(scenario_data=scenario_data)
-    ce.page.goto(get_session_link)
+    page.goto(get_session_link)
     helper.enter_details_on_mavis(consent_doubles_page)

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -1,17 +1,15 @@
 import pytest
 
-from libs import CurrentExecution
 from libs.mavis_constants import test_data_file_paths
 
 from .helpers.parental_consent_helper_hpv import ParentalConsentHelper
 
 
-ce = CurrentExecution()
 helper = ParentalConsentHelper()
 
 
 @pytest.fixture(scope="function")
-def get_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_page):
+def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -28,7 +26,7 @@ def get_session_link(start_mavis, nurse, dashboard_page, login_page, sessions_pa
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_gillick(start_mavis, nurse, dashboard_page, login_page, sessions_page):
+def setup_gillick(nurse, dashboard_page, login_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -50,9 +48,7 @@ def setup_gillick(start_mavis, nurse, dashboard_page, login_page, sessions_page)
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_invalidated_consent(
-    start_mavis, nurse, login_page, dashboard_page, sessions_page
-):
+def setup_invalidated_consent(nurse, login_page, dashboard_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -77,7 +73,7 @@ def setup_invalidated_consent(
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1696(start_mavis, nurse, login_page, dashboard_page, sessions_page):
+def setup_mavis_1696(nurse, login_page, dashboard_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -102,7 +98,7 @@ def setup_mavis_1696(start_mavis, nurse, login_page, dashboard_page, sessions_pa
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1864(start_mavis, nurse, login_page, dashboard_page, sessions_page):
+def setup_mavis_1864(nurse, login_page, dashboard_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -127,7 +123,7 @@ def setup_mavis_1864(start_mavis, nurse, login_page, dashboard_page, sessions_pa
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1818(start_mavis, nurse, login_page, dashboard_page, sessions_page):
+def setup_mavis_1818(nurse, login_page, dashboard_page, sessions_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
@@ -159,9 +155,9 @@ def setup_mavis_1818(start_mavis, nurse, login_page, dashboard_page, sessions_pa
     helper.df.iterrows(),
     ids=[tc[0] for tc in helper.df.iterrows()],
 )
-def test_consent_workflow_hpv(get_session_link, scenario_data, consent_hpv_page):
+def test_workflow(get_session_link, scenario_data, page, consent_hpv_page):
     helper.read_data_for_scenario(scenario_data=scenario_data)
-    ce.page.goto(get_session_link)
+    page.goto(get_session_link)
     helper.enter_details_on_mavis(consent_hpv_page)
 
 

--- a/tests/test_10_unmatched_consent_responses.py
+++ b/tests/test_10_unmatched_consent_responses.py
@@ -9,7 +9,7 @@ from libs.mavis_constants import test_data_file_paths
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_tests(start_mavis, nurse, login_page, dashboard_page):
+def setup_tests(nurse, login_page, dashboard_page):
     login_page.log_in(**nurse)
     dashboard_page.go_to_dashboard()
     dashboard_page.click_unmatched_consent_responses()
@@ -18,7 +18,7 @@ def setup_tests(start_mavis, nurse, login_page, dashboard_page):
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_ucr_match(start_mavis, nurse, login_page, dashboard_page, programmes_page):
+def setup_ucr_match(nurse, login_page, dashboard_page, programmes_page):
     try:
         login_page.log_in(**nurse)
         dashboard_page.go_to_dashboard()

--- a/tests/test_50_e2e.py
+++ b/tests/test_50_e2e.py
@@ -5,9 +5,7 @@ from libs.wrappers import wait_for_reset
 
 
 @pytest.fixture(scope="function", autouse=True)
-def setup_tests(
-    start_mavis, reset_environment, nurse, login_page, dashboard_page, sessions_page
-):
+def setup_tests(reset_environment, nurse, login_page, dashboard_page, sessions_page):
     reset_environment()
     wait_for_reset()
     login_page.log_in(**nurse)

--- a/tests/test_99_reset.py
+++ b/tests/test_99_reset.py
@@ -5,7 +5,7 @@ from libs.wrappers import wait_for_reset
 
 
 @pytest.fixture(scope="function", autouse=False)
-def setup_tests(start_mavis, reset_environment, nurse, login_page):
+def setup_tests(reset_environment, nurse, login_page):
     reset_environment()
     wait_for_reset()
     login_page.log_in(**nurse)


### PR DESCRIPTION
This removes the global singleton class `CurrentExecution` and replaces the two remaining attributes with session fixtures to match how `pytest-playwright` works, and therefore allows us to switch to using that plugin easily.