### PR TITLE
Change tab handling for children page

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -55,11 +55,13 @@ jobs:
 
       - name: Generate Allure report
         if: always()
+        continue-on-error: true
         run: |
           npx allure-commandline generate allure-results -o allure-report
 
       - name: Set GitHub Pages directory
         if: always()
+        continue-on-error: true
         id: set-pages-dir
         run: |
           sanitized_device=$(echo "${{ matrix.device }}" | tr -cd '[:alnum:]_-')
@@ -67,6 +69,7 @@ jobs:
 
       - name: Checkout gh-pages branch
         if: always()
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           ref: gh-pages
@@ -74,6 +77,7 @@ jobs:
 
       - name: Replace existing report with new report
         if: always()
+        continue-on-error: true
         run: |
           rm -rf gh-pages/${{ steps.set-pages-dir.outputs.dir }}
           mkdir -p gh-pages/${{ steps.set-pages-dir.outputs.dir }}
@@ -81,6 +85,7 @@ jobs:
 
       - name: Commit and push changes
         if: always()
+        continue-on-error: true
         run: |
           cd gh-pages
           git config user.name "github-actions[bot]"
@@ -88,11 +93,13 @@ jobs:
           git add ${{ steps.set-pages-dir.outputs.dir }}
           # Only commit if there are changes
           git diff --cached --quiet || git commit -m "Deploy changes to pages"
+          git pull --rebase origin gh-pages
           git push origin gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set Job Summary
         if: always()
+        continue-on-error: true
         run: |
           echo "Test report URL is https://nhsdigital.github.io/manage-vaccinations-in-schools-testing/${{ steps.set-pages-dir.outputs.dir }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/functional_selected_device.yaml
+++ b/.github/workflows/functional_selected_device.yaml
@@ -77,11 +77,13 @@ jobs:
 
       - name: Generate Allure report
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        continue-on-error: true
         run: |
           npx allure-commandline generate allure-results -o allure-report
 
       - name: Set GitHub Pages directory
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        continue-on-error: true
         id: set-pages-dir
         run: |
           sanitized_device=$(echo "${{ steps.set-variables.outputs.device }}" | tr -cd '[:alnum:]_-')
@@ -89,6 +91,7 @@ jobs:
 
       - name: Checkout gh-pages branch
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           ref: gh-pages
@@ -96,6 +99,7 @@ jobs:
 
       - name: Replace existing report with new report
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        continue-on-error: true
         run: |
           rm -rf gh-pages/${{ steps.set-pages-dir.outputs.dir }}
           mkdir -p gh-pages/${{ steps.set-pages-dir.outputs.dir }}
@@ -103,6 +107,7 @@ jobs:
 
       - name: Commit and push changes
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        continue-on-error: true
         run: |
           cd gh-pages
           git config user.name "github-actions[bot]"
@@ -110,11 +115,13 @@ jobs:
           git add ${{ steps.set-pages-dir.outputs.dir }}
           # Only commit if there are changes
           git diff --cached --quiet || git commit -m "Deploy changes to pages"
+          git pull --rebase origin gh-pages
           git push origin gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set Job Summary
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        continue-on-error: true
         run: |
           echo "Test report URL is https://nhsdigital.github.io/manage-vaccinations-in-schools-testing/${{ steps.set-pages-dir.outputs.dir }}" >> $GITHUB_STEP_SUMMARY

--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -89,8 +89,8 @@ class ChildrenPage:
 
     @step("Click on Child record")
     def click_child_record(self) -> None:
-        with self.page.expect_navigation():
-            self.child_record_link.click()
+        self.child_record_link.click()
+        self.child_record_link.get_by_role("strong").wait_for()
 
     @step("Click on Change NHS number")
     def click_change_nhs_no(self) -> None:
@@ -98,8 +98,8 @@ class ChildrenPage:
 
     @step("Click on Activity log")
     def click_activity_log(self) -> None:
-        with self.page.expect_navigation():
-            self.activity_log_link.click()
+        self.activity_log_link.click()
+        self.activity_log_link.get_by_role("strong").wait_for()
 
     @step("Click on Edit child record")
     def click_edit_child_record(self) -> None:


### PR DESCRIPTION
There are still some failures that only appear when using Firefox + Github actions together (and still only sometimes 😅 ). This handles the tab clicking differently, in a way that I think we've had more success with in other pages.