### PR TITLE
Check batch name when recording vaccs for children

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -606,6 +606,7 @@ class SessionsPage:
         self,
         child_name: str,
         programme: Programme,
+        batch_name: str,
         at_school: bool = True,
         notes: str = "",
     ):
@@ -625,7 +626,7 @@ class SessionsPage:
             self.pre_screening_notes.fill("Prescreening notes")
             self.click_continue_button()
 
-        self.page.get_by_role("radio", name=programme.vaccines[0]).check()
+        self.page.get_by_role("radio", name=batch_name).check()
         self.click_continue_button()
 
         if at_school:  # only skips MAV-854

--- a/mavis/test/pages/vaccines.py
+++ b/mavis/test/pages/vaccines.py
@@ -37,7 +37,7 @@ class VaccinesPage:
         self.year = self.future_expiry_date[:4]
 
     @step("Add a new batch for {1}")
-    def add_batch(self, vaccine: Vaccine, batch_name: str = ""):
+    def add_batch(self, vaccine: Vaccine, batch_name: str = "") -> str:
         self._calculate_batch_details(vaccine, batch_name=batch_name)
         expect(self.page.get_by_role("main")).to_contain_text(vaccine)
 
@@ -50,6 +50,8 @@ class VaccinesPage:
             expect(self.batch_added_alert).to_be_visible()
         else:
             expect(self.batch_name_error).to_be_visible()
+
+        return self.batch_name
 
     @step("Fill the batch details")
     def fill_batch_details(self):

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -69,7 +69,7 @@ def setup_mav_854(
         community_clinics_session = "Community clinics"
 
         dashboard_page.click_vaccines()
-        vaccines_page.add_batch(Vaccine.GARDASIL_9)
+        batch_name = vaccines_page.add_batch(Vaccine.GARDASIL_9)
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(schools[0], for_today=True)
@@ -83,7 +83,7 @@ def setup_mav_854(
         )
         dashboard_page.click_mavis()
         dashboard_page.click_children()
-        yield
+        yield batch_name
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
@@ -262,6 +262,7 @@ def test_rav_verify_excel_mav_854(
     consent_page,
 ):
     mav_854_child = "MAV_854, MAV_854"
+    batch_name = setup_mav_854
 
     children_page.search_for_a_child(mav_854_child)
     children_page.click_record_for_child(mav_854_child)
@@ -272,6 +273,7 @@ def test_rav_verify_excel_mav_854(
     sessions_page.record_vaccs_for_child(
         child_name=mav_854_child,
         programme=Programme.HPV,
+        batch_name=batch_name,
         at_school=False,
     )
     sessions_page.check_location_radio(clinics[0])

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -16,9 +16,9 @@ def setup_mav_965(
     vaccines_page,
 ):
     dashboard_page.click_vaccines()
-    vaccines_page.add_batch(Vaccine.GARDASIL_9)
-    vaccines_page.add_batch(Vaccine.MENQUADFI)
-    vaccines_page.add_batch(Vaccine.REVAXIS)
+    gardasil_9_batch_name = vaccines_page.add_batch(Vaccine.GARDASIL_9)
+    menquadfi_batch_name = vaccines_page.add_batch(Vaccine.MENQUADFI)
+    revaxis_batch_name = vaccines_page.add_batch(Vaccine.REVAXIS)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     sessions_page.schedule_a_valid_session(schools[0], for_today=True)
@@ -26,6 +26,7 @@ def setup_mav_965(
     import_records_page.upload_and_verify_output(FilePath.CLASS_MAV_965)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
+    return gardasil_9_batch_name, menquadfi_batch_name, revaxis_batch_name
 
 
 @allure.issue("MAV-965")
@@ -50,6 +51,7 @@ def test_programmes_rav_pre_screening_questions(
     """
 
     mav_965_child = "MAV_965, MAV_965"
+    gardasil_9_batch_name, menquadfi_batch_name, revaxis_batch_name = setup_mav_965
 
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
@@ -75,15 +77,18 @@ def test_programmes_rav_pre_screening_questions(
     sessions_page.record_vaccs_for_child(
         child_name=mav_965_child,
         programme=Programme.HPV,
+        batch_name=gardasil_9_batch_name,
         notes=generate_random_string(target_length=1001, spaces=True),  # MAV-955
     )
     sessions_page.record_vaccs_for_child(
         child_name=mav_965_child,
         programme=Programme.MENACWY,
+        batch_name=menquadfi_batch_name,
         notes=generate_random_string(target_length=1001, spaces=True),  # MAV-955
     )
     sessions_page.record_vaccs_for_child(
         child_name=mav_965_child,
         programme=Programme.TD_IPV,
+        batch_name=revaxis_batch_name,
         notes=generate_random_string(target_length=1001, spaces=True),  # MAV-955
     )


### PR DESCRIPTION
Make batch name checking more strict.

Part of #358 (resolves a problem that occurs when running `tests/test_reset.py::test_programmes_rav_pre_screening_questions` after `tests/test_programmes.py::test_rav_verify_excel_mav_854`)