### PR TITLE
fix test_cohorts_readd_to_cohort

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -238,3 +238,10 @@ class TestData:
     def get_session_id(self, path: Path) -> str:
         data_frame = pd.read_excel(path, sheet_name="Vaccinations")
         return data_frame["SESSION_ID"].iloc[0]
+
+    def increment_date_of_birth_for_records(self, file_path: Path):
+        _file_df = pd.read_csv(file_path)
+        _file_df["CHILD_DATE_OF_BIRTH"] = pd.to_datetime(
+            _file_df["CHILD_DATE_OF_BIRTH"]
+        ) + pd.Timedelta(days=1)
+        _file_df.to_csv(file_path, index=False)

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -136,6 +136,7 @@ def test_cohorts_readd_to_cohort(
     dashboard_page,
     children_page,
     import_records_page,
+    test_data,
 ):
     """
     Steps to reproduce:
@@ -159,7 +160,9 @@ def test_cohorts_readd_to_cohort(
         Server error page and user cannot bring the child back into the cohort
     """
     mav_909_child = "MAV_909, MAV_909"
-    import_records_page.upload_and_verify_output(CohortsFileMapping.MAV_909)
+    input_file_path, _ = import_records_page.upload_and_verify_output(
+        CohortsFileMapping.MAV_909
+    )
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
@@ -167,7 +170,11 @@ def test_cohorts_readd_to_cohort(
     dashboard_page.click_mavis()
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
-    import_records_page.upload_and_verify_output(CohortsFileMapping.MAV_909)
+
+    test_data.increment_date_of_birth_for_records(input_file_path)
+    import_records_page.set_input_file(input_file_path)
+    import_records_page.click_continue()
+
     programmes_page.expect_text("1 duplicate record needs review")
     programmes_page.click_review()
     programmes_page.click_use_duplicate()


### PR DESCRIPTION
Makes this test slightly more robust. It currently uploads the same file twice and hopes that a different date of birth is generated each time, but this could fail,