### PR TITLE
Add `log_in_as_` fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -120,13 +120,28 @@ def reset_environment_before_run(reset_environment):
 
 @pytest.fixture
 def page(reset_environment_before_run, page):
-    page.goto("/")
     return page
 
 
 @pytest.fixture
 def playwright_operations(page, screenshots_path):
     return PlaywrightOperations(page, screenshots_path)
+
+
+@pytest.fixture
+def log_in_as_nurse(nurse, login_page):
+    login_page.go_to_login_page()
+    login_page.log_in(**nurse)
+    yield
+    login_page.log_out()
+
+
+@pytest.fixture
+def log_in_as_admin(admin, login_page):
+    login_page.go_to_login_page()
+    login_page.log_in(**admin)
+    yield
+    login_page.log_out()
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,27 +2,25 @@
 log_file = logs/pytest.log
 log_file_date_format = %Y-%m-%d %H:%M:%S
 log_file_format = %(asctime)s - %(name)s %(levelname)s %(message)s
-
 addopts = -vs -rf --alluredir allure-results
-
 markers =
-  mobile
-  smoke
-  regression
   bug
-  order
-  login
-  vaccinations
+  childlist
+  children
+  classlist
+  cohorts
   consent
   consentworkflow
-  cohorts
-  childlist
-  classlist
-  vaccsbatch
-  rav
-  reports
-  children
-  sessions
-  schoolmoves
-  unmatchedconsentresponses
   e2e
+  login
+  mobile
+  order
+  rav
+  regression
+  reports
+  schoolmoves
+  sessions
+  smoke
+  unmatchedconsentresponses
+  vaccinations
+  vaccines

--- a/tests/test_00_smoke.py
+++ b/tests/test_00_smoke.py
@@ -29,7 +29,8 @@ def test_verify_packages():
 
 @pytest.mark.smoke
 @pytest.mark.order(3)
-def test_homepage_loads(playwright_operations):
+def test_homepage_loads(login_page, playwright_operations):
+    login_page.go_to_login_page()
     playwright_operations.verify(
         locator="heading",
         property=properties.TEXT,

--- a/tests/test_01_login.py
+++ b/tests/test_01_login.py
@@ -1,17 +1,22 @@
 import pytest
 
 
-test_parameters = [
-    ("invalid_user", "invalid_password", "Invalid Email or password."),
-    ("invalid_user", "", "Invalid Email or password."),
-    ("", "invalid_password", "Invalid Email or password."),
-    ("", "", "Invalid Email or password."),
-]
+@pytest.fixture(autouse=True)
+def go_to_log_in_page(login_page):
+    login_page.go_to_login_page()
 
 
 @pytest.mark.login
 @pytest.mark.order(101)
-@pytest.mark.parametrize("user,pwd,expected_message", test_parameters)
+@pytest.mark.parametrize(
+    "user,pwd,expected_message",
+    [
+        ("invalid_user", "invalid_password", "Invalid Email or password."),
+        ("invalid_user", "", "Invalid Email or password."),
+        ("", "invalid_password", "Invalid Email or password."),
+        ("", "", "Invalid Email or password."),
+    ],
+)
 def test_invalid(user, pwd, expected_message, login_page):
     login_page.try_invalid_login(user=user, pwd=pwd, expected_message=expected_message)
 
@@ -19,7 +24,6 @@ def test_invalid(user, pwd, expected_message, login_page):
 @pytest.mark.login
 @pytest.mark.order(102)
 def test_home_page_links_for_nurse(nurse, login_page, dashboard_page):
-    login_page.go_to_login_page()
     login_page.log_in(**nurse)
     dashboard_page.verify_all_expected_links_for_nurse()
     login_page.log_out()
@@ -28,7 +32,6 @@ def test_home_page_links_for_nurse(nurse, login_page, dashboard_page):
 @pytest.mark.login
 @pytest.mark.order(103)
 def test_home_page_links_for_superuser(superuser, login_page, dashboard_page):
-    login_page.go_to_login_page()
     login_page.log_in(**superuser)
     dashboard_page.verify_all_expected_links_for_superuser()
     login_page.log_out()
@@ -37,7 +40,6 @@ def test_home_page_links_for_superuser(superuser, login_page, dashboard_page):
 @pytest.mark.login
 @pytest.mark.order(104)
 def test_home_page_links_for_admin(admin, login_page, dashboard_page):
-    login_page.go_to_login_page()
     login_page.log_in(**admin)
     dashboard_page.verify_all_expected_links_for_admin()
     login_page.log_out()

--- a/tests/test_02_sessions.py
+++ b/tests/test_02_sessions.py
@@ -3,20 +3,14 @@ import pytest
 from libs.mavis_constants import test_data_file_paths
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_tests(nurse, login_page, dashboard_page):
-    login_page.log_in(**nurse)
-    dashboard_page.go_to_dashboard()
+@pytest.fixture
+def setup_tests(log_in_as_nurse, dashboard_page):
     dashboard_page.click_sessions()
-    yield
-    login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1822(nurse, login_page, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_mavis_1822(setup_tests, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
-        dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
@@ -33,14 +27,11 @@ def setup_mavis_1822(nurse, login_page, dashboard_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_mav_1018(nurse, login_page, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_mav_1018(setup_tests, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
-        dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
@@ -57,7 +48,6 @@ def setup_mav_1018(nurse, login_page, dashboard_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
 @pytest.mark.sessions

--- a/tests/test_03_import_records.py
+++ b/tests/test_03_import_records.py
@@ -6,21 +6,13 @@ from libs.mavis_constants import (
 )
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_tests(nurse, login_page):
-    login_page.log_in(**nurse)
-    yield
-    login_page.log_out()
-
-
-@pytest.fixture(scope="function", autouse=False)
-def setup_child_list(setup_tests, dashboard_page):
+@pytest.fixture
+def setup_child_list(log_in_as_nurse, dashboard_page):
     dashboard_page.click_import_records()
-    yield
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_class_list(setup_tests, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_class_list(log_in_as_nurse, dashboard_page, sessions_page):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1()
@@ -33,8 +25,8 @@ def setup_class_list(setup_tests, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions_for_school_1()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_vaccs(setup_tests, dashboard_page, sessions_page, import_records_page):
+@pytest.fixture
+def setup_vaccs(log_in_as_nurse, dashboard_page, sessions_page, import_records_page):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
@@ -52,8 +44,8 @@ def setup_vaccs(setup_tests, dashboard_page, sessions_page, import_records_page)
         sessions_page.delete_all_sessions_for_school_1()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_vaccs_systmone(setup_tests, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_vaccs_systmone(log_in_as_nurse, dashboard_page, sessions_page):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)

--- a/tests/test_04_school_moves.py
+++ b/tests/test_04_school_moves.py
@@ -3,16 +3,12 @@ import pytest
 from libs.mavis_constants import test_data_file_paths
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_tests(reset_environment, nurse, login_page):
+@pytest.fixture
+def setup_tests(log_in_as_nurse, reset_environment):
     reset_environment()
 
-    login_page.log_in(**nurse)
-    yield
-    login_page.log_out()
 
-
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_move_and_ignore(setup_tests, dashboard_page, sessions_page):
     try:
         dashboard_page.click_sessions()
@@ -44,7 +40,7 @@ def setup_move_and_ignore(setup_tests, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions_for_school_2()
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_move_to_homeschool_and_unknown(setup_tests, dashboard_page, sessions_page):
     try:
         dashboard_page.click_sessions()

--- a/tests/test_05_programmes.py
+++ b/tests/test_05_programmes.py
@@ -8,18 +8,14 @@ from libs.mavis_constants import (
 )
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_cohort_upload_and_reports(nurse, dashboard_page, login_page):
-    login_page.log_in(**nurse)
+@pytest.fixture
+def setup_cohort_upload_and_reports(log_in_as_nurse, dashboard_page):
     dashboard_page.click_programmes()
-    yield
-    login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_record_a_vaccine(nurse, dashboard_page, login_page, sessions_page):
+@pytest.fixture
+def setup_record_a_vaccine(log_in_as_nurse, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
@@ -29,15 +25,13 @@ def setup_record_a_vaccine(nurse, dashboard_page, login_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_mavis_1729(
-    nurse, dashboard_page, import_records_page, login_page, sessions_page
+    log_in_as_nurse, dashboard_page, import_records_page, sessions_page
 ):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         import_records_page.import_class_list_records_from_school_session(
@@ -59,20 +53,17 @@ def setup_mavis_1729(
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_mav_854(
-    nurse,
+    log_in_as_nurse,
     dashboard_page,
     import_records_page,
-    login_page,
     sessions_page,
     vaccines_page,
 ):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_vaccines()
         vaccines_page.add_batch(vaccine=Vaccine.GARDASIL_9)
         dashboard_page.go_to_dashboard()
@@ -92,15 +83,11 @@ def setup_mav_854(
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_mav_nnn(
-    admin, dashboard_page, login_page, import_records_page, sessions_page
-):
+@pytest.fixture
+def setup_mav_nnn(log_in_as_admin, dashboard_page, import_records_page, sessions_page):
     try:
-        login_page.log_in(**admin)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         import_records_page.import_class_list_records_from_school_session(
@@ -112,7 +99,6 @@ def setup_mav_nnn(
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
 @pytest.mark.cohorts

--- a/tests/test_06_vaccines.py
+++ b/tests/test_06_vaccines.py
@@ -3,18 +3,13 @@ import pytest
 from libs.mavis_constants import Vaccine
 
 
-@pytest.fixture(scope="function", autouse=True)
-def setup_tests(nurse, login_page, dashboard_page):
-    login_page.log_in(**nurse)
-    dashboard_page.click_vaccines()
-    yield
-    login_page.log_out()
-
-
-@pytest.mark.vaccsbatch
+@pytest.mark.vaccines
 @pytest.mark.order(601)
 @pytest.mark.parametrize("vaccine", Vaccine)
-def test_batch_add_change_archive(vaccine, vaccines_page):
+def test_batch_add_change_archive(
+    log_in_as_nurse, vaccine, dashboard_page, vaccines_page
+):
+    dashboard_page.click_vaccines()
     vaccines_page.add_batch(vaccine=vaccine)
     vaccines_page.change_batch(vaccine=vaccine)
     vaccines_page.archive_batch(vaccine=vaccine)

--- a/tests/test_07_children.py
+++ b/tests/test_07_children.py
@@ -3,15 +3,8 @@ import pytest
 from libs.mavis_constants import mavis_file_types, test_data_file_paths
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_tests(nurse, login_page):
-    login_page.log_in(**nurse)
-    yield
-    login_page.log_out()
-
-
-@pytest.fixture(scope="function", autouse=False)
-def setup_children_page(setup_tests, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_children_page(log_in_as_nurse, dashboard_page, sessions_page):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
@@ -30,8 +23,8 @@ def setup_children_page(setup_tests, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions_for_school_1()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_change_nhsno(setup_tests, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_change_nhsno(log_in_as_nurse, dashboard_page, sessions_page):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
@@ -50,9 +43,9 @@ def setup_change_nhsno(setup_tests, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions_for_school_1()
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_mav_853(
-    setup_tests, dashboard_page, import_records_page, programmes_page, sessions_page
+    log_in_as_nurse, dashboard_page, import_records_page, programmes_page, sessions_page
 ):
     try:
         dashboard_page.click_sessions()

--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -6,9 +6,10 @@ from .helpers.parental_consent_helper_doubles import ParentalConsentHelper
 helper = ParentalConsentHelper()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     try:
+        login_page.go_to_login_page()
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1()

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -8,9 +8,10 @@ from .helpers.parental_consent_helper_hpv import ParentalConsentHelper
 helper = ParentalConsentHelper()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     try:
+        login_page.go_to_login_page()
         login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1()
@@ -25,10 +26,9 @@ def get_session_link(nurse, dashboard_page, login_page, sessions_page):
         login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_gillick(nurse, dashboard_page, login_page, sessions_page):
+@pytest.fixture
+def setup_gillick(log_in_as_nurse, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
@@ -44,13 +44,11 @@ def setup_gillick(nurse, dashboard_page, login_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_invalidated_consent(nurse, login_page, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_invalidated_consent(log_in_as_nurse, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1()
         dashboard_page.go_to_dashboard()
@@ -69,13 +67,11 @@ def setup_invalidated_consent(nurse, login_page, dashboard_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1696(nurse, login_page, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_mavis_1696(log_in_as_nurse, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
@@ -94,13 +90,11 @@ def setup_mavis_1696(nurse, login_page, dashboard_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1864(nurse, login_page, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_mavis_1864(log_in_as_nurse, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
@@ -119,13 +113,11 @@ def setup_mavis_1864(nurse, login_page, dashboard_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_mavis_1818(nurse, login_page, dashboard_page, sessions_page):
+@pytest.fixture
+def setup_mavis_1818(log_in_as_nurse, dashboard_page, sessions_page):
     try:
-        login_page.log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1(for_today=True)
         dashboard_page.go_to_dashboard()
@@ -144,7 +136,6 @@ def setup_mavis_1818(nurse, login_page, dashboard_page, sessions_page):
         dashboard_page.go_to_dashboard()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
-        login_page.log_out()
 
 
 @pytest.mark.consent

--- a/tests/test_10_unmatched_consent_responses.py
+++ b/tests/test_10_unmatched_consent_responses.py
@@ -8,49 +8,37 @@ from libs.mavis_constants import test_data_file_paths
 # RUN WITH '--skip-reset' IF RUNNING ONLY CONSENT TESTS
 
 
-@pytest.fixture(scope="function", autouse=False)
-def setup_tests(nurse, login_page, dashboard_page):
-    login_page.log_in(**nurse)
+@pytest.fixture
+def go_to_unmatched_consent_responses(log_in_as_nurse, dashboard_page):
+    dashboard_page.click_unmatched_consent_responses()
+
+
+@pytest.fixture
+def setup_ucr_match(log_in_as_nurse, dashboard_page, programmes_page):
+    dashboard_page.click_programmes()
+    programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_UCR_MATCH)
     dashboard_page.go_to_dashboard()
     dashboard_page.click_unmatched_consent_responses()
-    yield
-    login_page.log_out()
-
-
-@pytest.fixture(scope="function", autouse=False)
-def setup_ucr_match(nurse, login_page, dashboard_page, programmes_page):
-    try:
-        login_page.log_in(**nurse)
-        dashboard_page.go_to_dashboard()
-        dashboard_page.click_programmes()
-        programmes_page.upload_cohorts(
-            file_paths=test_data_file_paths.COHORTS_UCR_MATCH
-        )
-        dashboard_page.go_to_dashboard()
-        dashboard_page.click_unmatched_consent_responses()
-        yield
-    finally:
-        login_page.log_out()
 
 
 @pytest.mark.unmatchedconsentresponses
 @pytest.mark.order(1001)
 @pytest.mark.dependency(name="ucr_records_exist")
-def test_check_records_exist(setup_tests, unmatched_page):
+def test_check_records_exist(go_to_unmatched_consent_responses, unmatched_page):
     unmatched_page.verify_records_exist()
 
 
 @pytest.mark.unmatchedconsentresponses
 @pytest.mark.order(1002)
 @pytest.mark.dependency(depends=["ucr_records_exist"])
-def test_archive_record(setup_tests, unmatched_page):
+def test_archive_record(go_to_unmatched_consent_responses, unmatched_page):
     unmatched_page.archive_record()  # Covers MAVIS-1782
 
 
 @pytest.mark.unmatchedconsentresponses
 @pytest.mark.order(1003)
 @pytest.mark.dependency(depends=["ucr_records_exist"])
-def test_create_record(setup_tests, unmatched_page):
+def test_create_record(go_to_unmatched_consent_responses, unmatched_page):
     unmatched_page.create_record()  # Covers MAVIS-1812
 
 
@@ -64,5 +52,7 @@ def test_match_record(setup_ucr_match, unmatched_page):
 @pytest.mark.unmatchedconsentresponses
 @pytest.mark.order(1005)
 @pytest.mark.dependency(depends=["ucr_records_exist"])
-def test_create_record_with_no_nhs_number(setup_tests, unmatched_page):
+def test_create_record_with_no_nhs_number(
+    go_to_unmatched_consent_responses, unmatched_page
+):
     unmatched_page.create_record_with_no_nhs_number()  # MAVIS-1781

--- a/tests/test_50_e2e.py
+++ b/tests/test_50_e2e.py
@@ -4,10 +4,11 @@ from libs.mavis_constants import test_data_file_paths
 from libs.wrappers import wait_for_reset
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def setup_tests(reset_environment, nurse, login_page, dashboard_page, sessions_page):
     reset_environment()
     wait_for_reset()
+    login_page.go_to_login_page()
     login_page.log_in(**nurse)
     yield
     dashboard_page.go_to_dashboard()

--- a/tests/test_99_reset.py
+++ b/tests/test_99_reset.py
@@ -4,16 +4,17 @@ from libs.mavis_constants import test_data_file_paths, Vaccine
 from libs.wrappers import wait_for_reset
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_tests(reset_environment, nurse, login_page):
     reset_environment()
     wait_for_reset()
+    login_page.go_to_login_page()
     login_page.log_in(**nurse)
     yield
     login_page.log_out()
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_mav_965(
     setup_tests, dashboard_page, import_records_page, sessions_page, vaccines_page
 ):
@@ -32,10 +33,9 @@ def setup_mav_965(
     yield
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture
 def setup_cohort_upload_and_reports(setup_tests, dashboard_page):
     dashboard_page.click_programmes()
-    yield
 
 
 @pytest.mark.rav


### PR DESCRIPTION
This adds two fixtures for logging in as a nurse and as an admin, to reduce duplicate code across the various set up and tear down steps.