### PR TITLE
Reduce number of parallel test jobs

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -19,8 +19,8 @@ jobs:
           - Galaxy S9+
           - Pixel 7
           - iPad (gen 7) landscape
-          - iPhone 14
           - iPhone 15
+      max-parallel: 2
 
     permissions: {}
 


### PR DESCRIPTION
With the tests themselves running in parallel, running the devices in parallal can lead to high numbers of failures due to timeouts or incorrect database state. I don't think this job needs to run as fast as locally so we can afford to slow down the number of parallel jobs.