### PR TITLE
Remove import records from pages

### DIFF
--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -72,8 +72,8 @@ def match_consent_response_page(page):
 
 
 @pytest.fixture
-def programmes_page(page, test_data, import_records_page):
-    return ProgrammesPage(page, test_data, import_records_page)
+def programmes_page(page, test_data):
+    return ProgrammesPage(page, test_data)
 
 
 @pytest.fixture
@@ -91,14 +91,12 @@ def sessions_page(
     test_data,
     page,
     dashboard_page,
-    import_records_page,
     consent_page,
 ):
     return SessionsPage(
         test_data,
         page,
         dashboard_page,
-        import_records_page,
         consent_page,
     )
 

--- a/mavis/test/models/import_records.py
+++ b/mavis/test/models/import_records.py
@@ -6,7 +6,6 @@ from ..step import step
 from playwright.sync_api import Page, expect
 
 from ..data import TestData
-from ..mavis_constants import mavis_file_types
 from ..wrappers import format_datetime_for_upload_link
 
 
@@ -92,28 +91,19 @@ class ImportRecordsPage:
         else:
             expect(tag).to_be_visible()
 
-    def import_child_records(self, file_paths: str):
-        _input_file_path, _output_file_path = self.test_data.get_file_paths(
-            file_paths=file_paths
-        )
+    def navigate_to_child_record_import(self):
         self.click_import_records()
         self.select_child_records()
         self.click_continue()
-        self.upload_and_verify_output(_input_file_path, _output_file_path)
-        return _input_file_path, _output_file_path
 
-    def import_class_list_records(
+    def navigate_to_class_list_record_import(
         self,
         location: str,
-        file_paths: str,
         year_groups: Optional[list[int]] = None,
     ):
         if year_groups is None:
             year_groups = [8, 9, 10, 11]
 
-        _input_file_path, _output_file_path = self.test_data.get_file_paths(
-            file_paths=file_paths
-        )
         self.click_import_records()
         self.select_class_list_records()
         self.click_continue()
@@ -125,17 +115,10 @@ class ImportRecordsPage:
 
         self.click_continue()
         self._select_year_groups(*year_groups)
-        self.upload_and_verify_output(_input_file_path, _output_file_path)
-        return _input_file_path, _output_file_path
 
-    def import_class_list_records_from_school_session(self, file_paths: str):
-        _input_file_path, _output_file_path = self.test_data.get_file_paths(
-            file_paths=file_paths
-        )
+    def navigate_to_class_list_import(self):
         self.click_import_class_lists()
         self._select_year_groups(8, 9, 10, 11)
-        self.upload_and_verify_output(_input_file_path, _output_file_path)
-        return _input_file_path, _output_file_path
 
     def navigate_to_vaccination_records_import(self):
         self.click_import_records()

--- a/mavis/test/models/import_records.py
+++ b/mavis/test/models/import_records.py
@@ -137,23 +137,17 @@ class ImportRecordsPage:
         self.upload_and_verify_output(_input_file_path, _output_file_path)
         return _input_file_path, _output_file_path
 
-    def import_vaccination_records(
-        self,
-        file_paths: str,
-        file_type: mavis_file_types = mavis_file_types.VACCS_MAVIS,
-        session_id: Optional[str] = None,
+    def navigate_to_vaccination_records_import(self):
+        self.click_import_records()
+        self.select_vaccination_records()
+        self.click_continue()
+
+    def upload_and_verify_output(
+        self, file_paths: str, session_id: Optional[str] = None
     ):
         _input_file_path, _output_file_path = self.test_data.get_file_paths(
             file_paths=file_paths, session_id=session_id
         )
-        self.click_import_records()
-        self.select_vaccination_records()
-        self.click_continue()
-        self.upload_and_verify_output(_input_file_path, _output_file_path)
-
-        return _input_file_path, _output_file_path
-
-    def upload_and_verify_output(self, _input_file_path, _output_file_path):
         self.set_input_file(_input_file_path)
         self.record_upload_time()
         self.click_continue()
@@ -163,6 +157,7 @@ class ImportRecordsPage:
             self.wait_for_processed()
 
         self.verify_upload_output(file_path=_output_file_path)
+        return _input_file_path, _output_file_path
 
     def record_upload_time(self):
         self.upload_time = datetime.now()

--- a/mavis/test/models/programmes.py
+++ b/mavis/test/models/programmes.py
@@ -1,6 +1,5 @@
 import pandas as pd
 
-from mavis.test.models.import_records import ImportRecordsPage
 
 from ..data import TestData
 from ..wrappers import get_current_datetime
@@ -14,13 +13,10 @@ from playwright.sync_api import Page, expect
 
 
 class ProgrammesPage:
-    def __init__(
-        self, page: Page, test_data: TestData, import_records_page: ImportRecordsPage
-    ):
+    def __init__(self, page: Page, test_data: TestData):
         self.test_data = test_data
 
         self.page = page
-        self.import_records_page = import_records_page
 
         self.programme_links = {
             programme: page.get_by_role("link", name=programme)
@@ -35,7 +31,6 @@ class ProgrammesPage:
 
         self.import_child_records_link = page.get_by_text("Import child records")
 
-        self.file_input = page.locator('input[type="file"]')
         self.continue_button = page.get_by_role("button", name="Continue")
         self.edit_vaccination_record_button = page.get_by_role(
             "button", name="Edit vaccination record"
@@ -89,33 +84,10 @@ class ProgrammesPage:
     def click_continue(self):
         self.continue_button.click()
 
-    @step("Set input file to {1}")
-    def choose_file_child_records(self, file_path: str):
-        self.file_input.set_input_files(file_path)
-
     @step("Click on DOSE2, Dose2")
     def click_dose2_child(self):
         self.dose2_child_link.click()
 
-    @step("Upload cohort {1}")
-    def upload_cohorts(self, file_paths: str, wait_long: bool = False):
-        _input_file_path, _output_file_path = self.test_data.get_file_paths(
-            file_paths=file_paths
-        )
-        self.click_programme(Programme.HPV)
-        self.click_cohorts()
-        self.click_import_child_records()
-        self.choose_file_child_records(_input_file_path)
-        self.import_records_page.record_upload_time()
-        self.import_records_page.click_continue()
-
-        if self.import_records_page.is_processing_in_background():
-            self.import_records_page.click_uploaded_file_datetime()
-            self.import_records_page.wait_for_processed()
-
-        self.import_records_page.verify_upload_output(file_path=_output_file_path)
-
-    @step("Navigate to cohort import for programme {1}")
     def navigate_to_cohort_import(self, programme: Programme):
         self.click_programme(programme)
         self.click_cohorts()

--- a/mavis/test/models/programmes.py
+++ b/mavis/test/models/programmes.py
@@ -115,6 +115,12 @@ class ProgrammesPage:
 
         self.import_records_page.verify_upload_output(file_path=_output_file_path)
 
+    @step("Navigate to cohort import for programme {1}")
+    def navigate_to_cohort_import(self, programme: Programme):
+        self.click_programme(programme)
+        self.click_cohorts()
+        self.click_import_child_records()
+
     @step("Edit dose to not given")
     def edit_dose_to_not_given(self):
         self.click_programme(Programme.HPV)

--- a/mavis/test/models/sessions.py
+++ b/mavis/test/models/sessions.py
@@ -18,7 +18,6 @@ from ..wrappers import (
 
 from .consent import ConsentPage
 from .dashboard import DashboardPage
-from .import_records import ImportRecordsPage
 
 
 class SessionsPage:
@@ -37,14 +36,12 @@ class SessionsPage:
         test_data: TestData,
         page: Page,
         dashboard_page: DashboardPage,
-        import_records_page: ImportRecordsPage,
         consent_page: ConsentPage,
     ):
         self.test_data = test_data
         self.page = page
         self.dashboard_page = dashboard_page
         self.consent_page = consent_page
-        self.import_records_page = import_records_page
 
         self.today_tab_link = self.page.get_by_role("link", name="Today")
         self.scheduled_tab_link = self.page.get_by_role(
@@ -573,24 +570,9 @@ class SessionsPage:
         self.click_location(location)
         self.__schedule_session(on_date=_invalid_date, expect_error=True)
 
-    def upload_class_list(
-        self,
-        file_paths: str,
-    ):
-        _input_file_path, _output_file_path = self.test_data.get_file_paths(
-            file_paths=file_paths
-        )
+    def navigate_to_class_list_import(self):
         self.click_import_class_list()
         self.select_year_groups(8, 9, 10, 11)
-        self.choose_file_child_records(_input_file_path)
-        self.import_records_page.record_upload_time()
-        self.import_records_page.click_continue()
-
-        if self.import_records_page.is_processing_in_background():
-            self.import_records_page.click_uploaded_file_datetime()
-            self.import_records_page.wait_for_processed()
-
-        self.import_records_page.verify_upload_output(file_path=_output_file_path)
 
     def set_gillick_competence_for_student(self, session: str):
         self.click_today()

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -1,13 +1,15 @@
 import allure
 import pytest
 
-from mavis.test.mavis_constants import Vaccine, test_data_file_paths
+from mavis.test.mavis_constants import Programme, Vaccine, test_data_file_paths
 
 pytestmark = pytest.mark.children
 
 
 @pytest.fixture
-def setup_children_session(log_in_as_nurse, schools, dashboard_page, sessions_page):
+def setup_children_session(
+    log_in_as_nurse, schools, dashboard_page, sessions_page, import_records_page
+):
     def _setup(class_list_file):
         try:
             dashboard_page.click_sessions()
@@ -15,7 +17,8 @@ def setup_children_session(log_in_as_nurse, schools, dashboard_page, sessions_pa
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_location(schools[0])
-            sessions_page.upload_class_list(class_list_file)
+            sessions_page.navigate_to_class_list_import()
+            import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
             dashboard_page.click_children()
             yield
@@ -49,14 +52,18 @@ def setup_mav_853(
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
-        import_records_page.import_class_list_records_from_school_session(
-            file_paths=test_data_file_paths.CLASS_SESSION_ID
+        import_records_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.CLASS_SESSION_ID
         )
         sessions_page.click_location(schools[0])
         session_id = sessions_page.get_session_id_from_offline_excel()
         dashboard_page.click_mavis()
         dashboard_page.click_programmes()
-        programmes_page.upload_cohorts(test_data_file_paths.COHORTS_MAV_853)
+        programmes_page.navigate_to_cohort_import(Programme.HPV)
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.COHORTS_MAV_853
+        )
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
         import_records_page.navigate_to_vaccination_records_import()

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -1,7 +1,7 @@
 import allure
 import pytest
 
-from mavis.test.mavis_constants import Vaccine, mavis_file_types, test_data_file_paths
+from mavis.test.mavis_constants import Vaccine, test_data_file_paths
 
 pytestmark = pytest.mark.children
 
@@ -59,10 +59,9 @@ def setup_mav_853(
         programmes_page.upload_cohorts(test_data_file_paths.COHORTS_MAV_853)
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
-        import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_MAV_853,
-            file_type=mavis_file_types.VACCS_MAVIS,
-            session_id=session_id,
+        import_records_page.navigate_to_vaccination_records_import()
+        import_records_page.upload_and_verify_output(
+            file_paths=test_data_file_paths.VACCS_MAV_853, session_id=session_id
         )
         dashboard_page.click_mavis()
         dashboard_page.click_children()

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -93,10 +93,13 @@ def test_match(
     programmes_page,
     schools,
     unmatched_consent_responses_page,
+    import_records_page,
 ):
     dashboard_page.click_mavis()
     dashboard_page.click_programmes()
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_UCR_MATCH)
+    programmes_page.navigate_to_cohort_import(Programme.HPV)
+    import_records_page.upload_and_verify_output(test_data_file_paths.COHORTS_UCR_MATCH)
+
     dashboard_page.click_mavis()
     dashboard_page.click_unmatched_consent_responses()
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mavis.test.mavis_constants import test_data_file_paths
+from mavis.test.mavis_constants import Programme, test_data_file_paths
 
 pytestmark = pytest.mark.e2e
 
@@ -24,9 +24,12 @@ def setup_tests(
     log_in_page.log_out()
 
 
-def test_e2e(schools, dashboard_page, programmes_page, sessions_page):
+def test_e2e(
+    schools, dashboard_page, programmes_page, sessions_page, import_records_page
+):
     dashboard_page.click_programmes()
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_E2E_1)
+    programmes_page.navigate_to_cohort_import(Programme.HPV)
+    import_records_page.upload_and_verify_output(test_data_file_paths.COHORTS_E2E_1)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     sessions_page.schedule_a_valid_session(schools[0])

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -4,12 +4,15 @@ from mavis.test.mavis_constants import Vaccine, mavis_file_types, test_data_file
 
 
 @pytest.fixture
-def setup_child_list(log_in_as_nurse, dashboard_page):
+def setup_child_list(log_in_as_nurse, dashboard_page, import_records_page):
     dashboard_page.click_import_records()
+    import_records_page.navigate_to_child_record_import()
 
 
 @pytest.fixture
-def setup_class_list(log_in_as_nurse, schools, dashboard_page, sessions_page):
+def setup_class_list(
+    log_in_as_nurse, schools, dashboard_page, sessions_page, import_records_page
+):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0])
@@ -29,8 +32,9 @@ def setup_vaccs(
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
-        import_records_page.import_class_list_records_from_school_session(
-            file_paths=test_data_file_paths.CLASS_SESSION_ID
+        import_records_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.CLASS_SESSION_ID
         )
         sessions_page.click_location(schools[0])
         session_id = sessions_page.get_session_id_from_offline_excel()
@@ -45,12 +49,15 @@ def setup_vaccs(
 
 
 @pytest.fixture
-def setup_vaccs_systmone(log_in_as_nurse, schools, dashboard_page, sessions_page):
+def setup_vaccs_systmone(
+    log_in_as_nurse, schools, dashboard_page, sessions_page, import_records_page
+):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
+        import_records_page.navigate_to_vaccination_records_import()
         yield
     finally:
         dashboard_page.click_mavis()
@@ -61,37 +68,29 @@ def setup_vaccs_systmone(log_in_as_nurse, schools, dashboard_page, sessions_page
 ########################################### CHILD LIST ###########################################
 @pytest.mark.childlist
 def test_child_list_file_upload_positive(setup_child_list, import_records_page):
-    import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_POSITIVE
-    )
+    import_records_page.upload_and_verify_output(test_data_file_paths.CHILD_POSITIVE)
 
 
 @pytest.mark.childlist
 def test_child_list_file_upload_negative(setup_child_list, import_records_page):
-    import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_NEGATIVE
-    )
+    import_records_page.upload_and_verify_output(test_data_file_paths.CHILD_NEGATIVE)
 
 
 @pytest.mark.childlist
 def test_child_list_file_structure(setup_child_list, import_records_page):
-    import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_INVALID_STRUCTURE
+    import_records_page.upload_and_verify_output(
+        test_data_file_paths.CHILD_INVALID_STRUCTURE
     )
 
 
 @pytest.mark.childlist
 def test_child_list_no_record(setup_child_list, import_records_page):
-    import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_HEADER_ONLY
-    )
+    import_records_page.upload_and_verify_output(test_data_file_paths.CHILD_HEADER_ONLY)
 
 
 @pytest.mark.childlist
 def test_child_list_empty_file(setup_child_list, import_records_page):
-    import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_EMPTY_FILE
-    )
+    import_records_page.upload_and_verify_output(test_data_file_paths.CHILD_EMPTY_FILE)
 
 
 @pytest.mark.childlist
@@ -99,8 +98,8 @@ def test_child_list_empty_file(setup_child_list, import_records_page):
 def test_child_list_space_normalization(
     setup_child_list, import_records_page, children_page, dashboard_page
 ):
-    input_file, _ = import_records_page.import_child_records(
-        file_paths=test_data_file_paths.CHILD_MAV_1080
+    input_file, _ = import_records_page.upload_and_verify_output(
+        test_data_file_paths.CHILD_MAV_1080
     )
     dashboard_page.click_mavis()
     dashboard_page.click_children()
@@ -114,48 +113,42 @@ def test_child_list_space_normalization(
 def test_class_list_file_upload_positive(
     setup_class_list, schools, import_records_page
 ):
-    import_records_page.import_class_list_records(
-        str(schools[0]), test_data_file_paths.CLASS_POSITIVE
-    )
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_POSITIVE)
 
 
 @pytest.mark.classlist
 def test_class_list_file_upload_negative(
     setup_class_list, schools, import_records_page
 ):
-    import_records_page.import_class_list_records(
-        str(schools[0]), test_data_file_paths.CLASS_NEGATIVE
-    )
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_NEGATIVE)
 
 
 @pytest.mark.classlist
 def test_class_list_file_structure(setup_class_list, schools, import_records_page):
-    import_records_page.import_class_list_records(
-        str(schools[0]), test_data_file_paths.CLASS_INVALID_STRUCTURE
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    import_records_page.upload_and_verify_output(
+        test_data_file_paths.CLASS_INVALID_STRUCTURE
     )
 
 
 @pytest.mark.classlist
 def test_class_list_no_record(setup_class_list, schools, import_records_page):
-    import_records_page.import_class_list_records(
-        str(schools[0]), test_data_file_paths.CLASS_HEADER_ONLY
-    )
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_HEADER_ONLY)
 
 
 @pytest.mark.classlist
 def test_class_list_empty_file(setup_class_list, schools, import_records_page):
-    import_records_page.import_class_list_records(
-        str(schools[0]), test_data_file_paths.CLASS_EMPTY_FILE
-    )
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_EMPTY_FILE)
 
 
 @pytest.mark.classlist
 def test_class_list_year_group(setup_class_list, schools, import_records_page):
-    import_records_page.import_class_list_records(
-        str(schools[0]),
-        test_data_file_paths.CLASS_YEAR_GROUP,
-        year_groups=[8],
-    )
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]), [8])
+    import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_YEAR_GROUP)
 
 
 @pytest.mark.classlist
@@ -163,9 +156,9 @@ def test_class_list_year_group(setup_class_list, schools, import_records_page):
 def test_class_list_space_normalization(
     setup_class_list, schools, import_records_page, children_page, dashboard_page
 ):
-    input_file, _ = import_records_page.import_class_list_records(
-        str(schools[0]),
-        test_data_file_paths.CLASS_MAV_1080,
+    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    input_file, _ = import_records_page.upload_and_verify_output(
+        test_data_file_paths.CLASS_MAV_1080
     )
     dashboard_page.click_mavis()
     dashboard_page.click_children()

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -36,6 +36,7 @@ def setup_vaccs(
         session_id = sessions_page.get_session_id_from_offline_excel()
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
+        import_records_page.navigate_to_vaccination_records_import()
         yield session_id
     finally:
         dashboard_page.click_mavis()
@@ -176,19 +177,15 @@ def test_class_list_space_normalization(
 
 @pytest.mark.vaccinations
 def test_vaccs_positive_file_upload(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_POSITIVE,
-        file_type=mavis_file_types.VACCS_MAVIS,
-        session_id=setup_vaccs,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_POSITIVE, session_id=setup_vaccs
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_negative_file_upload(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_NEGATIVE,
-        file_type=mavis_file_types.VACCS_MAVIS,
-        session_id=setup_vaccs,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_NEGATIVE, session_id=setup_vaccs
     )
 
 
@@ -196,55 +193,49 @@ def test_vaccs_negative_file_upload(setup_vaccs, import_records_page):
 def test_vaccs_duplicate_record_upload(
     setup_vaccs, dashboard_page, import_records_page
 ):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_DUP_1,
-        file_type=mavis_file_types.VACCS_MAVIS,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_DUP_1
     )
     dashboard_page.click_mavis()
     dashboard_page.click_import_records()
-    import_records_page.import_vaccination_records(
+    import_records_page.navigate_to_vaccination_records_import()
+    import_records_page.upload_and_verify_output(
         file_paths=test_data_file_paths.VACCS_DUP_2,
-        file_type=mavis_file_types.VACCS_MAVIS,
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_file_structure(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_INVALID_STRUCTURE,
-        file_type=mavis_file_types.VACCS_MAVIS,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_INVALID_STRUCTURE
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_no_record(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_HEADER_ONLY,
-        file_type=mavis_file_types.VACCS_MAVIS,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_HEADER_ONLY
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_empty_file(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_EMPTY_FILE,
-        file_type=mavis_file_types.VACCS_MAVIS,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_EMPTY_FILE
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_historic_positive_file_upload(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_HIST_POSITIVE,
-        file_type=mavis_file_types.VACCS_MAVIS,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_HIST_POSITIVE
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_historic_negative_file_upload(setup_vaccs, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_HIST_NEGATIVE,
-        file_type=mavis_file_types.VACCS_MAVIS,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_HIST_NEGATIVE
     )
 
 
@@ -254,9 +245,8 @@ def test_vaccs_historic_no_urn_mav_855(
     setup_vaccs, schools, dashboard_page, import_records_page, children_page
 ):
     mav_855_child = "MAV_855, MAV_855"
-    import_records_page.import_vaccination_records(
+    import_records_page.upload_and_verify_output(
         file_paths=test_data_file_paths.VACCS_HPV_MAV_855,
-        file_type=mavis_file_types.VACCS_MAVIS,
     )
     dashboard_page.click_mavis()
     dashboard_page.click_children()
@@ -268,17 +258,15 @@ def test_vaccs_historic_no_urn_mav_855(
 
 @pytest.mark.vaccinations
 def test_vaccs_systmone_positive_file_upload(setup_vaccs_systmone, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_SYSTMONE_POSITIVE,
-        file_type=mavis_file_types.VACCS_SYSTMONE,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_POSITIVE
     )
 
 
 @pytest.mark.vaccinations
 def test_vaccs_systmone_negative_file_upload(setup_vaccs_systmone, import_records_page):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_SYSTMONE_NEGATIVE,
-        file_type=mavis_file_types.VACCS_SYSTMONE,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_NEGATIVE
     )
 
 
@@ -286,9 +274,8 @@ def test_vaccs_systmone_negative_file_upload(setup_vaccs_systmone, import_record
 def test_vaccs_systmone_negative_historical_file_upload(
     setup_vaccs_systmone, import_records_page
 ):
-    import_records_page.import_vaccination_records(
-        file_paths=test_data_file_paths.VACCS_SYSTMONE_HIST_NEGATIVE,
-        file_type=mavis_file_types.VACCS_SYSTMONE,
+    import_records_page.upload_and_verify_output(
+        file_paths=test_data_file_paths.VACCS_SYSTMONE_HIST_NEGATIVE
     )
 
 
@@ -297,9 +284,8 @@ def test_vaccs_systmone_negative_historical_file_upload(
 def test_vaccs_hpv_space_normalization(
     setup_vaccs, import_records_page, children_page, dashboard_page
 ):
-    input_file, _ = import_records_page.import_vaccination_records(
+    input_file, _ = import_records_page.upload_and_verify_output(
         file_paths=test_data_file_paths.VACCS_MAV_1080,
-        file_type=mavis_file_types.VACCS_MAVIS,
     )
     dashboard_page.click_mavis()
     dashboard_page.click_children()
@@ -312,7 +298,6 @@ def test_vaccs_hpv_space_normalization(
 @pytest.mark.vaccinations
 @pytest.mark.bug
 def test_vaccs_systmone_space_normalization(setup_vaccs_systmone, import_records_page):
-    import_records_page.import_vaccination_records(
+    import_records_page.upload_and_verify_output(
         file_paths=test_data_file_paths.VACCS_SYSTMONE_MAV_1080,
-        file_type=mavis_file_types.VACCS_SYSTMONE,
     )

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -2,7 +2,6 @@ import allure
 import pytest
 
 from mavis.test.mavis_constants import (
-    mavis_file_types,
     test_data_file_paths,
     Programme,
     Vaccine,
@@ -43,10 +42,9 @@ def setup_mavis_1729(
         session_id = sessions_page.get_session_id_from_offline_excel()
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
-        import_records_page.import_vaccination_records(
-            file_paths=test_data_file_paths.VACCS_HPV_DOSE_TWO,
-            file_type=mavis_file_types.VACCS_MAVIS,
-            session_id=session_id,
+        import_records_page.navigate_to_vaccination_records_import()
+        import_records_page.upload_and_verify_output(
+            file_paths=test_data_file_paths.VACCS_HPV_DOSE_TWO, session_id=session_id
         )
         dashboard_page.click_mavis()
         dashboard_page.click_programmes()

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -10,7 +10,13 @@ from mavis.test.mavis_constants import (
 
 
 @pytest.fixture
-def setup_cohort_upload_and_reports(log_in_as_nurse, dashboard_page):
+def setup_cohort_upload(log_in_as_nurse, dashboard_page, programmes_page):
+    dashboard_page.click_programmes()
+    programmes_page.navigate_to_cohort_import(Programme.HPV)
+
+
+@pytest.fixture
+def setup_reports(log_in_as_nurse, dashboard_page):
     dashboard_page.click_programmes()
 
 
@@ -35,8 +41,9 @@ def setup_mavis_1729(
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
-        import_records_page.import_class_list_records_from_school_session(
-            file_paths=test_data_file_paths.CLASS_SESSION_ID
+        import_records_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.CLASS_SESSION_ID
         )
         sessions_page.click_location(schools[0])
         session_id = sessions_page.get_session_id_from_offline_excel()
@@ -71,9 +78,8 @@ def setup_mav_854(
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
-        import_records_page.import_class_list_records_from_school_session(
-            test_data_file_paths.CLASS_MAV_854
-        )
+        import_records_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_MAV_854)
         sessions_page.click_location(schools[0])
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
@@ -94,8 +100,9 @@ def setup_mav_nnn(
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
-        import_records_page.import_class_list_records_from_school_session(
-            file_paths=test_data_file_paths.CLASS_SINGLE_VACC
+        import_records_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.CLASS_SINGLE_VACC
         )
         sessions_page.click_location(schools[0])
         yield
@@ -106,35 +113,45 @@ def setup_mav_nnn(
 
 
 @pytest.mark.cohorts
-def test_cohort_upload_positive(setup_cohort_upload_and_reports, programmes_page):
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_POSITIVE)
+def test_cohort_upload_positive(setup_cohort_upload, import_records_page):
+    import_records_page.upload_and_verify_output(test_data_file_paths.COHORTS_POSITIVE)
 
 
 @pytest.mark.cohorts
-def test_cohort_upload_negative(setup_cohort_upload_and_reports, programmes_page):
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_NEGATIVE)
+def test_cohort_upload_negative(setup_cohort_upload, import_records_page):
+    import_records_page.upload_and_verify_output(test_data_file_paths.COHORTS_NEGATIVE)
 
 
 @pytest.mark.cohorts
-def test_cohorts_file_structure(setup_cohort_upload_and_reports, programmes_page):
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_INVALID_STRUCTURE)
+def test_cohorts_file_structure(setup_cohort_upload, import_records_page):
+    import_records_page.upload_and_verify_output(
+        test_data_file_paths.COHORTS_INVALID_STRUCTURE
+    )
 
 
 @pytest.mark.cohorts
-def test_cohorts_no_record(setup_cohort_upload_and_reports, programmes_page):
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_HEADER_ONLY)
+def test_cohorts_no_record(setup_cohort_upload, import_records_page):
+    import_records_page.upload_and_verify_output(
+        test_data_file_paths.COHORTS_HEADER_ONLY
+    )
 
 
 @pytest.mark.cohorts
-def test_cohorts_empty_file(setup_cohort_upload_and_reports, programmes_page):
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_EMPTY_FILE)
+def test_cohorts_empty_file(setup_cohort_upload, import_records_page):
+    import_records_page.upload_and_verify_output(
+        test_data_file_paths.COHORTS_EMPTY_FILE
+    )
 
 
 @allure.issue("MAV-909")
 @pytest.mark.cohorts
 @pytest.mark.bug
 def test_cohorts_readd_to_cohort(
-    setup_cohort_upload_and_reports, programmes_page, dashboard_page, children_page
+    setup_cohort_upload,
+    programmes_page,
+    dashboard_page,
+    children_page,
+    import_records_page,
 ):
     """
     Steps to reproduce:
@@ -158,14 +175,15 @@ def test_cohorts_readd_to_cohort(
         Server error page and user cannot bring the child back into the cohort
     """
     mav_909_child = "MAV_909, MAV_909"
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_MAV_909)
+    import_records_page.upload_and_verify_output(test_data_file_paths.COHORTS_MAV_909)
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
     children_page.remove_child_from_cohort(child_name=mav_909_child)
     dashboard_page.click_mavis()
     dashboard_page.click_programmes()
-    programmes_page.upload_cohorts(test_data_file_paths.COHORTS_MAV_909)
+    programmes_page.navigate_to_cohort_import(Programme.HPV)
+    import_records_page.upload_and_verify_output(test_data_file_paths.COHORTS_MAV_909)
     programmes_page.expect_text("1 duplicate record needs review")
     programmes_page.click_review()
     programmes_page.click_use_duplicate()
@@ -218,9 +236,7 @@ def test_rav_verify_banners(setup_mav_nnn):
 
 
 @pytest.mark.reports
-def test_verify_careplus_report_for_hpv(
-    setup_cohort_upload_and_reports, programmes_page
-):
+def test_verify_careplus_report_for_hpv(setup_reports, programmes_page):
     programmes_page.verify_report_format(
         programme=Programme.HPV, report_format=ReportFormat.CAREPLUS
     )
@@ -228,7 +244,7 @@ def test_verify_careplus_report_for_hpv(
 
 @pytest.mark.reports
 def test_verify_careplus_report_for_doubles(
-    setup_cohort_upload_and_reports, dashboard_page, programmes_page
+    setup_reports, dashboard_page, programmes_page
 ):
     programmes_page.verify_report_format(
         programme=Programme.MENACWY, report_format=ReportFormat.CAREPLUS
@@ -241,16 +257,14 @@ def test_verify_careplus_report_for_doubles(
 
 
 @pytest.mark.reports
-def test_verify_csv_report_for_hpv(setup_cohort_upload_and_reports, programmes_page):
+def test_verify_csv_report_for_hpv(setup_reports, programmes_page):
     programmes_page.verify_report_format(
         programme=Programme.HPV, report_format=ReportFormat.CSV
     )
 
 
 @pytest.mark.reports
-def test_verify_csv_report_for_doubles(
-    setup_cohort_upload_and_reports, dashboard_page, programmes_page
-):
+def test_verify_csv_report_for_doubles(setup_reports, dashboard_page, programmes_page):
     programmes_page.verify_report_format(
         programme=Programme.MENACWY, report_format=ReportFormat.CSV
     )
@@ -262,9 +276,7 @@ def test_verify_csv_report_for_doubles(
 
 
 @pytest.mark.reports
-def test_verify_systmone_report_for_hpv(
-    setup_cohort_upload_and_reports, programmes_page
-):
+def test_verify_systmone_report_for_hpv(setup_reports, programmes_page):
     programmes_page.verify_report_format(
         programme=Programme.HPV, report_format=ReportFormat.SYSTMONE
     )

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -19,9 +19,8 @@ def setup_mav_965(
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     sessions_page.schedule_a_valid_session(schools[0], for_today=True)
-    import_records_page.import_class_list_records_from_school_session(
-        file_paths=test_data_file_paths.CLASS_MAV_965
-    )
+    import_records_page.navigate_to_class_list_import()
+    import_records_page.upload_and_verify_output(test_data_file_paths.CLASS_MAV_965)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
 

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -115,21 +115,23 @@ def test_download(
 
 @pytest.fixture
 def setup_to_homeschool_and_unknown(
-    log_in_as_nurse, schools, dashboard_page, sessions_page
+    log_in_as_nurse, schools, dashboard_page, sessions_page, import_records_page
 ):
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0])
         sessions_page.click_location(schools[0])
-        sessions_page.upload_class_list(
-            test_data_file_paths.CLASS_MOVES_UNKNOWN_HOMESCHOOLED,
+        sessions_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.CLASS_MOVES_UNKNOWN_HOMESCHOOLED
         )
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.click_scheduled()
         sessions_page.click_location(schools[1])
-        sessions_page.upload_class_list(
-            test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE,
+        sessions_page.navigate_to_class_list_import()
+        import_records_page.upload_and_verify_output(
+            test_data_file_paths.CLASS_MOVES_CONFIRM_IGNORE
         )
         yield
     finally:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,14 +12,17 @@ def setup_tests(log_in_as_nurse, dashboard_page):
 
 
 @pytest.fixture
-def setup_session_with_file_upload(setup_tests, schools, dashboard_page, sessions_page):
+def setup_session_with_file_upload(
+    setup_tests, schools, dashboard_page, sessions_page, import_records_page
+):
     def _setup(class_list_file):
         try:
             sessions_page.schedule_a_valid_session(schools[0], for_today=True)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_location(schools[0])
-            sessions_page.upload_class_list(class_list_file)
+            sessions_page.navigate_to_class_list_import()
+            import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_today()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.consent
 
 @pytest.fixture
 def setup_session_with_file_upload(
-    log_in_as_nurse, schools, dashboard_page, sessions_page
+    log_in_as_nurse, schools, dashboard_page, sessions_page, import_records_page
 ):
     def _setup(class_list_file):
         try:
@@ -18,7 +18,8 @@ def setup_session_with_file_upload(
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_location(schools[0])
-            sessions_page.upload_class_list(class_list_file)
+            sessions_page.navigate_to_class_list_import()
+            import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             yield


### PR DESCRIPTION
This PR ensures that the Programmes and Sessions pages no longer rely on the ImportRecords page