### PR TITLE
Remove static ordering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
     "NOCONSENT",
     "nodeid",
     "SAIS",
-    "schoolmoves",
+    "school_moves",
     "sessionfinish",
     "sessionstart",
     "SYSTM",

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ necessary to skip resetting the environment (when running a single test for
 example). To do this, there is `--skip-reset` flag available:
 
 ```shell
-$ pytest tests/test_11_unmatched_consent_responses.py --skip-reset
+$ pytest tests/test_unmatched_consent_responses.py --skip-reset
 ```
 
 #### Tracing

--- a/mavis/test/models/consent.py
+++ b/mavis/test/models/consent.py
@@ -361,7 +361,7 @@ class ConsentPage:
             expected_value=expected_message,
         )
 
-    def change_parent_phone(self):  # MAVIS-1778
+    def change_parent_phone(self):
         self.po.act(
             locator=self.TXT_PHONE_OPTIONAL, action=actions.FILL, value="7700900000"
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,7 @@ markers =
   rav
   regression
   reports
-  schoolmoves
+  school_moves
   sessions
   smoke
   unmatched_consent_responses

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -1,6 +1,9 @@
+import allure
 import pytest
 
 from mavis.test.mavis_constants import mavis_file_types, test_data_file_paths
+
+pytestmark = pytest.mark.children
 
 
 @pytest.fixture
@@ -79,22 +82,17 @@ def setup_mav_853(
         sessions_page.delete_all_sessions(schools[0])
 
 
-@pytest.mark.children
-@pytest.mark.order(701)
 def test_headers_and_filter(setup_children_page, children_page):
     children_page.verify_headers()
     children_page.verify_filter()
 
 
-@pytest.mark.children
+@allure.issue("MAV-853")
 @pytest.mark.bug
-@pytest.mark.order(702)
 def test_details_mav_853(setup_mav_853, children_page):
-    children_page.verify_mav_853()  # MAV-853
+    children_page.verify_mav_853()
 
 
-@pytest.mark.children
 @pytest.mark.bug
-@pytest.mark.order(703)
 def test_change_nhsno(setup_change_nhsno, children_page):
     children_page.change_nhs_no()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3,6 +3,8 @@ import pytest
 from mavis.test.mavis_constants import test_data_file_paths
 from mavis.test.wrappers import wait_for_reset
 
+pytestmark = pytest.mark.e2e
+
 
 @pytest.fixture(autouse=True)
 def setup_tests(
@@ -26,8 +28,6 @@ def setup_tests(
     log_in_page.log_out()
 
 
-@pytest.mark.e2e
-@pytest.mark.order(5001)
 def test_e2e(schools, dashboard_page, programmes_page, sessions_page):
     dashboard_page.click_programmes()
     programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_E2E_1)

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -59,7 +59,6 @@ def setup_vaccs_systmone(log_in_as_nurse, schools, dashboard_page, sessions_page
 
 ########################################### CHILD LIST ###########################################
 @pytest.mark.childlist
-@pytest.mark.order(301)
 def test_child_list_file_upload_positive(setup_child_list, import_records_page):
     import_records_page.import_child_records(
         file_paths=test_data_file_paths.CHILD_POSITIVE
@@ -67,7 +66,6 @@ def test_child_list_file_upload_positive(setup_child_list, import_records_page):
 
 
 @pytest.mark.childlist
-@pytest.mark.order(302)
 def test_child_list_file_upload_negative(setup_child_list, import_records_page):
     import_records_page.import_child_records(
         file_paths=test_data_file_paths.CHILD_NEGATIVE
@@ -75,7 +73,6 @@ def test_child_list_file_upload_negative(setup_child_list, import_records_page):
 
 
 @pytest.mark.childlist
-@pytest.mark.order(303)
 def test_child_list_file_structure(setup_child_list, import_records_page):
     import_records_page.import_child_records(
         file_paths=test_data_file_paths.CHILD_INVALID_STRUCTURE
@@ -83,7 +80,6 @@ def test_child_list_file_structure(setup_child_list, import_records_page):
 
 
 @pytest.mark.childlist
-@pytest.mark.order(304)
 def test_child_list_no_record(setup_child_list, import_records_page):
     import_records_page.import_child_records(
         file_paths=test_data_file_paths.CHILD_HEADER_ONLY
@@ -91,7 +87,6 @@ def test_child_list_no_record(setup_child_list, import_records_page):
 
 
 @pytest.mark.childlist
-@pytest.mark.order(305)
 def test_child_list_empty_file(setup_child_list, import_records_page):
     import_records_page.import_child_records(
         file_paths=test_data_file_paths.CHILD_EMPTY_FILE
@@ -100,7 +95,6 @@ def test_child_list_empty_file(setup_child_list, import_records_page):
 
 @pytest.mark.childlist
 @pytest.mark.bug
-@pytest.mark.order(306)
 def test_child_list_space_normalization(setup_child_list, import_records_page):
     import_records_page.import_child_records(
         file_paths=test_data_file_paths.CHILD_MAV_1080, verify_on_children_page=True
@@ -111,7 +105,6 @@ def test_child_list_space_normalization(setup_child_list, import_records_page):
 
 
 @pytest.mark.classlist
-@pytest.mark.order(326)
 def test_class_list_file_upload_positive(
     setup_class_list, schools, import_records_page
 ):
@@ -121,7 +114,6 @@ def test_class_list_file_upload_positive(
 
 
 @pytest.mark.classlist
-@pytest.mark.order(327)
 def test_class_list_file_upload_negative(
     setup_class_list, schools, import_records_page
 ):
@@ -131,7 +123,6 @@ def test_class_list_file_upload_negative(
 
 
 @pytest.mark.classlist
-@pytest.mark.order(328)
 def test_class_list_file_structure(setup_class_list, schools, import_records_page):
     import_records_page.import_class_list_records(
         schools[0], test_data_file_paths.CLASS_INVALID_STRUCTURE
@@ -139,7 +130,6 @@ def test_class_list_file_structure(setup_class_list, schools, import_records_pag
 
 
 @pytest.mark.classlist
-@pytest.mark.order(329)
 def test_class_list_no_record(setup_class_list, schools, import_records_page):
     import_records_page.import_class_list_records(
         schools[0], test_data_file_paths.CLASS_HEADER_ONLY
@@ -147,7 +137,6 @@ def test_class_list_no_record(setup_class_list, schools, import_records_page):
 
 
 @pytest.mark.classlist
-@pytest.mark.order(330)
 def test_class_list_empty_file(setup_class_list, schools, import_records_page):
     import_records_page.import_class_list_records(
         schools[0], test_data_file_paths.CLASS_EMPTY_FILE
@@ -155,7 +144,6 @@ def test_class_list_empty_file(setup_class_list, schools, import_records_page):
 
 
 @pytest.mark.classlist
-@pytest.mark.order(331)
 def test_class_list_year_group(setup_class_list, schools, import_records_page):
     import_records_page.import_class_list_records(
         schools[0],
@@ -166,7 +154,6 @@ def test_class_list_year_group(setup_class_list, schools, import_records_page):
 
 @pytest.mark.classlist
 @pytest.mark.bug
-@pytest.mark.order(332)
 def test_class_list_space_normalization(setup_class_list, schools, import_records_page):
     import_records_page.import_class_list_records(
         schools[0], test_data_file_paths.CLASS_MAV_1080, verify_on_children_page=True
@@ -177,7 +164,6 @@ def test_class_list_space_normalization(setup_class_list, schools, import_record
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(351)
 def test_vaccs_positive_file_upload(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_POSITIVE,
@@ -187,7 +173,6 @@ def test_vaccs_positive_file_upload(setup_vaccs, import_records_page):
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(352)
 def test_vaccs_negative_file_upload(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_NEGATIVE,
@@ -197,7 +182,6 @@ def test_vaccs_negative_file_upload(setup_vaccs, import_records_page):
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(353)
 def test_vaccs_duplicate_record_upload(
     setup_vaccs, dashboard_page, import_records_page
 ):
@@ -214,7 +198,6 @@ def test_vaccs_duplicate_record_upload(
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(354)
 def test_vaccs_file_structure(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_INVALID_STRUCTURE,
@@ -223,7 +206,6 @@ def test_vaccs_file_structure(setup_vaccs, import_records_page):
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(355)
 def test_vaccs_no_record(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_HEADER_ONLY,
@@ -232,7 +214,6 @@ def test_vaccs_no_record(setup_vaccs, import_records_page):
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(356)
 def test_vaccs_empty_file(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_EMPTY_FILE,
@@ -241,7 +222,6 @@ def test_vaccs_empty_file(setup_vaccs, import_records_page):
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(357)
 def test_vaccs_historic_positive_file_upload(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_HIST_POSITIVE,
@@ -250,7 +230,6 @@ def test_vaccs_historic_positive_file_upload(setup_vaccs, import_records_page):
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(358)
 def test_vaccs_historic_negative_file_upload(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_HIST_NEGATIVE,
@@ -260,7 +239,6 @@ def test_vaccs_historic_negative_file_upload(setup_vaccs, import_records_page):
 
 @pytest.mark.vaccinations
 @pytest.mark.bug
-@pytest.mark.order(359)
 def test_vaccs_historic_no_urn_mav_855(
     setup_vaccs, schools, dashboard_page, import_records_page
 ):
@@ -274,7 +252,6 @@ def test_vaccs_historic_no_urn_mav_855(
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(360)
 def test_vaccs_systmone_positive_file_upload(setup_vaccs_systmone, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_SYSTMONE_POSITIVE,
@@ -283,7 +260,6 @@ def test_vaccs_systmone_positive_file_upload(setup_vaccs_systmone, import_record
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(361)
 def test_vaccs_systmone_negative_file_upload(setup_vaccs_systmone, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_SYSTMONE_NEGATIVE,
@@ -292,7 +268,6 @@ def test_vaccs_systmone_negative_file_upload(setup_vaccs_systmone, import_record
 
 
 @pytest.mark.vaccinations
-@pytest.mark.order(362)
 def test_vaccs_systmone_negative_historical_file_upload(
     setup_vaccs_systmone, import_records_page
 ):
@@ -304,7 +279,6 @@ def test_vaccs_systmone_negative_historical_file_upload(
 
 @pytest.mark.vaccinations
 @pytest.mark.bug
-@pytest.mark.order(363)
 def test_vaccs_hpv_space_normalization(setup_vaccs, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_MAV_1080,
@@ -315,7 +289,6 @@ def test_vaccs_hpv_space_normalization(setup_vaccs, import_records_page):
 
 @pytest.mark.vaccinations
 @pytest.mark.bug
-@pytest.mark.order(364)
 def test_vaccs_systmone_space_normalization(setup_vaccs_systmone, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_SYSTMONE_MAV_1080,

--- a/tests/test_log_in.py
+++ b/tests/test_log_in.py
@@ -1,14 +1,14 @@
 from playwright.sync_api import expect
 import pytest
 
+pytestmark = pytest.mark.log_in
+
 
 @pytest.fixture(autouse=True)
 def go_to_log_in_page(start_page):
     start_page.navigate_and_start()
 
 
-@pytest.mark.log_in
-@pytest.mark.order(101)
 @pytest.mark.parametrize("username", ("", "invalid"))
 @pytest.mark.parametrize("password", ("", "invalid"))
 def test_invalid(username, password, log_in_page):
@@ -25,8 +25,6 @@ def users(admin, nurse, superuser) -> dict[str, dict[str, str]]:
     }
 
 
-@pytest.mark.log_in
-@pytest.mark.order(102)
 @pytest.mark.parametrize("role", ("admin", "nurse", "superuser"))
 def test_valid(role, users, organisation, dashboard_page, log_in_page):
     log_in_page.log_in(**users[role])

--- a/tests/test_online_consent_doubles.py
+++ b/tests/test_online_consent_doubles.py
@@ -16,7 +16,6 @@ def start_consent(url, page, start_page):
     start_page.start()
 
 
-@pytest.mark.order(801)
 def test_refused(consent_page, faker, schools):
     consent_page.fill_child_name_details("ROSS", "HAYES", "AKAFirst", "AKALast")
     consent_page.fill_child_dob(10, 8, 2009)
@@ -35,7 +34,6 @@ def test_refused(consent_page, faker, schools):
     """)
 
 
-@pytest.mark.order(802)
 @pytest.mark.parametrize("consent_for", ("both", "menacwy", "td_ipv"))
 @pytest.mark.parametrize("change_school", (False, True))
 @pytest.mark.parametrize("health_question", (False, True))

--- a/tests/test_online_consent_hpv.py
+++ b/tests/test_online_consent_hpv.py
@@ -16,7 +16,6 @@ def start_consent(url, page, start_page):
     start_page.start()
 
 
-@pytest.mark.order(801)
 def test_refused(consent_page, faker, schools):
     consent_page.fill_child_name_details("LIEN", "MAH", "AKAFirst", "AKALast")
     consent_page.fill_child_dob(3, 1, 2011)
@@ -34,7 +33,6 @@ def test_refused(consent_page, faker, schools):
     """)
 
 
-@pytest.mark.order(802)
 @pytest.mark.parametrize("change_school", (False, True))
 @pytest.mark.parametrize("health_question", (False, True))
 def test_given(consent_page, faker, schools, change_school, health_question):

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -1,3 +1,4 @@
+import allure
 import pytest
 
 from mavis.test.mavis_constants import (
@@ -107,19 +108,16 @@ def setup_mav_nnn(
 
 
 @pytest.mark.cohorts
-@pytest.mark.order(501)
 def test_cohort_upload_positive(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_POSITIVE)
 
 
 @pytest.mark.cohorts
-@pytest.mark.order(502)
 def test_cohort_upload_negative(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_NEGATIVE)
 
 
 @pytest.mark.cohorts
-@pytest.mark.order(503)
 def test_cohorts_file_structure(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.upload_cohorts(
         file_paths=test_data_file_paths.COHORTS_INVALID_STRUCTURE
@@ -127,29 +125,24 @@ def test_cohorts_file_structure(setup_cohort_upload_and_reports, programmes_page
 
 
 @pytest.mark.cohorts
-@pytest.mark.order(504)
 def test_cohorts_no_record(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_HEADER_ONLY)
 
 
 @pytest.mark.cohorts
-@pytest.mark.order(505)
 def test_cohorts_empty_file(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_EMPTY_FILE)
 
 
+@allure.issue("MAV-909")
 @pytest.mark.cohorts
 @pytest.mark.bug
-@pytest.mark.order(506)
-def test_cohorts_readd_to_cohort(
-    setup_cohort_upload_and_reports, programmes_page
-):  # MAV-909
+def test_cohorts_readd_to_cohort(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.upload_cohorts(file_paths=test_data_file_paths.COHORTS_MAV_909)
     programmes_page.verify_mav_909()
 
 
 @pytest.mark.rav
-@pytest.mark.order(526)
 def test_rav_triage_positive(setup_record_a_vaccine, schools, sessions_page):
     sessions_page.update_triage_outcome_positive(
         schools[0], test_data_file_paths.COHORTS_FULL_NAME
@@ -157,29 +150,26 @@ def test_rav_triage_positive(setup_record_a_vaccine, schools, sessions_page):
 
 
 @pytest.mark.rav
-@pytest.mark.order(527)
 def test_rav_triage_consent_refused(setup_record_a_vaccine, schools, sessions_page):
     sessions_page.update_triage_outcome_consent_refused(
         schools[0], test_data_file_paths.COHORTS_FULL_NAME
     )
 
 
+@allure.issue("MAVIS-1729")
 @pytest.mark.rav
 @pytest.mark.bug
-@pytest.mark.order(528)
 def test_rav_edit_dose_to_not_given(setup_mavis_1729, programmes_page):
-    programmes_page.edit_dose_to_not_given()  # MAVIS-1729
+    programmes_page.edit_dose_to_not_given()
 
 
 @pytest.mark.rav
 @pytest.mark.bug
-@pytest.mark.order(529)
 def test_rav_verify_excel_mav_854(setup_mav_854, schools, clinics, programmes_page):
     programmes_page.verify_mav_854(schools, clinics)
 
 
 @pytest.mark.rav
-@pytest.mark.order(530)
 @pytest.mark.skip(reason="Test under construction")
 def test_rav_verify_banners(setup_mav_nnn):
     # programmes_page.verify_mav_nnn()
@@ -187,7 +177,6 @@ def test_rav_verify_banners(setup_mav_nnn):
 
 
 @pytest.mark.reports
-@pytest.mark.order(551)
 def test_verify_careplus_report_for_hpv(
     setup_cohort_upload_and_reports, programmes_page
 ):
@@ -195,7 +184,6 @@ def test_verify_careplus_report_for_hpv(
 
 
 @pytest.mark.reports
-@pytest.mark.order(552)
 def test_verify_careplus_report_for_doubles(
     setup_cohort_upload_and_reports, dashboard_page, programmes_page
 ):
@@ -206,13 +194,11 @@ def test_verify_careplus_report_for_doubles(
 
 
 @pytest.mark.reports
-@pytest.mark.order(553)
 def test_verify_csv_report_for_hpv(setup_cohort_upload_and_reports, programmes_page):
     programmes_page.verify_csv_report_format(Programme.HPV)
 
 
 @pytest.mark.reports
-@pytest.mark.order(554)
 def test_verify_csv_report_for_doubles(
     setup_cohort_upload_and_reports, dashboard_page, programmes_page
 ):
@@ -223,7 +209,6 @@ def test_verify_csv_report_for_doubles(
 
 
 @pytest.mark.reports
-@pytest.mark.order(555)
 def test_verify_systmone_report_for_hpv(
     setup_cohort_upload_and_reports, programmes_page
 ):

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -40,6 +40,5 @@ def setup_mav_965(
 
 @pytest.mark.rav
 @pytest.mark.bug
-@pytest.mark.order(9901)
 def test_programmes_rav_prescreening_questions(setup_mav_965, schools, programmes_page):
     programmes_page.verify_mav_965(schools[0])

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -2,6 +2,8 @@ import pytest
 
 from mavis.test.mavis_constants import test_data_file_paths
 
+pytestmark = pytest.mark.school_moves
+
 
 @pytest.fixture
 def setup_tests(log_in_as_nurse, reset_environment):
@@ -68,22 +70,15 @@ def setup_move_to_homeschool_and_unknown(
         sessions_page.delete_all_sessions(schools[2])
 
 
-@pytest.mark.schoolmoves
-@pytest.mark.order(401)
 def test_confirm_and_ignore(setup_move_and_ignore, schools, school_moves_page):
     school_moves_page.confirm_and_ignore_moves(schools)
 
 
-# Add tests for school moves to Homeschool or Unknown school
-@pytest.mark.schoolmoves
-@pytest.mark.order(402)
 @pytest.mark.skip(reason="Test under construction")
 def test_to_homeschool_and_unknown(setup_move_to_homeschool_and_unknown):
     pass
 
 
-@pytest.mark.schoolmoves
-@pytest.mark.order(403)
 def test_download_report(setup_move_and_ignore, dashboard_page, school_moves_page):
     dashboard_page.click_mavis()
     dashboard_page.click_school_moves()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,6 +1,9 @@
+import allure
 import pytest
 
 from mavis.test.mavis_constants import test_data_file_paths
+
+pytestmark = pytest.mark.sessions
 
 
 @pytest.fixture
@@ -50,8 +53,6 @@ def setup_mav_1018(setup_tests, schools, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions(schools[0])
 
 
-@pytest.mark.sessions
-@pytest.mark.order(201)
 def test_lifecycle(setup_tests, schools, dashboard_page, sessions_page):
     sessions_page.schedule_a_valid_session(schools[0])
     dashboard_page.click_mavis()
@@ -62,21 +63,17 @@ def test_lifecycle(setup_tests, schools, dashboard_page, sessions_page):
     sessions_page.delete_all_sessions(schools[0])
 
 
-@pytest.mark.sessions
-@pytest.mark.order(202)
 def test_invalid(setup_tests, schools, sessions_page):
     sessions_page.create_invalid_session(schools[0])
 
 
-@pytest.mark.sessions
+@allure.issue("MAVIS-1822")
 @pytest.mark.bug
-@pytest.mark.order(203)
 def test_verify_attendance_filters(setup_mavis_1822, sessions_page):
-    sessions_page.verify_attendance_filters()  # MAVIS-1822
+    sessions_page.verify_attendance_filters()
 
 
-@pytest.mark.sessions
+@allure.issue("MAV-1018")
 @pytest.mark.bug
-@pytest.mark.order(204)
 def test_verify_search(setup_mav_1018, sessions_page):
-    sessions_page.verify_search()  # MAV-1018
+    sessions_page.verify_search()

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -2,10 +2,10 @@ import pytest
 
 from playwright.sync_api import expect
 
+pytestmark = pytest.mark.smoke
 
-@pytest.mark.smoke
-@pytest.mark.order(1)
-def test_start(start_page, playwright_operations):
+
+def test_visible(start_page, playwright_operations):
     start_page.navigate()
 
     expect(start_page.heading).to_be_visible()

--- a/tests/test_unmatched_consent_responses.py
+++ b/tests/test_unmatched_consent_responses.py
@@ -61,13 +61,11 @@ def go_to_unmatched_consent_responses(log_in_as_nurse, dashboard_page):
     dashboard_page.click_unmatched_consent_responses()
 
 
-@pytest.mark.order(1002)
 @allure.issue("MAVIS-1782")
 def test_archive_record(unmatched_page, child_name):
     unmatched_page.archive_record(*child_name)
 
 
-@pytest.mark.order(1004)
 @allure.issue("MAVIS-1812")
 @pytest.mark.parametrize("child_name", [("CMatch1", "CMatch1")])
 def test_match_record(
@@ -82,7 +80,6 @@ def test_match_record(
     unmatched_page.match_with_record(schools[0], "CMatch1", "CMatch1")
 
 
-@pytest.mark.order(1003)
 @allure.issue("MAVIS-1812")
 @pytest.mark.parametrize("child_name", [("Helena", "Hoyte")])
 @pytest.mark.parametrize("child_date_of_birth", [(20, 8, 2011)])
@@ -93,7 +90,6 @@ def test_create_record_with_nhs_number(unmatched_page, schools, child_name):
     unmatched_page.create_record(schools[0], *child_name)
 
 
-@pytest.mark.order(1005)
 @allure.issue("MAVIS-1781")
 def test_create_record_with_no_nhs_number(unmatched_page, schools, child_name):
     unmatched_page.create_record_with_no_nhs_number(schools[0], *child_name)

--- a/tests/test_vaccines.py
+++ b/tests/test_vaccines.py
@@ -2,9 +2,9 @@ import pytest
 
 from mavis.test.mavis_constants import Vaccine
 
+pytestmark = pytest.mark.vaccines
 
-@pytest.mark.vaccines
-@pytest.mark.order(601)
+
 @pytest.mark.parametrize("vaccine", Vaccine)
 def test_batch_add_change_archive(
     log_in_as_nurse, vaccine, dashboard_page, vaccines_page

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -1,3 +1,4 @@
+import allure
 import pytest
 
 from mavis.test.mavis_constants import test_data_file_paths
@@ -26,7 +27,6 @@ def setup_gillick(log_in_as_nurse, schools, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions(schools[0])
 
 
-@pytest.mark.order(902)
 def test_gillick_competence(setup_gillick, schools, sessions_page):
     sessions_page.set_gillick_competence_for_student(schools[0])
 
@@ -54,10 +54,10 @@ def setup_mavis_1696(log_in_as_nurse, schools, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions(schools[0])
 
 
+@allure.issue("MAVIS-1696")
 @pytest.mark.bug
-@pytest.mark.order(903)
 def test_invalid_consent(setup_mavis_1696, sessions_page):
-    sessions_page.bug_mavis_1696()  # MAVIS-1696
+    sessions_page.bug_mavis_1696()
 
 
 @pytest.fixture
@@ -83,10 +83,10 @@ def setup_mavis_1864(log_in_as_nurse, schools, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions(schools[0])
 
 
+@allure.issue("MAVIS-1864")
 @pytest.mark.bug
-@pytest.mark.order(905)
 def test_parent_provides_consent_twice(setup_mavis_1864, sessions_page):
-    sessions_page.bug_mavis_1864()  # MAVIS-1864
+    sessions_page.bug_mavis_1864()
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def setup_mavis_1818(log_in_as_nurse, schools, dashboard_page, sessions_page):
         sessions_page.delete_all_sessions(schools[0])
 
 
+@allure.issue("MAVIS-1818")
 @pytest.mark.bug
-@pytest.mark.order(906)
 def test_conflicting_consent_with_gillick_consent(setup_mavis_1818, sessions_page):
-    sessions_page.bug_mavis_1818()  # MAVIS-1818
+    sessions_page.bug_mavis_1818()


### PR DESCRIPTION
This removes the specified ordering of the tests and instead allows Pytest to collect the tests in its own order. By having a specific order we can inadvertently introduce dependencies between the tests meaning they can't be run on their own or in parallel.

Depends on #277