### PR TITLE
Update tests following patient session redesign

### DIFF
--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from playwright.sync_api import Page, expect
 
 from ..data import TestData
-from ..models import School, Vaccine
+from ..models import School
 from ..step import step
 
 
@@ -40,6 +40,11 @@ class ChildrenPage:
         )
         self.continue_button = self.page.get_by_role("button", name="Continue")
 
+        vaccinations_card = page.locator("section").filter(
+            has=page.get_by_role("heading", name="Vaccinations")
+        )
+        self.vaccinations_card_row = vaccinations_card.get_by_role("row")
+
     def verify_headers(self):
         expect(self.children_heading).to_be_visible()
         for header in self.children_table_headers:
@@ -71,17 +76,11 @@ class ChildrenPage:
     def click_record_for_child(self, child_name: str) -> None:
         self.page.get_by_role("link", name=child_name).click()
 
-    @step("Click on {1} vaccination details for school {2}")
-    def click_vaccination_details_for_school(
-        self, vaccine: Vaccine, school: School
-    ) -> None:
-        self.page.get_by_role("row").filter(has_text=str(school)).get_by_role(
-            "link", name=str(vaccine), exact=False
-        ).click()
-
     @step("Click on {1} vaccination details")
-    def click_vaccination_details(self, vaccine: Vaccine) -> None:
-        self.page.get_by_role("link", name=str(vaccine), exact=False).click()
+    def click_vaccination_details(self, school: School) -> None:
+        self.vaccinations_card_row.filter(has_text=str(school)).get_by_role(
+            "link"
+        ).click()
 
     @step("Click on Child record")
     def click_child_record(self) -> None:

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -99,8 +99,8 @@ class SessionsPage:
             "button", name="Mark as invalid"
         )
         self.notes_textbox = self.page.get_by_role("textbox", name="Notes")
-        self.get_consent_response_button = self.page.get_by_role(
-            "button", name="Get consent response"
+        self.get_verbal_consent_button = self.page.get_by_role(
+            "button", name="Get verbal consent"
         )
         self.update_results_button = self.page.get_by_role(
             "button", name="Update results"
@@ -311,9 +311,9 @@ class SessionsPage:
     def fill_notes(self, notes: str):
         self.notes_textbox.fill(notes)
 
-    @step("Click on Get consent response")
-    def click_get_consent_response(self):
-        self.get_consent_response_button.click()
+    @step("Click on Get verbal consent")
+    def click_get_verbal_consent(self):
+        self.get_verbal_consent_button.click()
 
     def navigate_to_todays_sessions(self, location: str):
         self.click_today()
@@ -328,7 +328,7 @@ class SessionsPage:
     def navigate_to_consent_response(self, child: str, programme: Programme):
         self.click_child(child)
         self.click_programme_tab(programme)
-        self.click_get_consent_response()
+        self.click_get_verbal_consent()
 
     def navigate_to_update_triage_outcome(self, child: str, programme: Programme):
         self.click_child(child)

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -529,9 +529,7 @@ class SessionsPage:
 
         self.click_back_to_child()
         self.expect_main_to_contain_text("Consent refusedInvalid")
-        self.expect_main_to_contain_text(
-            "No-one responded to our requests for consent."
-        )
+        self.expect_main_to_contain_text("No requests have been sent.")
 
     def verify_scheduled_date(self, message: str):
         self.expect_main_to_contain_text(message)

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -2,7 +2,7 @@ import allure
 import pytest
 
 from mavis.test.data import ClassFileMapping, CohortsFileMapping, VaccsFileMapping
-from mavis.test.models import Programme, Vaccine
+from mavis.test.models import Programme
 
 pytestmark = pytest.mark.children
 
@@ -99,7 +99,7 @@ def test_details_mav_853(setup_mav_853, children_page, schools):
     children_page.expect_text_in_main("Vaccinated with Gardasil 9")
     # Verify vaccination record
     children_page.click_child_record()
-    children_page.click_vaccination_details_for_school(Vaccine.GARDASIL_9, schools[0])
+    children_page.click_vaccination_details(schools[0])
     children_page.expect_text_in_main("OutcomeVaccinated")
 
 

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -1,7 +1,6 @@
 import pytest
 
 from mavis.test.data import ClassFileMapping, ChildFileMapping, VaccsFileMapping
-from mavis.test.models import Vaccine
 
 
 @pytest.fixture
@@ -224,7 +223,7 @@ def test_vaccs_historic_no_urn_mav_855(
     dashboard_page.click_children()
     children_page.search_for_a_child(mav_855_child)
     children_page.click_record_for_child(mav_855_child)
-    children_page.click_vaccination_details(Vaccine.GARDASIL_9)
+    children_page.click_vaccination_details(schools[0])
     children_page.expect_text_in_main(str(schools[0]))
 
 

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -262,7 +262,7 @@ def test_rav_verify_excel_mav_854(
     children_page.search_for_a_child(mav_854_child)
     children_page.click_record_for_child(mav_854_child)
     sessions_page.click_session("Community clinics", Programme.HPV)
-    sessions_page.click_get_consent_response()
+    sessions_page.click_get_verbal_consent()
     consent_page.parent_1_verbal_positive(change_phone=False)
     sessions_page.register_child_as_attending(child_name=mav_854_child)
     sessions_page.record_vaccs_for_child(

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -58,17 +58,17 @@ def test_programmes_rav_pre_screening_questions(
     sessions_page.click_consent_tab()
     sessions_page.search_child(child_name=mav_965_child)
     sessions_page.click_programme_tab(Programme.HPV)
-    sessions_page.click_get_consent_response()
+    sessions_page.click_get_verbal_consent()
     consent_page.parent_1_verbal_positive(change_phone=False)
     sessions_page.search_child(child_name=mav_965_child)
     sessions_page.click_programme_tab(Programme.MENACWY)
-    sessions_page.click_get_consent_response()
+    sessions_page.click_get_verbal_consent()
     consent_page.parent_1_verbal_positive(
         change_phone=False, programme=Programme.MENACWY
     )
     sessions_page.search_child(child_name=mav_965_child)
     sessions_page.click_programme_tab(Programme.TD_IPV)
-    sessions_page.click_get_consent_response()
+    sessions_page.click_get_verbal_consent()
     consent_page.parent_1_verbal_positive(
         change_phone=False, programme=Programme.TD_IPV
     )

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -193,9 +193,9 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.select_consent_given()
     sessions_page.click_child(conflicting_gillick_consent_child)
     sessions_page.click_programme_tab(Programme.HPV)
-    sessions_page.expect_main_to_contain_text("Ready for nurse")
+    sessions_page.expect_main_to_contain_text("HPV: Safe to vaccinate")
     sessions_page.expect_main_to_contain_text(
-        f"NURSE, Nurse decided that {conflicting_gillick_consent_child} is ready for the nurse."
+        f"NURSE, Nurse decided that {conflicting_gillick_consent_child} is safe to vaccinate."
     )
     sessions_page.expect_main_to_contain_text("Consent given")
     sessions_page.click_activity_log()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -184,8 +184,8 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.add_gillick_competence(
         is_competent=True, competence_details="Gillick competent"
     )
-    sessions_page.expect_main_to_contain_text("Triaged decision: Safe to vaccinate")
-    sessions_page.click_get_consent_response()
+    sessions_page.expect_main_to_contain_text("HPV: Safe to vaccinate")
+    sessions_page.click_get_verbal_consent()
     consent_page.child_consent_verbal_positive()
     sessions_page.expect_main_to_contain_text(
         f"Consent recorded for {conflicting_gillick_consent_child}"


### PR DESCRIPTION
In https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3169 the design of the patient session page has been changed, mostly moving various sections around but no change to the actual information shown.

[Jira Issue - MAV-1171](https://nhsd-jira.digital.nhs.uk/browse/MAV-1171)