### PR TITLE
use uv instead of pip for dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,7 +12,7 @@ updates:
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This was missed in the switch to `uv`, it should automatically update the `uv.lock` file but we'll have to see if it actually works.

Should close #381 but we'll see