### PR TITLE
change how note checking works

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -453,8 +453,7 @@ class SessionsPage:
     def add_note(self, note: str):
         self.click_add_a_note()
         self.fill_note_textbox(note)
-        with self.page.expect_navigation():
-            self.click_save_note()
+        self.click_save_note()
         expect(self.success_alert).to_contain_text("Note added")
         self.check_notes_appear_in_order([note])
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -103,6 +103,7 @@ def test_recording_notes(setup_fixed_child, sessions_page, schools, children):
     sessions_page.click_child(child)
     sessions_page.click_session_activity_and_notes()
     sessions_page.add_note(NOTE_1)
+    sessions_page.click_session_activity_and_notes()
     sessions_page.add_note(NOTE_2)
     sessions_page.click_location(schools[0])
     sessions_page.click_consent_tab()


### PR DESCRIPTION
Replace `expect_navigation` with clicking the session activity tab again, so that the `expect(self.success_alert)` step can work for the second note. 

I'm finding using `expect` as a way to check elements load before proceeding as a far more reliable method than `expect_navigation`, so I'll use that from now on.