### PR TITLE
Increase wait for file to be processed

### DIFF
--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -121,12 +121,9 @@ class ChildrenPage:
     def verify_activity_log_for_created_or_matched_child(
         self, child_name: str, location: str
     ):
-        self.search_textbox.fill(child_name)
-        self.search_button.click()
-        self.page.wait_for_timeout(1000)
-        self.page.get_by_text(child_name).click()
-        self.activity_log_link.click()
-        self.page.wait_for_timeout(1000)
+        self.search_for_a_child(child_name)
+        self.click_record_for_child(child_name)
+        self.click_activity_log()
         self.expect_text_in_main("Consent given")
         self.expect_text_in_main(f"Invited to the session at {location}")
 

--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -61,8 +61,8 @@ class ChildrenPage:
     @step("Search for child {1}")
     def search_for_a_child(self, child_name: str) -> None:
         self.search_textbox.fill(child_name)
-        self.search_button.click()
-        self.page.wait_for_timeout(1000)
+        with self.page.expect_navigation():
+            self.search_button.click()
         self.expect_text_in_main(child_name)
 
     def assert_n_children_found(self, n: int) -> None:

--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -92,9 +92,9 @@ class ChildrenPage:
         self.change_nhs_no_link.click()
 
     @step("Click on Activity log")
-    def click_activity_log_and_wait(self) -> None:
-        self.activity_log_link.click()
-        self.page.wait_for_timeout(1000)
+    def click_activity_log(self) -> None:
+        with self.page.expect_navigation():
+            self.activity_log_link.click()
 
     @step("Click on Edit child record")
     def click_edit_child_record(self) -> None:

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -78,11 +78,11 @@ class ImportRecordsPage:
     def wait_for_processed(self):
         self.page.wait_for_load_state()
 
-        # Wait up to 10 seconds for file to be processed.
+        # Wait up to 30 seconds for file to be processed.
 
         tag = self.completed_tag.or_(self.invalid_tag)
 
-        for i in range(20):
+        for i in range(60):
             if tag.is_visible():
                 break
 

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -744,7 +744,7 @@ class SessionsPage:
 
     def verify_child_shows_correct_flu_consent_method(self, child: Child, method: str):
         patient_card = self.page.locator(
-            f"div.nhsuk-card.app-card--patient:has(h2:has-text('{str(child)}'))"
+            f'div.nhsuk-card.app-card--patient:has(h2:has-text("{str(child)}"))'
         )
         flu_consent_section = patient_card.locator("p:has-text('Flu')")
         expect(flu_consent_section).to_contain_text("Consent given")

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -113,7 +113,7 @@ def test_details_mav_853(setup_mav_853, children_page, schools, children):
     children_page.search_for_a_child(child_name)
     children_page.click_record_for_child(child_name)
     # Verify activity log
-    children_page.click_activity_log_and_wait()
+    children_page.click_activity_log()
     children_page.expect_text_in_main("Vaccinated with Gardasil 9")
     # Verify vaccination record
     children_page.click_child_record()


### PR DESCRIPTION
Increases the time spent refreshing/waiting for files to be processed from 10 seconds to 30 seconds. This should fix the occasional flakiness seen from certain file upload tests. Due to how this works, this will have no impact on most tests.

If it somehow takes longer than 30 seconds for the file to be processed, then this is something we should look at