### PR TITLE
Reload until note appears

### DIFF
--- a/mavis/test/pages/consent_responses.py
+++ b/mavis/test/pages/consent_responses.py
@@ -1,6 +1,7 @@
 from playwright.sync_api import Page
 
 from ..step import step
+from ..wrappers import reload_until_element_is_visible
 
 
 def get_child_full_name(first_name: str, last_name: str) -> str:
@@ -27,6 +28,7 @@ class UnmatchedConsentResponsesPage:
     @step("Click on consent response for {1} {2}")
     def click_child(self, first_name: str, last_name: str):
         row = self._get_row_for_child(first_name, last_name)
+        reload_until_element_is_visible(self.page, row)
         row.get_by_role("link").first.click()
 
     def _get_row_for_child(self, first_name: str, last_name: str):

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -7,7 +6,7 @@ from playwright.sync_api import Page, expect
 
 from ..data import FileMapping, TestData
 from ..step import step
-from ..wrappers import format_datetime_for_upload_link
+from ..wrappers import format_datetime_for_upload_link, reload_until_element_is_visible
 
 
 class ImportRecordsPage:
@@ -78,19 +77,9 @@ class ImportRecordsPage:
     def wait_for_processed(self):
         self.page.wait_for_load_state()
 
-        # Wait up to 30 seconds for file to be processed.
-
         tag = self.completed_tag.or_(self.invalid_tag)
 
-        for i in range(60):
-            if tag.is_visible():
-                break
-
-            time.sleep(0.5)
-
-            self.page.reload()
-        else:
-            expect(tag).to_be_visible()
+        reload_until_element_is_visible(self.page, tag, seconds=30)
 
     def navigate_to_child_record_import(self):
         self.click_import_records()

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -12,6 +12,7 @@ from mavis.test.wrappers import (
     generate_random_string,
     get_current_datetime,
     get_offset_date,
+    reload_until_element_is_visible,
 )
 
 
@@ -455,7 +456,10 @@ class SessionsPage:
         self.fill_note_textbox(note)
         with self.page.expect_navigation():
             self.click_save_note()
+
         expect(self.success_alert).to_contain_text("Note added")
+        reload_until_element_is_visible(self.page, self.page.get_by_text(note))
+
         self.check_notes_appear_in_order([note])
 
     @step("Search for {1}")

--- a/mavis/test/wrappers.py
+++ b/mavis/test/wrappers.py
@@ -2,6 +2,8 @@ from datetime import date, datetime, timedelta
 
 from faker import Faker
 import re
+import time
+from playwright.sync_api import Page, Locator, expect
 
 faker = Faker()
 
@@ -94,3 +96,15 @@ def normalize_whitespace(string: str) -> str:
     string = string.replace("\u200d", "")
     string = string.replace("\u00a0", " ")
     return re.sub(r"\s+", " ", string).strip()
+
+
+def reload_until_element_is_visible(page: Page, tag: Locator, seconds: int = 30):
+    for i in range(seconds * 2):
+        if tag.is_visible():
+            break
+
+        time.sleep(0.5)
+
+        page.reload()
+    else:
+        expect(tag).to_be_visible()

--- a/mavis/test/wrappers.py
+++ b/mavis/test/wrappers.py
@@ -99,7 +99,7 @@ def normalize_whitespace(string: str) -> str:
 
 
 def reload_until_element_is_visible(page: Page, tag: Locator, seconds: int = 30):
-    for i in range(seconds * 2):
+    for _ in range(seconds * 2):
         if tag.is_visible():
             break
 


### PR DESCRIPTION
If the environment is a little slow, the notes test often fails as the note does not appear immediately after being added. This just reloads the page until it appears..