### PR TITLE
Refactor vaccine pages

### DIFF
--- a/mavis/test/__init__.py
+++ b/mavis/test/__init__.py
@@ -4,7 +4,10 @@ from .hooks import (
     pytest_sessionstart,
 )
 from .fixtures import (
+    add_batch_page,
+    add_vaccine_batch,
     admin,
+    archive_batch_page,
     archive_consent_response_page,
     base_url,
     basic_auth,
@@ -17,6 +20,7 @@ from .fixtures import (
     create_new_record_consent_response_page,
     dashboard_page,
     download_school_moves_page,
+    edit_batch_page,
     get_online_consent_url,
     import_records_page,
     log_in_as_admin,
@@ -45,7 +49,10 @@ from .fixtures import (
 
 
 __all__ = [
+    "add_batch_page",
+    "add_vaccine_batch",
     "admin",
+    "archive_batch_page",
     "archive_consent_response_page",
     "base_url",
     "basic_auth",
@@ -58,6 +65,7 @@ __all__ = [
     "create_new_record_consent_response_page",
     "dashboard_page",
     "download_school_moves_page",
+    "edit_batch_page",
     "get_online_consent_url",
     "import_records_page",
     "log_in_as_admin",

--- a/mavis/test/fixtures/__init__.py
+++ b/mavis/test/fixtures/__init__.py
@@ -1,5 +1,13 @@
-from .helpers import get_online_consent_url, log_in_as_admin, log_in_as_nurse, test_data
+from .helpers import (
+    add_vaccine_batch,
+    get_online_consent_url,
+    log_in_as_admin,
+    log_in_as_nurse,
+    test_data,
+)
 from .pages import (
+    add_batch_page,
+    archive_batch_page,
     archive_consent_response_page,
     children_page,
     consent_page,
@@ -7,6 +15,7 @@ from .pages import (
     create_new_record_consent_response_page,
     dashboard_page,
     download_school_moves_page,
+    edit_batch_page,
     import_records_page,
     log_in_page,
     match_consent_response_page,
@@ -40,7 +49,10 @@ from .playwright import (
 )
 
 __all__ = [
+    "add_vaccine_batch",
+    "add_batch_page",
     "admin",
+    "archive_batch_page",
     "archive_consent_response_page",
     "base_url",
     "basic_auth",
@@ -53,6 +65,7 @@ __all__ = [
     "create_new_record_consent_response_page",
     "dashboard_page",
     "download_school_moves_page",
+    "edit_batch_page",
     "get_online_consent_url",
     "import_records_page",
     "log_in_as_admin",

--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -1,6 +1,22 @@
+from datetime import date, timedelta
+
 import pytest
 
 from ..data import TestData
+from ..models import Vaccine
+
+
+@pytest.fixture
+def add_vaccine_batch(add_batch_page, dashboard_page, vaccines_page):
+    def wrapper(vaccine: Vaccine, batch_name: str = "ABC123"):
+        vaccines_page.navigate()
+        vaccines_page.click_add_batch(vaccine)
+        add_batch_page.fill_name(batch_name)
+        add_batch_page.fill_expiry_date(date.today() + timedelta(days=1))
+        add_batch_page.confirm()
+        return batch_name
+
+    return wrapper
 
 
 @pytest.fixture

--- a/mavis/test/fixtures/pages.py
+++ b/mavis/test/fixtures/pages.py
@@ -1,6 +1,8 @@
 import pytest
 
 from ..pages import (
+    AddBatchPage,
+    ArchiveBatchPage,
     ArchiveConsentResponsePage,
     ChildrenPage,
     ConsentPage,
@@ -8,6 +10,7 @@ from ..pages import (
     CreateNewRecordConsentResponsePage,
     DashboardPage,
     DownloadSchoolMovesPage,
+    EditBatchPage,
     ImportRecordsPage,
     LogInPage,
     MatchConsentResponsePage,
@@ -19,6 +22,16 @@ from ..pages import (
     UnmatchedConsentResponsesPage,
     VaccinesPage,
 )
+
+
+@pytest.fixture
+def add_batch_page(page):
+    return AddBatchPage(page)
+
+
+@pytest.fixture
+def archive_batch_page(page):
+    return ArchiveBatchPage(page)
 
 
 @pytest.fixture
@@ -54,6 +67,11 @@ def dashboard_page(page):
 @pytest.fixture
 def download_school_moves_page(page):
     return DownloadSchoolMovesPage(page)
+
+
+@pytest.fixture
+def edit_batch_page(page):
+    return EditBatchPage(page)
 
 
 @pytest.fixture

--- a/mavis/test/pages/__init__.py
+++ b/mavis/test/pages/__init__.py
@@ -14,10 +14,12 @@ from .consent_responses import (
     MatchConsentResponsePage,
     UnmatchedConsentResponsesPage,
 )
-from .vaccines import VaccinesPage
+from .vaccines import AddBatchPage, ArchiveBatchPage, EditBatchPage, VaccinesPage
 
 
 __all__ = [
+    "AddBatchPage",
+    "ArchiveBatchPage",
     "ArchiveConsentResponsePage",
     "ChildrenPage",
     "ConsentPage",
@@ -25,6 +27,7 @@ __all__ = [
     "CreateNewRecordConsentResponsePage",
     "DashboardPage",
     "DownloadSchoolMovesPage",
+    "EditBatchPage",
     "ImportRecordsPage",
     "LogInPage",
     "MatchConsentResponsePage",

--- a/mavis/test/pages/vaccines.py
+++ b/mavis/test/pages/vaccines.py
@@ -1,95 +1,95 @@
-from playwright.sync_api import Page, expect
+from datetime import date
+
+from playwright.sync_api import Page
 
 from ..models import Vaccine
 from ..step import step
-from ..wrappers import get_current_datetime, get_offset_date
+
+
+class BatchExpiryDateMixin:
+    def __init__(self, page: Page):
+        self.expiry_day_textbox = page.get_by_role("textbox", name="Day")
+        self.expiry_month_textbox = page.get_by_role("textbox", name="Month")
+        self.expiry_year_textbox = page.get_by_role("textbox", name="Year")
+
+    @step("Fill in expiry date with {1}")
+    def fill_expiry_date(self, value: date):
+        self.expiry_day_textbox.fill(str(value.day))
+        self.expiry_month_textbox.fill(str(value.month))
+        self.expiry_year_textbox.fill(str(value.year))
+
+
+class AddBatchPage(BatchExpiryDateMixin):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+        self.page = page
+
+        self.name_textbox = page.get_by_role("textbox", name="Batch")
+        self.confirm_button = page.get_by_role("button", name="Add batch")
+        self.success_alert = page.get_by_role("alert", name="Success").filter(
+            has_text="added"
+        )
+
+        error_alert = page.get_by_role("alert").filter(has_text="There is a problem")
+        self.error_listitem = error_alert.get_by_role("listitem")
+
+    @step("Fill in name with {1}")
+    def fill_name(self, value: str):
+        self.name_textbox.fill(value)
+
+    @step("Confirm add batch")
+    def confirm(self):
+        self.confirm_button.click()
+
+
+class EditBatchPage(BatchExpiryDateMixin):
+    def __init__(self, page: Page):
+        super().__init__(page)
+
+        self.page = page
+
+        self.confirm_button = page.get_by_role("button", name="Save changes")
+        self.success_alert = page.get_by_role("alert", name="Success").filter(
+            has_text="updated"
+        )
+
+    @step("Confirm edit batch")
+    def confirm(self):
+        self.confirm_button.click()
+
+
+class ArchiveBatchPage:
+    def __init__(self, page: Page):
+        self.page = page
+        self.confirm_button = page.get_by_role("button", name="Yes, archive this batch")
+        self.success_alert = page.get_by_role("alert", name="Success").filter(
+            has_text="archived"
+        )
+
+    @step("Click on Archive this batch")
+    def confirm(self):
+        self.confirm_button.click()
 
 
 class VaccinesPage:
     def __init__(self, page: Page):
         self.page = page
 
-        self.batch_textbox = self.page.get_by_role("textbox", name="Batch")
-        self.day_textbox = self.page.get_by_role("textbox", name="Day")
-        self.month_textbox = self.page.get_by_role("textbox", name="Month")
-        self.year_textbox = self.page.get_by_role("textbox", name="Year")
-        self.add_batch_button = self.page.get_by_role("button", name="Add batch")
-        self.save_changes_button = self.page.get_by_role("button", name="Save changes")
-        self.confirm_archive_button = self.page.get_by_role(
-            "button", name="Yes, archive this batch"
-        )
-        self.batch_added_alert = page.get_by_role("alert", name="Success").filter(
-            has_text="added"
-        )
-        self.batch_name_error = (
-            page.locator("div").filter(has_text="There is a problemEnter a").nth(3)
-        )
+    @step("Go to vaccines page")
+    def navigate(self):
+        self.page.goto("/vaccines")
 
-    def _calculate_batch_details(self, vaccine: Vaccine, batch_name: str):
-        self.batch_name = (
-            f"{vaccine.replace(' ', '').replace('-', '')}{get_current_datetime()}"
-            if batch_name == ""
-            else batch_name
-        )
-        self.future_expiry_date = get_offset_date(offset_days=365)
-        self.day = self.future_expiry_date[-2:]
-        self.month = self.future_expiry_date[4:6]
-        self.year = self.future_expiry_date[:4]
-
-    @step("Add a new batch for {1}")
-    def add_batch(self, vaccine: Vaccine, batch_name: str = "") -> str:
-        self._calculate_batch_details(vaccine, batch_name=batch_name)
-        expect(self.page.get_by_role("main")).to_contain_text(vaccine)
-
+    @step("Add batch for {1}")
+    def click_add_batch(self, vaccine: Vaccine):
         self.page.get_by_role("link", name=f"Add a new {vaccine} batch").click()
 
-        expect(self.page.get_by_role("main")).to_contain_text(vaccine)
-        self.fill_batch_details()
-        self.click_add_batch_button()
-        if len(batch_name) <= 100:
-            expect(self.batch_added_alert).to_be_visible()
-        else:
-            expect(self.batch_name_error).to_be_visible()
+    @step("Change {2} batch for {1}")
+    def click_change_batch(self, vaccine: Vaccine, batch_name: str):
+        name = f"Change {batch_name} batch of {vaccine}"
+        self.page.get_by_role("link", name=name).click()
 
-        return self.batch_name
-
-    @step("Fill the batch details")
-    def fill_batch_details(self):
-        self.batch_textbox.fill(value=self.batch_name)
-        self.day_textbox.fill(value=self.day)
-        self.month_textbox.fill(value=self.month)
-        self.year_textbox.fill(value=self.year)
-
-    @step("Click on Add batch")
-    def click_add_batch_button(self):
-        self.add_batch_button.click()
-
-    @step("Click on Save changes")
-    def click_save_changes(self):
-        self.save_changes_button.click()
-
-    @step("Click on Archive this batch")
-    def click_archive_this_batch(self):
-        self.confirm_archive_button.click()
-
-    @step("Change the batch for {1}")
-    def change_batch(self, vaccine: Vaccine):
-        batch_name = self.batch_name or str(vaccine)
-        self.__click_batch_option(batch_name, "Change")
-        self.year_textbox.fill(value=get_offset_date(offset_days=730)[:4])
-        self.click_save_changes()
-        _success_message = f"Batch {self.batch_name} updated"
-        expect(self.page.get_by_role("alert")).to_contain_text(_success_message)
-
-    @step("Archive the batch for {1}")
-    def archive_batch(self, vaccine: Vaccine):
-        batch_name = self.batch_name or str(vaccine)
-        self.__click_batch_option(batch_name, "Archive")
-        self.click_archive_this_batch()
-        expect(self.page.get_by_role("alert")).to_contain_text("Batch archived.")
-
-    def __click_batch_option(self, batch_name: str, link_text: str):
-        row = self.page.locator("tr").filter(
-            has=self.page.locator("td:first-child", has_text=batch_name)
-        )
-        row.locator("td:last-child").get_by_role("link", name=link_text).click()
+    @step("Archive {2} batch for {1}")
+    def click_archive_batch(self, vaccine: Vaccine, batch_name: str):
+        name = f"Archive {batch_name} batch of {vaccine}"
+        self.page.get_by_role("link", name=name).click()

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -59,17 +59,14 @@ def setup_mavis_1729(
 @pytest.fixture
 def setup_mav_854(
     log_in_as_nurse,
+    add_vaccine_batch,
     schools,
     dashboard_page,
     import_records_page,
     sessions_page,
-    vaccines_page,
 ):
     try:
-        community_clinics_session = "Community clinics"
-
-        dashboard_page.click_vaccines()
-        batch_name = vaccines_page.add_batch(Vaccine.GARDASIL_9)
+        batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
@@ -78,9 +75,7 @@ def setup_mav_854(
         sessions_page.click_location(schools[0])
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(
-            community_clinics_session, for_today=True
-        )
+        sessions_page.schedule_a_valid_session("Community clinics", for_today=True)
         dashboard_page.click_mavis()
         dashboard_page.click_children()
         yield batch_name

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -9,16 +9,15 @@ from mavis.test.wrappers import generate_random_string
 @pytest.fixture
 def setup_mav_965(
     log_in_as_nurse,
+    add_vaccine_batch,
     schools,
     dashboard_page,
     import_records_page,
     sessions_page,
-    vaccines_page,
 ):
-    dashboard_page.click_vaccines()
-    gardasil_9_batch_name = vaccines_page.add_batch(Vaccine.GARDASIL_9)
-    menquadfi_batch_name = vaccines_page.add_batch(Vaccine.MENQUADFI)
-    revaxis_batch_name = vaccines_page.add_batch(Vaccine.REVAXIS)
+    gardasil_9_batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
+    menquadfi_batch_name = add_vaccine_batch(Vaccine.MENQUADFI)
+    revaxis_batch_name = add_vaccine_batch(Vaccine.REVAXIS)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     sessions_page.schedule_a_valid_session(schools[0], for_today=True)


### PR DESCRIPTION
This refactors the vaccine page object in to separate page objects for each distinct page in the service to ensure the classes and smaller and don't leak elements from other pages.

I've also added a test to ensure the batch names are at least 2 characters long.

This change depends on a few changes to the service being deployed first, specifically the improved accessibility labels: https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3717