### PR TITLE
Specify code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NHSDigital/mavis


### PR DESCRIPTION
This ensures that when raising a PR, the code owners will be automatically asked for a review.