### PR TITLE
Infinite loops

### DIFF
--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -143,7 +143,8 @@ jobs:
               -JThreads=${{inputs.threads}} \
               -JRampUp=${{inputs.ramp_up}} \
               -JVaccinationLoop=${{inputs.vaccination_loop}} \
-              -JInputFile="cohortnew.csv"
+              -JInputFile="cohortnew.csv" \
+              -JLoops=-1
 
       - name: Upload consent journey JMeter output
         if: inputs.runDataPrep == true


### PR DESCRIPTION
Add an 'infinite loops' parameter to nurse journey. This will ensure the test is limited by the duration not the loops (and thus permit soak testing).