### PR TITLE
Update consent-journey.jmx

### DIFF
--- a/performance-tests/E2E/consent-journey.jmx
+++ b/performance-tests/E2E/consent-journey.jmx
@@ -407,7 +407,7 @@ vars.put(&quot;ConsentSession&quot;, cohortCodes.get(vars.get(&quot;CHILD_SCHOOL
         </TransactionController>
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get school name" enabled="true">
-            <stringProp name="HTTPSampler.path">api/locations?type=school&amp;status=open</stringProp>
+            <stringProp name="HTTPSampler.path">api/locations?type=school</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.use_keepalive">true</boolProp>


### PR DESCRIPTION
Remove the 'open' filter on the school api call to allow Sherborne to be used as a test URN (the school is closed).