### PR TITLE
Perf gh pages

### DIFF
--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -168,7 +168,6 @@ jobs:
           publish_dir: nurse-output/report
           destination_dir: JMeter/report-${{ env.timestamp }}
           keep_files: true
-          enable_jekyll: true
 
       - name: Set Job Summary
         run: |


### PR DESCRIPTION
Add steps to the workflow to commit the results to gh-pages branch where the pages are built and deployed automatically. The url is then published on the original pipeline in the summary so the viewer can go from the workflow direct to the applicable test result. 