### PR TITLE
Save screenshots when steps fail

### DIFF
--- a/mavis/test/step.py
+++ b/mavis/test/step.py
@@ -4,30 +4,38 @@ import allure
 
 
 def step(title: str, attach_screenshot: bool = True):
-    step_context = allure.step(title)
-
     def decorator(func):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
-            return_value = func(self, *args, **kwargs)
+            with allure.step(title):
+                try:
+                    return_value = func(self, *args, **kwargs)
+                except Exception:
+                    if attach_screenshot:
+                        allure.attach(
+                            self.page.screenshot(),
+                            name="Screenshot on failure",
+                            attachment_type=allure.attachment_type.PNG,
+                        )
+                    raise
 
-            coverage = kwargs.get("coverage")
-            if coverage:
-                allure.attach(
-                    coverage,
-                    name="Coverage",
-                    attachment_type=allure.attachment_type.TEXT,
-                )
+                coverage = kwargs.get("coverage")
+                if coverage:
+                    allure.attach(
+                        coverage,
+                        name="Coverage",
+                        attachment_type=allure.attachment_type.TEXT,
+                    )
 
-            if attach_screenshot:
-                allure.attach(
-                    self.page.screenshot(),
-                    name="Screenshot",
-                    attachment_type=allure.attachment_type.PNG,
-                )
+                if attach_screenshot:
+                    allure.attach(
+                        self.page.screenshot(),
+                        name="Screenshot",
+                        attachment_type=allure.attachment_type.PNG,
+                    )
 
-            return return_value
+                return return_value
 
-        return step_context(wrapper)
+        return wrapper
 
     return decorator


### PR DESCRIPTION
This PR ensures that screenshots are taken/attached to the report when test steps fail, which will help with debugging.