### PR TITLE
Add start page model object

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -130,16 +130,14 @@ def playwright_operations(page, screenshots_path):
 
 @pytest.fixture
 def log_in_as_nurse(nurse, login_page):
-    login_page.go_to_login_page()
-    login_page.log_in(**nurse)
+    login_page.navigate_and_log_in(**nurse)
     yield
     login_page.log_out()
 
 
 @pytest.fixture
 def log_in_as_admin(admin, login_page):
-    login_page.go_to_login_page()
-    login_page.log_in(**admin)
+    login_page.navigate_and_log_in(**admin)
     yield
     login_page.log_out()
 

--- a/libs/step.py
+++ b/libs/step.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+import allure
+
+
+def step(title: str, attach_screenshot: bool = True):
+    step_context = allure.step(title)
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            return_value = func(self, *args, **kwargs)
+
+            if attach_screenshot:
+                allure.attach(
+                    self.page.screenshot(),
+                    name="Screenshot",
+                    attachment_type=allure.attachment_type.PNG,
+                )
+
+            return return_value
+
+        return step_context(wrapper)
+
+    return decorator

--- a/pages/__init__.py
+++ b/pages/__init__.py
@@ -8,6 +8,7 @@ from .login import LoginPage
 from .programmes import ProgrammesPage
 from .school_moves import SchoolMovesPage
 from .sessions import SessionsPage
+from .start import StartPage
 from .unmatched import UnmatchedPage
 from .vaccines import VaccinesPage
 
@@ -50,6 +51,11 @@ def school_moves_page(playwright_operations):
 @pytest.fixture
 def sessions_page(playwright_operations):
     return SessionsPage(playwright_operations)
+
+
+@pytest.fixture
+def start_page(page):
+    return StartPage(page)
 
 
 @pytest.fixture

--- a/pages/consent.py
+++ b/pages/consent.py
@@ -6,7 +6,6 @@ from libs.playwright_ops import PlaywrightOperations
 
 
 class ConsentPage:
-    BTN_START_NOW: Final[str] = "Start now"
     TXT_CHILD_FIRST_NAME: Final[str] = "First name"
     TXT_CHILD_LAST_NAME: Final[str] = "Last name"
     RDO_KNOWN_BY_ANOTHER_NAME_YES: Final[str] = "Yes"
@@ -86,9 +85,6 @@ class ConsentPage:
 
     def __init__(self, playwright_operations: PlaywrightOperations):
         self.po = playwright_operations
-
-    def click_start_now(self):
-        self.po.act(locator=self.BTN_START_NOW, action=actions.CLICK_BUTTON)
 
     def fill_child_name_details(
         self,

--- a/pages/login.py
+++ b/pages/login.py
@@ -6,7 +6,6 @@ from libs.playwright_ops import PlaywrightOperations
 
 
 class LoginPage:
-    LNK_START_NOW: Final[str] = "Start now"
     TXT_EMAIL_ADDRESS: Final[str] = "Email address"
     TXT_PASSWORD: Final[str] = "Password"
     BTN_LOGIN: Final[str] = "Log in"
@@ -18,10 +17,17 @@ class LoginPage:
     def __init__(self, playwright_operations: PlaywrightOperations):
         self.po = playwright_operations
 
+    def navigate(self):
+        self.po.page.goto("/users/sign-in")
+
     def log_in(self, username: str, password: str):
         self.__login_actions(username=username, password=password)
         self.po.act(locator=self.BTN_ROLE, action=actions.CLICK_BUTTON)
         self.verify_login(is_successful_login=True, verify_text=self.BTN_LOGOUT)
+
+    def navigate_and_log_in(self, username: str, password: str):
+        self.navigate()
+        self.log_in(username, password)
 
     def log_out(self):
         self.po.act(locator=self.BTN_LOGOUT, action=actions.CLICK_BUTTON)
@@ -37,10 +43,6 @@ class LoginPage:
         )
 
     def __login_actions(self, username: str, password: str) -> None:
-        self.po.act(locator=self.LNK_START_NOW, action=actions.CLICK_LINK)
         self.po.act(locator=self.TXT_EMAIL_ADDRESS, action=actions.FILL, value=username)
         self.po.act(locator=self.TXT_PASSWORD, action=actions.FILL, value=password)
         self.po.act(locator=self.BTN_LOGIN, action=actions.CLICK_BUTTON)
-
-    def go_to_login_page(self) -> None:
-        self.po.page.goto("/")

--- a/pages/start.py
+++ b/pages/start.py
@@ -1,0 +1,24 @@
+from playwright.sync_api import Page
+
+from libs.step import step
+
+
+class StartPage:
+    def __init__(self, page: Page):
+        self.page = page
+        self.heading = page.get_by_role(
+            "heading", name="Manage vaccinations in schools (Mavis)"
+        )
+        self.start_link = page.get_by_role("link", name="Start now")
+
+    @step("Go to start page")
+    def navigate(self):
+        self.page.goto("/")
+
+    @step("Click on start button")
+    def start(self):
+        self.start_link.click()
+
+    def navigate_and_start(self):
+        self.navigate()
+        self.start()

--- a/tests/helpers/parental_consent_helper_doubles.py
+++ b/tests/helpers/parental_consent_helper_doubles.py
@@ -46,7 +46,6 @@ class ParentalConsentHelper:
         self.expected_message = _row["ExpectedFinalMessage"]
 
     def enter_details_on_mavis(self, page: ConsentPage):
-        page.click_start_now()
         page.fill_child_name_details(
             scenario_id=self.scenario_id,
             child_first_name=self.child_first_name,

--- a/tests/helpers/parental_consent_helper_hpv.py
+++ b/tests/helpers/parental_consent_helper_hpv.py
@@ -42,7 +42,6 @@ class ParentalConsentHelper:
         self.expected_message = _row["ExpectedFinalMessage"]
 
     def enter_details_on_mavis(self, page: ConsentPage) -> None:
-        page.click_start_now()
         page.fill_child_name_details(
             scenario_id=self.scenario_id,
             child_first_name=self.child_first_name,

--- a/tests/test_00_smoke.py
+++ b/tests/test_00_smoke.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from libs.generic_constants import properties
+from playwright.sync_api import expect
 
 
 @pytest.mark.smoke
@@ -29,10 +29,8 @@ def test_verify_packages():
 
 @pytest.mark.smoke
 @pytest.mark.order(3)
-def test_homepage_loads(login_page, playwright_operations):
-    login_page.go_to_login_page()
-    playwright_operations.verify(
-        locator="heading",
-        property=properties.TEXT,
-        expected_value="Manage vaccinations in schools (Mavis)",
-    )
+def test_start(start_page, playwright_operations):
+    start_page.navigate()
+
+    expect(start_page.heading).to_be_visible()
+    expect(start_page.start_link).to_be_visible()

--- a/tests/test_01_login.py
+++ b/tests/test_01_login.py
@@ -2,8 +2,8 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def go_to_log_in_page(login_page):
-    login_page.go_to_login_page()
+def go_to_log_in_page(start_page):
+    start_page.navigate_and_start()
 
 
 @pytest.mark.login

--- a/tests/test_08_consent_doubles.py
+++ b/tests/test_08_consent_doubles.py
@@ -9,16 +9,14 @@ helper = ParentalConsentHelper()
 @pytest.fixture
 def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     try:
-        login_page.go_to_login_page()
-        login_page.log_in(**nurse)
+        login_page.navigate_and_log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1()
         link = sessions_page.get_doubles_consent_url()
         login_page.log_out()
         yield link
     finally:
-        login_page.go_to_login_page()
-        login_page.log_in(**nurse)
+        login_page.navigate_and_log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
         login_page.log_out()
@@ -32,7 +30,8 @@ def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     helper.df.iterrows(),
     ids=[tc[0] for tc in helper.df.iterrows()],
 )
-def test_workflow(get_session_link, scenario_data, page, consent_page):
+def test_workflow(get_session_link, scenario_data, page, consent_page, start_page):
     helper.read_data_for_scenario(scenario_data=scenario_data)
     page.goto(get_session_link)
+    start_page.start()
     helper.enter_details_on_mavis(consent_page)

--- a/tests/test_09_consent_hpv.py
+++ b/tests/test_09_consent_hpv.py
@@ -11,16 +11,14 @@ helper = ParentalConsentHelper()
 @pytest.fixture
 def get_session_link(nurse, dashboard_page, login_page, sessions_page):
     try:
-        login_page.go_to_login_page()
-        login_page.log_in(**nurse)
+        login_page.navigate_and_log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session_in_school_1()
         link = sessions_page.get_hpv_consent_url()
         login_page.log_out()
         yield link
     finally:
-        login_page.go_to_login_page()
-        login_page.log_in(**nurse)
+        login_page.navigate_and_log_in(**nurse)
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions_for_school_1()
         login_page.log_out()
@@ -146,9 +144,10 @@ def setup_mavis_1818(log_in_as_nurse, dashboard_page, sessions_page):
     helper.df.iterrows(),
     ids=[tc[0] for tc in helper.df.iterrows()],
 )
-def test_workflow(get_session_link, scenario_data, page, consent_page):
+def test_workflow(get_session_link, scenario_data, page, consent_page, start_page):
     helper.read_data_for_scenario(scenario_data=scenario_data)
     page.goto(get_session_link)
+    start_page.start()
     helper.enter_details_on_mavis(consent_page)
 
 

--- a/tests/test_50_e2e.py
+++ b/tests/test_50_e2e.py
@@ -5,10 +5,12 @@ from libs.wrappers import wait_for_reset
 
 
 @pytest.fixture(autouse=True)
-def setup_tests(reset_environment, nurse, login_page, dashboard_page, sessions_page):
+def setup_tests(
+    reset_environment, nurse, login_page, dashboard_page, sessions_page, start_page
+):
     reset_environment()
     wait_for_reset()
-    login_page.go_to_login_page()
+    start_page.navigate_and_start()
     login_page.log_in(**nurse)
     yield
     dashboard_page.go_to_dashboard()

--- a/tests/test_99_reset.py
+++ b/tests/test_99_reset.py
@@ -5,10 +5,10 @@ from libs.wrappers import wait_for_reset
 
 
 @pytest.fixture
-def setup_tests(reset_environment, nurse, login_page):
+def setup_tests(reset_environment, nurse, login_page, start_page):
     reset_environment()
     wait_for_reset()
-    login_page.go_to_login_page()
+    start_page.navigate_and_start()
     login_page.log_in(**nurse)
     yield
     login_page.log_out()


### PR DESCRIPTION
This adds a new class `StartPage` that is a page model object that can handle the two kinds of start pages that we have in the service:

- The main start page that users will see before logging in.
- The start page shown to parents before the consent journey.

The class is following the conventions documented by Playwright: https://playwright.dev/python/docs/pom

To support this page I've also create a `step` decorator that works in a very similar way to the `allure.step` but also automatically takes a screenshot at the end of the step and adds it to the Allure report.

This is different to how we're currently doing page objects, but I think this approach has a number of advantages:

- We can be more deliberate about which steps get added to the report. At the moment every single Playwright operation is added to the steps automatically which can lead to there being lots of unnecessary steps which can make the reports harder to use for assurance. We do lose this automatic approach with this style, but I think that will help to make the reports more compact and readable.
- Better separate of concerns on the page objects, by calling `page.get_by_` in the constructor we store the locators in one place and can pass those objects around directly, eventually avoiding the need to pass strings and have the current special case parsing for chained locators or sibling/children elements.
- We can make better use of the built-in Playwright assertions (`expect`) and ensure that they're applied consistently. By using this built-ins (both the assertions and the locators), we can take advantage of the [trace viewer feature](https://playwright.dev/python/docs/trace-viewer) allowing the tests to be followed live and even to check what the tests are doing at each stage in terms of locators and assertions, allowing this to be shared with the assurance team.