### PR TITLE
extract reload function

### DIFF
--- a/mavis/test/pages/consent_responses.py
+++ b/mavis/test/pages/consent_responses.py
@@ -1,6 +1,7 @@
 from playwright.sync_api import Page
 
 from ..step import step
+from ..wrappers import reload_until_element_is_visible
 
 
 def get_child_full_name(first_name: str, last_name: str) -> str:
@@ -27,6 +28,7 @@ class UnmatchedConsentResponsesPage:
     @step("Click on consent response for {1} {2}")
     def click_child(self, first_name: str, last_name: str):
         row = self._get_row_for_child(first_name, last_name)
+        reload_until_element_is_visible(self.page, row)
         row.get_by_role("link").first.click()
 
     def _get_row_for_child(self, first_name: str, last_name: str):

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -7,7 +6,7 @@ from playwright.sync_api import Page, expect
 
 from ..data import FileMapping, TestData
 from ..step import step
-from ..wrappers import format_datetime_for_upload_link
+from ..wrappers import format_datetime_for_upload_link, reload_until_element_is_visible
 
 
 class ImportRecordsPage:
@@ -78,19 +77,9 @@ class ImportRecordsPage:
     def wait_for_processed(self):
         self.page.wait_for_load_state()
 
-        # Wait up to 30 seconds for file to be processed.
-
         tag = self.completed_tag.or_(self.invalid_tag)
 
-        for i in range(60):
-            if tag.is_visible():
-                break
-
-            time.sleep(0.5)
-
-            self.page.reload()
-        else:
-            expect(tag).to_be_visible()
+        reload_until_element_is_visible(self.page, tag, seconds=30)
 
     def navigate_to_child_record_import(self):
         self.click_import_records()

--- a/mavis/test/wrappers.py
+++ b/mavis/test/wrappers.py
@@ -2,6 +2,8 @@ from datetime import date, datetime, timedelta
 
 from faker import Faker
 import re
+import time
+from playwright.sync_api import Page, Locator, expect
 
 faker = Faker()
 
@@ -94,3 +96,15 @@ def normalize_whitespace(string: str) -> str:
     string = string.replace("\u200d", "")
     string = string.replace("\u00a0", " ")
     return re.sub(r"\s+", " ", string).strip()
+
+
+def reload_until_element_is_visible(page: Page, tag: Locator, seconds: int = 30):
+    for i in range(seconds * 2):
+        if tag.is_visible():
+            break
+
+        time.sleep(0.5)
+
+        page.reload()
+    else:
+        expect(tag).to_be_visible()


### PR DESCRIPTION
In a few places, we want to reload the page until an element appears. This is so that tests can still pass even if the environment is slow.

This PR extracts this functionality and reuses it in a few places where tests occasionally fail due to the environment not showing the expected information. It seems to fix these issues.