### PR TITLE
add suffix to company names

### DIFF
--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -95,7 +95,7 @@ def superuser():
 def team():
     return Team(
         key="team",
-        name=onboarding_faker.company(),
+        name=f"{onboarding_faker.company()} est. {random.randint(1600, 2025)}",
         email=onboarding_faker.email(),
         phone=onboarding_faker.cellphone_number(),
     )


### PR DESCRIPTION
Adds "est. <year>" to generated organisation names. Should massively reduce the number of 422 errors we get while keeping realistic looking test data.