### PR TITLE
Remove test for verified packages

### DIFF
--- a/tests/test_00_smoke.py
+++ b/tests/test_00_smoke.py
@@ -1,5 +1,3 @@
-import subprocess
-
 import pytest
 
 from playwright.sync_api import expect
@@ -7,18 +5,6 @@ from playwright.sync_api import expect
 
 @pytest.mark.smoke
 @pytest.mark.order(1)
-def test_verify_packages():
-    packages_installed = subprocess.run(
-        args=["pip", "list"], capture_output=True, text=True
-    ).stdout.strip()
-    packages_to_verify = ["dotenv", "playwright", "requests"]
-    for package in packages_to_verify:
-        if package not in packages_installed:
-            assert False, f"{package} not installed"
-
-
-@pytest.mark.smoke
-@pytest.mark.order(2)
 def test_start(start_page, playwright_operations):
     start_page.navigate()
 


### PR DESCRIPTION
If these packages don't exist, this test can't even run because various `import` statements fail, so this test isn't adding any value as it either passes or can't be run anyway. If we did want something like this in the future, it would be better as a shell script or separate Python script run outside of `pytest`.