### PR TITLE
normalize whitespace in school names

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import re
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional
@@ -15,6 +14,7 @@ from ..wrappers import (
     get_current_time,
     get_date_of_birth_for_year_group,
     get_offset_date,
+    normalize_whitespace,
 )
 
 
@@ -289,22 +289,10 @@ class TestData:
         else:
             _cols = ["CHILD_LAST_NAME", "CHILD_FIRST_NAME"]
 
-        col0 = _file_df[_cols[0]].apply(self.normalize_whitespace)
-        col1 = _file_df[_cols[1]].apply(self.normalize_whitespace)
+        col0 = _file_df[_cols[0]].apply(normalize_whitespace)
+        col1 = _file_df[_cols[1]].apply(normalize_whitespace)
         _names_list = (col0 + ", " + col1).tolist()
         return _names_list
-
-    def normalize_whitespace(self, string: str) -> str:
-        """
-        Normalize whitespace in a string:
-        - Remove zero-width joiners
-        - Replace non-breaking spaces with regular spaces
-        - Collapse consecutive whitespace to a single space
-        - Strip leading/trailing whitespace
-        """
-        string = string.replace("\u200d", "")
-        string = string.replace("\u00a0", " ")
-        return re.sub(r"\s+", " ", string).strip()
 
     def get_session_id(self, path: Path) -> str:
         data_frame = pd.read_excel(path, sheet_name="Vaccinations", dtype=str)

--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -19,7 +19,7 @@ from mavis.test.models import (
     Parent,
     Relationship,
 )
-from mavis.test.wrappers import get_date_of_birth_for_year_group
+from mavis.test.wrappers import get_date_of_birth_for_year_group, normalize_whitespace
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ def schools(base_url) -> List[School]:
     schools_data = random.choices(data, k=2)
 
     return [
-        School(name=school_data["name"], urn=school_data["urn"])
+        School(name=normalize_whitespace(school_data["name"]), urn=school_data["urn"])
         for school_data in schools_data
     ]
 

--- a/mavis/test/wrappers.py
+++ b/mavis/test/wrappers.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timedelta
 
 from faker import Faker
+import re
 
 faker = Faker()
 
@@ -80,3 +81,16 @@ def generate_random_string(target_length: int = 100, spaces: bool = False) -> st
             )
         )
     return generated_string
+
+
+def normalize_whitespace(string: str) -> str:
+    """
+    Normalize whitespace in a string:
+    - Remove zero-width joiners
+    - Replace non-breaking spaces with regular spaces
+    - Collapse consecutive whitespace to a single space
+    - Strip leading/trailing whitespace
+    """
+    string = string.replace("\u200d", "")
+    string = string.replace("\u00a0", " ")
+    return re.sub(r"\s+", " ", string).strip()


### PR DESCRIPTION
Some locators break when school names contain double spaces, so this PR reuses the existing normalize_whitespace method and uses it when setting school names.