### PR TITLE
Run tests in parallel in CI

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -5,127 +5,53 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   test:
-    runs-on: ubuntu-latest
-    env:
-      TZ: "Europe/London"
+    name: Test
+
     strategy:
       matrix:
-        location: ["UK"]
+        device:
+          - Desktop Chrome
+          - Desktop Edge
+          - Desktop Firefox
+          - Desktop Safari
+          - Galaxy S9+
+          - Pixel 7
+          - iPad (gen 7) landscape
+          - iPhone 14
+          - iPhone 15
+
+    permissions: {}
+
+    runs-on: ubuntu-latest
+
+    env:
+      TZ: "Europe/London"
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version-file: .tool-versions
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          playwright install
-          playwright install-deps
-      - name: Test on Chromium
+          pip install -U pip
+          pip install -r requirements.txt
+
+      - name: Install Playwright
+        run: playwright install --with-deps
+
+      - name: Run tests
+        run: pytest --device "${{ matrix.device }}"
         env:
           BASE_URL: ${{ vars.BASE_URL }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
           BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::Chromium"
-          pytest --browser chromium
-          echo "::endgroup::"
-      - name: Test on Chrome
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::Chrome"
-          pytest --browser chromium --browser-channel chrome
-          echo "::endgroup::"
-      - name: Test on Firefox
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::Firefox"
-          pytest --browser firefox
-          echo "::endgroup::"
-      - name: Test on Edge
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::Edge"
-          pytest --browser chromium --browser-channel msedge
-          echo "::endgroup::"
-      - name: Test on iPhone 14
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::iPhone 14"
-          pytest -m mobile --browser webkit --device "iPhone 14"
-          echo "::endgroup::"
-      - name: Test on iPhone 15
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::iPhone 15"
-          pytest -m mobile --browser webkit --device "iPhone 15"
-          echo "::endgroup::"
-      - name: Test on iPad Gen 7
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::iPad Gen 7"
-          pytest -m mobile --browser webkit --device "iPad (gen 7) landscape"
-          echo "::endgroup::"
-      - name: Test on Samsung Galaxy S9+
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::Samsung Galaxy S9+"
-          pytest -m mobile --browser chromium --device "Galaxy S9+"
-          echo "::endgroup::"
-      - name: Test on Google Pixel 7
-        if: always()
-        env:
-          BASE_URL: ${{ vars.BASE_URL }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-        run: |
-          echo "::group::Google Pixel 7"
-          pytest -m mobile --browser chromium --device "Pixel 7"
-          echo "::endgroup::"
-      - name: Upload report
-        if: always()
+
+      - name: Upload Allure results
         uses: actions/upload-artifact@v4
         with:
-          name: allure-reports
-          path: reports
-      - name: Upload screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshots
-          path: screenshots
+          name: ${{ matrix.device }}
+          path: allure-results

--- a/README.md
+++ b/README.md
@@ -63,32 +63,31 @@ $ pytest
 
 #### Browsers and devices
 
-By default, the tests will run using `Chromium` with no particular device,
-however it's possible to run the tests in different browsers and devices.
-Some examples are listed below.
+By default, the tests will run using the `Desktop Chrome` device, however it's
+possible to run the tests in devices. Some examples are listed below.
 
 ##### iPhone 15
 
 ```shell
-$ pytest --browser webkit --device "iPhone 15"
+$ pytest --device "iPhone 15"
 ```
 
 ##### Firefox
 
 ```shell
-$ pytest --browser firefox
+$ pytest --device "Desktop Firefox"
 ```
 
 ##### Google Pixel 7
 
 ```shell
-$ pytest --browser chromium --device "Pixel 7"
+$ pytest --device "Pixel 7"
 ```
 
 ##### Microsoft Edge
 
 ```shell
-$ pytest --browser chromium --browser-channel msedge
+$ pytest --device "Desktop Edge"
 ```
 
 #### Headless mode

--- a/mavis/test/__init__.py
+++ b/mavis/test/__init__.py
@@ -1,10 +1,15 @@
-from .hooks import pytest_runtest_logreport, pytest_sessionfinish, pytest_sessionstart
+from .hooks import (
+    pytest_runtest_logreport,
+    pytest_sessionfinish,
+    pytest_sessionstart,
+)
 from .fixtures import (
     admin,
     archive_consent_response_page,
     base_url,
     basic_auth,
     browser_context_args,
+    browser_type,
     children_page,
     clinics,
     consent_page,
@@ -46,6 +51,7 @@ __all__ = [
     "base_url",
     "basic_auth",
     "browser_context_args",
+    "browser_type",
     "children_page",
     "clinics",
     "consent_page",

--- a/mavis/test/fixtures/__init__.py
+++ b/mavis/test/fixtures/__init__.py
@@ -35,6 +35,7 @@ from .playwright import (
     base_url,
     basic_auth,
     browser_context_args,
+    browser_type,
     playwright_operations,
     screenshots_path,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "base_url",
     "basic_auth",
     "browser_context_args",
+    "browser_type",
     "children_page",
     "clinics",
     "consent_page",

--- a/mavis/test/fixtures/playwright.py
+++ b/mavis/test/fixtures/playwright.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import os
 from typing import Optional
 
+from playwright.sync_api import BrowserType, Playwright
 import pytest
 
 from ..playwright_ops import PlaywrightOperations
@@ -32,6 +33,13 @@ def screenshots_path(pytestconfig) -> Optional[Path]:
     path = Path("screenshots") / session_name
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+@pytest.fixture(scope="session")
+def browser_type(playwright: Playwright, device: Optional[str]) -> BrowserType:
+    device = device or "Desktop Chrome"
+    browser_name = playwright.devices[device]["default_browser_type"]
+    return getattr(playwright, browser_name)
 
 
 @pytest.fixture(scope="session")

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,6 @@ markers =
   consentworkflow
   e2e
   log_in
-  mobile
   order
   rav
   regression

--- a/tests/test_online_consent_doubles.py
+++ b/tests/test_online_consent_doubles.py
@@ -2,7 +2,7 @@ import pytest
 
 from mavis.test.mavis_constants import Programme
 
-pytestmark = [pytest.mark.consent, pytest.mark.mobile]
+pytestmark = pytest.mark.consent
 
 
 @pytest.fixture

--- a/tests/test_online_consent_hpv.py
+++ b/tests/test_online_consent_hpv.py
@@ -2,7 +2,7 @@ import pytest
 
 from mavis.test.mavis_constants import Programme
 
-pytestmark = [pytest.mark.consent, pytest.mark.mobile]
+pytestmark = pytest.mark.consent
 
 
 @pytest.fixture


### PR DESCRIPTION
This configures the workflow to run the tests for each device in parallel. This is possible since they are no longer using the same organisation, and cuts down the total time for this run from about 4 hours to 15 minutes.