### PR TITLE
remove children page from import_records and sessions page

### DIFF
--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -27,8 +27,8 @@ def archive_consent_response_page(page):
 
 
 @pytest.fixture
-def children_page(page, dashboard_page):
-    return ChildrenPage(page, dashboard_page)
+def children_page(page, dashboard_page, test_data):
+    return ChildrenPage(page, dashboard_page, test_data)
 
 
 @pytest.fixture
@@ -57,8 +57,8 @@ def download_school_moves_page(page):
 
 
 @pytest.fixture
-def import_records_page(test_data, page, children_page):
-    return ImportRecordsPage(test_data, page, children_page)
+def import_records_page(test_data, page):
+    return ImportRecordsPage(test_data, page)
 
 
 @pytest.fixture
@@ -91,7 +91,6 @@ def sessions_page(
     test_data,
     page,
     dashboard_page,
-    children_page,
     import_records_page,
     consent_page,
 ):
@@ -99,7 +98,6 @@ def sessions_page(
         test_data,
         page,
         dashboard_page,
-        children_page,
         import_records_page,
         consent_page,
     )

--- a/mavis/test/models/children.py
+++ b/mavis/test/models/children.py
@@ -1,5 +1,7 @@
+from mavis.test.data import TestData
 from mavis.test.mavis_constants import Vaccine
 from mavis.test.onboarding import School
+from ..mavis_constants import mavis_file_types
 from .dashboard import DashboardPage
 
 from playwright.sync_api import Page, expect
@@ -8,8 +10,9 @@ from ..step import step
 
 
 class ChildrenPage:
-    def __init__(self, page: Page, dashboard_page: DashboardPage):
+    def __init__(self, page: Page, dashboard_page: DashboardPage, test_data: TestData):
         self.page = page
+        self.test_data = test_data
         self.dashboard_page = dashboard_page
 
         self.children_heading = self.page.get_by_role(
@@ -52,11 +55,16 @@ class ChildrenPage:
         self.page.wait_for_timeout(1000)
         expect(self.one_child_found_heading).to_be_visible()
 
-    def verify_child_has_been_uploaded(self, child_list) -> None:
-        if len(child_list) >= 1:
+    def verify_list_has_been_uploaded(
+        self, list: str, file_type: mavis_file_types = mavis_file_types.CHILD_LIST
+    ) -> None:
+        _child_name_list = self.test_data.create_child_list_from_file(
+            file_path=list, file_type=file_type
+        )
+        if _child_name_list:
             self.dashboard_page.click_mavis()
             self.dashboard_page.click_children()
-            for _child_name in child_list:
+            for _child_name in _child_name_list:
                 self.search_for_a_child(_child_name)
 
     @step("Search for child {1}")

--- a/mavis/test/models/import_records.py
+++ b/mavis/test/models/import_records.py
@@ -9,19 +9,15 @@ from ..data import TestData
 from ..mavis_constants import mavis_file_types
 from ..wrappers import format_datetime_for_upload_link
 
-from .children import ChildrenPage
-
 
 class ImportRecordsPage:
     def __init__(
         self,
         test_data: TestData,
         page: Page,
-        children_page: ChildrenPage,
     ):
         self.test_data = test_data
         self.page = page
-        self.children_page = children_page
 
         self.alert_success = self.page.get_by_text("Import processing started")
         self.completed_tag = self.page.get_by_role("strong").get_by_text("Completed")
@@ -96,28 +92,21 @@ class ImportRecordsPage:
         else:
             expect(tag).to_be_visible()
 
-    def import_child_records(
-        self, file_paths: str, verify_on_children_page: bool = False
-    ):
+    def import_child_records(self, file_paths: str):
         _input_file_path, _output_file_path = self.test_data.get_file_paths(
             file_paths=file_paths
         )
         self.click_import_records()
         self.select_child_records()
         self.click_continue()
-        self._upload_and_verify_output(_input_file_path, _output_file_path)
-        if verify_on_children_page:
-            _cl = self.test_data.create_child_list_from_file(
-                file_path=_input_file_path, file_type=mavis_file_types.CHILD_LIST
-            )
-            self.children_page.verify_child_has_been_uploaded(child_list=_cl)
+        self.upload_and_verify_output(_input_file_path, _output_file_path)
+        return _input_file_path, _output_file_path
 
     def import_class_list_records(
         self,
         location: str,
         file_paths: str,
         year_groups: Optional[list[int]] = None,
-        verify_on_children_page: bool = False,
     ):
         if year_groups is None:
             year_groups = [8, 9, 10, 11]
@@ -136,13 +125,8 @@ class ImportRecordsPage:
 
         self.click_continue()
         self._select_year_groups(*year_groups)
-        self._upload_and_verify_output(_input_file_path, _output_file_path)
-
-        if verify_on_children_page:
-            _cl = self.test_data.create_child_list_from_file(
-                file_path=_input_file_path, file_type=mavis_file_types.CHILD_LIST
-            )
-            self.children_page.verify_child_has_been_uploaded(child_list=_cl)
+        self.upload_and_verify_output(_input_file_path, _output_file_path)
+        return _input_file_path, _output_file_path
 
     def import_class_list_records_from_school_session(self, file_paths: str):
         _input_file_path, _output_file_path = self.test_data.get_file_paths(
@@ -150,13 +134,13 @@ class ImportRecordsPage:
         )
         self.click_import_class_lists()
         self._select_year_groups(8, 9, 10, 11)
-        self._upload_and_verify_output(_input_file_path, _output_file_path)
+        self.upload_and_verify_output(_input_file_path, _output_file_path)
+        return _input_file_path, _output_file_path
 
     def import_vaccination_records(
         self,
         file_paths: str,
         file_type: mavis_file_types = mavis_file_types.VACCS_MAVIS,
-        verify_on_children_page: bool = False,
         session_id: Optional[str] = None,
     ):
         _input_file_path, _output_file_path = self.test_data.get_file_paths(
@@ -165,15 +149,11 @@ class ImportRecordsPage:
         self.click_import_records()
         self.select_vaccination_records()
         self.click_continue()
-        self._upload_and_verify_output(_input_file_path, _output_file_path)
+        self.upload_and_verify_output(_input_file_path, _output_file_path)
 
-        if verify_on_children_page:
-            _cl = self.test_data.create_child_list_from_file(
-                file_path=_input_file_path, file_type=file_type
-            )
-            self.children_page.verify_child_has_been_uploaded(child_list=_cl)
+        return _input_file_path, _output_file_path
 
-    def _upload_and_verify_output(self, _input_file_path, _output_file_path):
+    def upload_and_verify_output(self, _input_file_path, _output_file_path):
         self.set_input_file(_input_file_path)
         self.record_upload_time()
         self.click_continue()

--- a/mavis/test/models/sessions.py
+++ b/mavis/test/models/sessions.py
@@ -9,14 +9,13 @@ from playwright.sync_api import Page, expect
 
 from ..data import TestData
 from ..onboarding import Clinic
-from ..mavis_constants import mavis_file_types, PrescreeningQuestion, Programme
+from ..mavis_constants import PrescreeningQuestion, Programme
 
 from ..wrappers import (
     get_current_datetime,
     get_offset_date,
 )
 
-from .children import ChildrenPage
 from .consent import ConsentPage
 from .dashboard import DashboardPage
 from .import_records import ImportRecordsPage
@@ -38,7 +37,6 @@ class SessionsPage:
         test_data: TestData,
         page: Page,
         dashboard_page: DashboardPage,
-        children_page: ChildrenPage,
         import_records_page: ImportRecordsPage,
         consent_page: ConsentPage,
     ):
@@ -46,7 +44,6 @@ class SessionsPage:
         self.page = page
         self.dashboard_page = dashboard_page
         self.consent_page = consent_page
-        self.children_page = children_page
         self.import_records_page = import_records_page
 
         self.today_tab_link = self.page.get_by_role("link", name="Today")
@@ -579,7 +576,6 @@ class SessionsPage:
     def upload_class_list(
         self,
         file_paths: str,
-        verify_on_children: bool = False,
     ):
         _input_file_path, _output_file_path = self.test_data.get_file_paths(
             file_paths=file_paths
@@ -595,11 +591,6 @@ class SessionsPage:
             self.import_records_page.wait_for_processed()
 
         self.import_records_page.verify_upload_output(file_path=_output_file_path)
-        if verify_on_children:
-            _cl = self.test_data.create_child_list_from_file(
-                file_path=_input_file_path, file_type=mavis_file_types.CLASS_LIST
-            )
-            self.children_page.verify_child_has_been_uploaded(child_list=_cl)
 
     def set_gillick_competence_for_student(self, session: str):
         self.click_today()

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -95,10 +95,13 @@ def test_child_list_empty_file(setup_child_list, import_records_page):
 
 @pytest.mark.childlist
 @pytest.mark.bug
-def test_child_list_space_normalization(setup_child_list, import_records_page):
-    import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_MAV_1080, verify_on_children_page=True
+def test_child_list_space_normalization(
+    setup_child_list, import_records_page, children_page
+):
+    input_file, _ = import_records_page.import_child_records(
+        file_paths=test_data_file_paths.CHILD_MAV_1080
     )
+    children_page.verify_list_has_been_uploaded(input_file)
 
 
 ########################################### CLASS LIST ###########################################
@@ -154,12 +157,14 @@ def test_class_list_year_group(setup_class_list, schools, import_records_page):
 
 @pytest.mark.classlist
 @pytest.mark.bug
-def test_class_list_space_normalization(setup_class_list, schools, import_records_page):
-    import_records_page.import_class_list_records(
+def test_class_list_space_normalization(
+    setup_class_list, schools, import_records_page, children_page
+):
+    input_file, _ = import_records_page.import_class_list_records(
         str(schools[0]),
         test_data_file_paths.CLASS_MAV_1080,
-        verify_on_children_page=True,
     )
+    children_page.verify_list_has_been_uploaded(input_file)
 
 
 ########################################### VACCINATIONS ###########################################
@@ -285,11 +290,14 @@ def test_vaccs_systmone_negative_historical_file_upload(
 
 @pytest.mark.vaccinations
 @pytest.mark.bug
-def test_vaccs_hpv_space_normalization(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
+def test_vaccs_hpv_space_normalization(setup_vaccs, import_records_page, children_page):
+    input_file, _ = import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_MAV_1080,
-        verify_on_children_page=True,
         file_type=mavis_file_types.VACCS_MAVIS,
+    )
+    children_page.verify_list_has_been_uploaded(
+        input_file,
+        mavis_file_types.VACCS_MAVIS,
     )
 
 
@@ -298,6 +306,5 @@ def test_vaccs_hpv_space_normalization(setup_vaccs, import_records_page):
 def test_vaccs_systmone_space_normalization(setup_vaccs_systmone, import_records_page):
     import_records_page.import_vaccination_records(
         file_paths=test_data_file_paths.VACCS_SYSTMONE_MAV_1080,
-        verify_on_children_page=False,
         file_type=mavis_file_types.VACCS_SYSTMONE,
     )


### PR DESCRIPTION
This PR removes the need for the ImportRecords page and the Sessions page to rely on the Children page