### PR TITLE
Handle child names consistently

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -8,8 +8,8 @@ import nhs_number
 import pandas as pd
 from faker import Faker
 
-from ..models import Child, Organisation, School, User
-from ..wrappers import (
+from mavis.test.models import Child, Organisation, School, User
+from mavis.test.wrappers import (
     get_current_datetime,
     get_current_time,
     get_date_of_birth_for_year_group,

--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -2,9 +2,9 @@ from datetime import date, timedelta
 
 import pytest
 
-from ..data import TestData
-from ..models import Vaccine
-from ..wrappers import get_date_of_birth_for_year_group
+from mavis.test.data import TestData
+from mavis.test.models import Vaccine
+from mavis.test.wrappers import get_date_of_birth_for_year_group
 
 
 @pytest.fixture

--- a/mavis/test/fixtures/pages.py
+++ b/mavis/test/fixtures/pages.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..pages import (
+from mavis.test.pages import (
     AddBatchPage,
     ArchiveBatchPage,
     ArchiveConsentResponsePage,

--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from playwright.sync_api import Page, expect
 
-from ..data import TestData
-from ..models import School
-from ..step import step
-from ..wrappers import reload_until_element_is_visible
+from mavis.test.data import TestData
+from mavis.test.models import School, Child
+from mavis.test.step import step
+from mavis.test.wrappers import reload_until_element_is_visible
 
 
 class ChildrenPage:
@@ -61,10 +61,10 @@ class ChildrenPage:
             file_path, is_vaccinations
         )
         for child_name in child_names:
-            self.search_for_a_child(child_name)
+            self.search_for_a_child_name(child_name)
 
     @step("Search for child {1}")
-    def search_for_a_child(self, child_name: str) -> None:
+    def search_for_a_child_name(self, child_name: str) -> None:
         self.search_textbox.fill(child_name)
 
         with self.page.expect_navigation():
@@ -80,9 +80,9 @@ class ChildrenPage:
         ).to_be_visible()
 
     @step("Click on record for child {1}")
-    def click_record_for_child(self, child_name: str) -> None:
+    def click_record_for_child(self, child: Child) -> None:
         with self.page.expect_navigation():
-            self.page.get_by_role("link", name=child_name).click()
+            self.page.get_by_role("link", name=str(child)).click()
 
     @step("Click on {1} vaccination details")
     def click_vaccination_details(self, school: School) -> None:
@@ -118,8 +118,8 @@ class ChildrenPage:
         self.remove_from_cohort_button.click()
 
     @step("Fill NHS number {2} for child {1}")
-    def fill_nhs_no_for_child(self, child_name: str, nhs_no: str) -> None:
-        self.page.get_by_role("textbox", name=child_name).fill(nhs_no)
+    def fill_nhs_no_for_child(self, child: Child, nhs_no: str) -> None:
+        self.page.get_by_role("textbox", name=str(child)).fill(nhs_no)
 
     def expect_text_in_main(self, text: str) -> None:
         expect(self.page.get_by_role("main")).to_contain_text(text)
@@ -134,10 +134,10 @@ class ChildrenPage:
         )
 
     def verify_activity_log_for_created_or_matched_child(
-        self, child_name: str, location: str
+        self, child: Child, location: str
     ):
-        self.search_for_a_child(child_name)
-        self.click_record_for_child(child_name)
+        self.search_for_a_child_name(str(child))
+        self.click_record_for_child(child)
         self.click_activity_log()
         self.expect_text_in_main("Consent given")
         self.expect_text_in_main(f"Invited to the session at {location}")
@@ -145,8 +145,8 @@ class ChildrenPage:
         # FIXME: Update this text when MAVIS-1896/MAV-253 is closed
         self.check_log_updates_with_match()
 
-    def remove_child_from_cohort(self, child_name: str):
-        self.search_for_a_child(child_name)
-        self.click_record_for_child(child_name)
+    def remove_child_from_cohort(self, child: Child):
+        self.search_for_a_child_name(str(child))
+        self.click_record_for_child(child)
         self.click_remove_from_cohort()
-        self.expect_text_in_main(f"{child_name} removed from cohort")
+        self.expect_text_in_main(f"{str(child)} removed from cohort")

--- a/mavis/test/pages/consent_responses.py
+++ b/mavis/test/pages/consent_responses.py
@@ -1,11 +1,8 @@
 from playwright.sync_api import Page
 
-from ..step import step
-from ..wrappers import reload_until_element_is_visible
-
-
-def get_child_full_name(first_name: str, last_name: str) -> str:
-    return f"{last_name.upper()}, {first_name}"
+from mavis.test.step import step
+from mavis.test.wrappers import reload_until_element_is_visible
+from mavis.test.models import Child
 
 
 class UnmatchedConsentResponsesPage:
@@ -26,14 +23,10 @@ class UnmatchedConsentResponsesPage:
         )
 
     @step("Click on consent response for {1} {2}")
-    def click_child(self, first_name: str, last_name: str):
-        row = self._get_row_for_child(first_name, last_name)
+    def click_child(self, child: Child):
+        row = self.rows.filter(has=self.page.get_by_text(str(child)))
         reload_until_element_is_visible(self.page, row)
         row.get_by_role("link").first.click()
-
-    def _get_row_for_child(self, first_name: str, last_name: str):
-        full_name = get_child_full_name(first_name, last_name)
-        return self.rows.filter(has=self.page.get_by_text(full_name))
 
 
 class ConsentResponsePage:
@@ -65,7 +58,7 @@ class ArchiveConsentResponsePage:
         self.archive_button = page.get_by_role("button", name="Archive")
 
     @step("Archive consent response")
-    def archive(self, *, notes: str):
+    def archive(self, notes: str):
         self.notes_textbox.fill(notes)
         self.archive_button.click()
 
@@ -90,11 +83,9 @@ class MatchConsentResponsePage:
         self.link_button = page.get_by_role("button", name="Link response with record")
 
     @step("Match consent response with {1} {2}")
-    def match(self, first_name: str, last_name: str):
-        full_name = get_child_full_name(first_name, last_name)
-
-        self.search_textbox.fill(full_name)
+    def match(self, child: Child):
+        self.search_textbox.fill(str(child))
         self.search_button.click()
 
-        self.page.get_by_role("link", name=full_name).click()
+        self.page.get_by_role("link", name=str(child)).click()
         self.link_button.click()

--- a/mavis/test/pages/dashboard.py
+++ b/mavis/test/pages/dashboard.py
@@ -1,6 +1,6 @@
 from playwright.sync_api import Page
 
-from ..step import step
+from mavis.test.step import step
 
 
 class DashboardPage:

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -4,9 +4,12 @@ from typing import Optional
 
 from playwright.sync_api import Page, expect
 
-from ..data import FileMapping, TestData
-from ..step import step
-from ..wrappers import format_datetime_for_upload_link, reload_until_element_is_visible
+from mavis.test.data import FileMapping, TestData
+from mavis.test.step import step
+from mavis.test.wrappers import (
+    format_datetime_for_upload_link,
+    reload_until_element_is_visible,
+)
 
 
 class ImportRecordsPage:

--- a/mavis/test/pages/log_in.py
+++ b/mavis/test/pages/log_in.py
@@ -1,7 +1,7 @@
 from playwright.sync_api import Page
 
-from ..models import Organisation, User
-from ..step import step
+from mavis.test.models import Organisation, User
+from mavis.test.step import step
 
 
 class LogInPage:

--- a/mavis/test/pages/programmes.py
+++ b/mavis/test/pages/programmes.py
@@ -2,10 +2,10 @@ import pandas as pd
 from playwright.sync_api import Page, expect
 from io import StringIO
 
-from ..data import TestData
-from ..models import ReportFormat, Programme
-from ..step import step
-from ..wrappers import get_current_datetime
+from mavis.test.data import TestData
+from mavis.test.models import ReportFormat, Programme, Child
+from mavis.test.step import step
+from mavis.test.wrappers import get_current_datetime
 
 
 class ProgrammesPage:
@@ -79,8 +79,8 @@ class ProgrammesPage:
         self.continue_button.click()
 
     @step("Click on {1}")
-    def click_child(self, child_name: str):
-        self.page.get_by_role("link", name=child_name).click()
+    def click_child(self, child: Child):
+        self.page.get_by_role("link", name=str(child)).click()
 
     def navigate_to_cohort_import(self, programme: Programme):
         self.click_programme(programme)

--- a/mavis/test/pages/school_moves.py
+++ b/mavis/test/pages/school_moves.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pandas import DataFrame
 from io import StringIO
 
-from ..step import step
+from mavis.test.step import step
 
 
 def get_child_full_name(first_name: str, last_name: str) -> str:

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -249,16 +249,16 @@ class SessionsPage:
         self.file_input.set_input_files(file_path)
 
     @step("Click on child {1}")
-    def click_child(self, child_name: str):
+    def click_child(self, child: Child):
         with self.page.expect_navigation():
-            self.page.get_by_role("heading", name=child_name).get_by_role(
+            self.page.get_by_role("heading", name=str(child)).get_by_role(
                 "link"
             ).first.click()
 
     @step("Search and click on {1}")
-    def search_and_click_child(self, child_name: str):
-        self.filter_name_textbox.fill(child_name)
-        self.click_child(child_name)
+    def search_and_click_child(self, child: Child):
+        self.filter_name_textbox.fill(str(child))
+        self.click_child(child)
 
     @step("Click on Update triage outcome")
     def click_update_triage_outcome(self):
@@ -355,13 +355,13 @@ class SessionsPage:
         self.click_today()
         self.click_location(location)
 
-    def navigate_to_gillick_competence(self, child: str, programme: Programme):
+    def navigate_to_gillick_competence(self, child: Child, programme: Programme):
         self.click_consent_tab()
         self.click_child(child)
         self.click_programme_tab(programme)
         self.click_assess_gillick_competence()
 
-    def navigate_to_consent_response(self, child: str, programme: Programme):
+    def navigate_to_consent_response(self, child: Child, programme: Programme):
         self.click_child(child)
         self.click_programme_tab(programme)
         self.click_get_verbal_consent()
@@ -369,7 +369,7 @@ class SessionsPage:
     def navigate_to_verbal_consent_response(self):
         self.click_get_verbal_consent()
 
-    def navigate_to_update_triage_outcome(self, child: str, programme: Programme):
+    def navigate_to_update_triage_outcome(self, child: Child, programme: Programme):
         self.click_child(child)
         self.click_programme_tab(programme)
         self.click_update_triage_outcome()
@@ -446,8 +446,8 @@ class SessionsPage:
             expect(self.page.get_by_role("blockquote").nth(i)).to_have_text(note)
 
     @step("Check note {2} appears in search for {1}")
-    def check_note_appears_in_search(self, child: str, note: str):
-        heading = self.page.get_by_role("heading", name=child)
+    def check_note_appears_in_search(self, child: Child, note: str):
+        heading = self.page.get_by_role("heading", name=str(child))
         next_element = heading.locator("xpath=following-sibling::*[1]")
         expect(next_element.get_by_role("blockquote")).to_have_text(note)
 
@@ -673,9 +673,9 @@ class SessionsPage:
             self.page.get_by_role("checkbox", name=f"Year {year_group}").check()
         self.click_continue_button()
 
-    def register_child_as_attending(self, child_name: str):
+    def register_child_as_attending(self, child: Child):
         self.click_register_tab()
-        self.search_for(child_name)
+        self.search_for(str(child))
         self.click_on_attending()
 
     def verify_search(self):
@@ -737,11 +737,11 @@ class SessionsPage:
             )
 
     def verify_consent_filters(self, children):
-        child_name = str(children[0])
+        child = children[0]
         self.review_no_consent_response_link.click()
-        self.page.get_by_role("link", name=child_name).click()
+        self.page.get_by_role("link", name=str(child)).click()
         self.click_get_verbal_consent()
-        self.click_parent_radio_button(children[0].parents[0].full_name)
+        self.click_parent_radio_button(child.parents[0].full_name)
         self.click_continue_button()
         self.click_continue_button()  # Parent details
         self.in_person_radio.click()

--- a/mavis/test/pages/start.py
+++ b/mavis/test/pages/start.py
@@ -1,6 +1,6 @@
 from playwright.sync_api import Page
 
-from ..step import step
+from mavis.test.step import step
 
 
 class StartPage:

--- a/mavis/test/pages/vaccines.py
+++ b/mavis/test/pages/vaccines.py
@@ -2,8 +2,8 @@ from datetime import date
 
 from playwright.sync_api import Page, expect
 
-from ..models import Vaccine
-from ..step import step
+from mavis.test.models import Vaccine
+from mavis.test.step import step
 
 
 class BatchExpiryDateMixin:

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -92,10 +92,10 @@ def setup_mav_853(
 
 
 def test_headers_and_filter(setup_children_page, children_page, children):
-    child_name = str(children[0])
+    child = children[0]
 
     children_page.verify_headers()
-    children_page.search_for_a_child(child_name)
+    children_page.search_for_a_child_name(str(child))
     children_page.assert_n_children_found(1)
 
 
@@ -108,10 +108,10 @@ def test_details_mav_853(setup_mav_853, children_page, schools, children):
     3. Expected: patient details can be seen
     Actual: crash
     """
-    child_name = str(children[0])
+    child = children[0]
 
-    children_page.search_for_a_child(child_name)
-    children_page.click_record_for_child(child_name)
+    children_page.search_for_a_child_name(str(child))
+    children_page.click_record_for_child(child)
     # Verify activity log
     children_page.click_activity_log()
     children_page.expect_text_in_main("Vaccinated with Gardasil 9")
@@ -123,12 +123,12 @@ def test_details_mav_853(setup_mav_853, children_page, schools, children):
 
 @pytest.mark.bug
 def test_change_nhsno(setup_change_nhsno, children_page, children):
-    child_name = str(children[0])
+    child = children[0]
 
-    children_page.search_for_a_child(child_name)
-    children_page.click_record_for_child(child_name)
+    children_page.search_for_a_child_name(str(child))
+    children_page.click_record_for_child(child)
     children_page.click_edit_child_record()
     children_page.click_change_nhs_no()
-    children_page.fill_nhs_no_for_child(child_name, "9123456789")
+    children_page.fill_nhs_no_for_child(child, "9123456789")
     children_page.click_continue()
     children_page.expect_text_in_main("Enter a valid NHS number")

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -47,7 +47,8 @@ def test_archive(
     consent_response_page,
     unmatched_consent_responses_page,
 ):
-    unmatched_consent_responses_page.click_child(*children[0].name)
+    child = children[0]
+    unmatched_consent_responses_page.click_child(child)
 
     consent_response_page.click_archive()
     archive_consent_response_page.archive(notes="Some notes.")
@@ -68,7 +69,7 @@ def test_match(
     unmatched_consent_responses_page,
     import_records_page,
 ):
-    child_name = children[0].name
+    child = children[0]
     dashboard_page.click_mavis()
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
@@ -77,19 +78,17 @@ def test_match(
     dashboard_page.click_mavis()
     dashboard_page.click_unmatched_consent_responses()
 
-    unmatched_consent_responses_page.click_child(*child_name)
+    unmatched_consent_responses_page.click_child(child)
 
     consent_response_page.click_match()
-    match_consent_response_page.match(*child_name)
+    match_consent_response_page.match(child)
 
     expect(unmatched_consent_responses_page.matched_alert).to_be_visible()
     expect(unmatched_consent_responses_page.empty_paragraph).to_be_visible()
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(
-        str(children[0]), schools[0]
-    )
+    children_page.verify_activity_log_for_created_or_matched_child(child, schools[0])
 
 
 patient = random.choice(pds_test_data.child_patients_without_date_of_death)
@@ -120,8 +119,8 @@ def test_create_with_nhs_number(
     schools,
     unmatched_consent_responses_page,
 ):
-    child_name = children[0].name
-    unmatched_consent_responses_page.click_child(*child_name)
+    child = children[0]
+    unmatched_consent_responses_page.click_child(child)
 
     consent_response_page.click_create_new_record()
     create_new_record_consent_response_page.create_new_record()
@@ -131,9 +130,7 @@ def test_create_with_nhs_number(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(
-        f"{child_name[1]}, {child_name[0]}", schools[0]
-    )
+    children_page.verify_activity_log_for_created_or_matched_child(child, schools[0])
 
 
 @allure.issue("MAVIS-1781")
@@ -146,7 +143,8 @@ def test_create_with_no_nhs_number(
     schools,
     unmatched_consent_responses_page,
 ):
-    unmatched_consent_responses_page.click_child(*children[0].name)
+    child = children[0]
+    unmatched_consent_responses_page.click_child(child)
 
     consent_response_page.click_create_new_record()
     create_new_record_consent_response_page.create_new_record()
@@ -156,6 +154,4 @@ def test_create_with_no_nhs_number(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(
-        str(children[0]), schools[0]
-    )
+    children_page.verify_activity_log_for_created_or_matched_child(child, schools[0])

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -29,7 +29,7 @@ def test_e2e(
     children,
     programmes_enabled,
 ):
-    child_name = str(children[0])
+    child = children[0]
 
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
@@ -38,7 +38,7 @@ def test_e2e(
     dashboard_page.click_sessions()
     sessions_page.schedule_a_valid_session(schools[0], programmes_enabled)
     sessions_page.click_consent_tab()
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
     consent_page.parent_verbal_positive(
         parent=children[0].parents[0], change_phone=False
     )

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -242,14 +242,14 @@ def test_vaccs_historic_negative_file_upload(setup_vaccs, import_records_page):
 def test_vaccs_historic_no_urn_mav_855(
     setup_vaccs, schools, dashboard_page, import_records_page, children_page, children
 ):
-    child_name = str(children[0])
+    child = children[0]
 
     import_records_page.upload_and_verify_output(VaccsFileMapping.MAV_855)
     dashboard_page.click_mavis()
     dashboard_page.click_children()
 
-    children_page.search_for_a_child(child_name)
-    children_page.click_record_for_child(child_name)
+    children_page.search_for_a_child_name(str(child))
+    children_page.click_record_for_child(child)
     children_page.click_vaccination_details(schools[0])
     children_page.expect_text_in_main(str(schools[0]))
 

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -163,7 +163,7 @@ def test_cohorts_readd_to_cohort(
         Actual Result:
         Server error page and user cannot bring the child back into the cohort
     """
-    child_name = str(children[0])
+    child = children[0]
 
     input_file_path, _ = import_records_page.upload_and_verify_output(
         CohortsFileMapping.FIXED_CHILD_YEAR_8
@@ -171,7 +171,7 @@ def test_cohorts_readd_to_cohort(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.remove_child_from_cohort(child_name=child_name)
+    children_page.remove_child_from_cohort(child)
     dashboard_page.click_mavis()
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
@@ -197,7 +197,7 @@ def test_rav_triage_consent_given(
     consent_page,
     children,
 ):
-    child_name = str(children[0])
+    child = children[0]
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.navigate_to_class_list_import()
 
@@ -207,8 +207,8 @@ def test_rav_triage_consent_given(
 
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.click_consent_tab()
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
-    consent_page.parent_phone_positive(children[0].parents[0])
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    consent_page.parent_phone_positive(child.parents[0])
 
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
@@ -216,7 +216,7 @@ def test_rav_triage_consent_given(
     sessions_page.navigate_to_scheduled_sessions(schools[0])
 
     sessions_page.click_register_tab()
-    sessions_page.navigate_to_update_triage_outcome(child_name, Programme.HPV)
+    sessions_page.navigate_to_update_triage_outcome(child, Programme.HPV)
     sessions_page.select_yes_safe_to_vaccinate()
     sessions_page.click_save_triage()
     sessions_page.verify_triage_updated_for_child()
@@ -232,7 +232,7 @@ def test_rav_triage_consent_refused(
     consent_page,
     children,
 ):
-    child_name = str(children[0])
+    child = children[0]
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.navigate_to_class_list_import()
 
@@ -241,16 +241,16 @@ def test_rav_triage_consent_refused(
     dashboard_page.click_sessions()
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.click_consent_tab()
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
 
-    consent_page.parent_paper_refuse_consent(children[0].parents[0])
-    consent_page.expect_text_in_main(child_name)
+    consent_page.parent_paper_refuse_consent(child.parents[0])
+    consent_page.expect_text_in_main(str(child))
 
     sessions_page.select_consent_refused()
-    sessions_page.click_child(child_name)
+    sessions_page.click_child(child)
     sessions_page.click_session_activity_and_notes()
     sessions_page.expect_main_to_contain_text(
-        f"Consent refused by {children[0].parents[0].name_and_relationship}"
+        f"Consent refused by {child.parents[0].name_and_relationship}"
     )
 
 
@@ -258,9 +258,11 @@ def test_rav_triage_consent_refused(
 @pytest.mark.rav
 @pytest.mark.bug
 def test_rav_edit_dose_to_not_given(setup_mavis_1729, programmes_page, children):
+    child = children[0]
+
     programmes_page.click_programme(Programme.HPV)
     programmes_page.click_vaccinations()
-    programmes_page.click_child(str(children[0]))
+    programmes_page.click_child(child)
     programmes_page.click_edit_vaccination_record()
     programmes_page.click_change_outcome()
     programmes_page.click_they_refused_it()
@@ -281,19 +283,17 @@ def test_rav_verify_excel_mav_854(
     consent_page,
     children,
 ):
-    child_name = str(children[0])
+    child = children[0]
     batch_name = setup_mav_854
 
-    children_page.search_for_a_child(child_name)
-    children_page.click_record_for_child(child_name)
+    children_page.search_for_a_child_name(str(child))
+    children_page.click_record_for_child(child)
     sessions_page.click_session("Community clinics", Programme.HPV)
     sessions_page.click_get_verbal_consent()
-    consent_page.parent_verbal_positive(
-        parent=children[0].parents[0], change_phone=False
-    )
-    sessions_page.register_child_as_attending(child_name=child_name)
+    consent_page.parent_verbal_positive(parent=child.parents[0], change_phone=False)
+    sessions_page.register_child_as_attending(child)
     sessions_page.record_vaccs_for_child(
-        child=children[0],
+        child=child,
         programme=Programme.HPV,
         batch_name=batch_name,
         at_school=False,

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -68,21 +68,19 @@ def test_programmes_rav_pre_screening_questions(
     sessions_page.search_child(child)
     sessions_page.click_programme_tab(Programme.HPV)
     sessions_page.click_get_verbal_consent()
-    consent_page.parent_verbal_positive(
-        parent=children[0].parents[0], change_phone=False
-    )
+    consent_page.parent_verbal_positive(parent=child.parents[0], change_phone=False)
     sessions_page.search_child(child)
     sessions_page.click_programme_tab(Programme.MENACWY)
     sessions_page.click_get_verbal_consent()
     consent_page.parent_verbal_positive(
-        parent=children[0].parents[0], change_phone=False, programme=Programme.MENACWY
+        parent=child.parents[0], change_phone=False, programme=Programme.MENACWY
     )
 
     sessions_page.search_child(child)
     sessions_page.click_programme_tab(Programme.TD_IPV)
     sessions_page.click_get_verbal_consent()
     consent_page.parent_verbal_positive(
-        parent=children[0].parents[0], change_phone=False, programme=Programme.TD_IPV
+        parent=child.parents[0], change_phone=False, programme=Programme.TD_IPV
     )
     sessions_page.register_child_as_attending(str(child))
     sessions_page.record_vaccs_for_child(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -94,19 +94,18 @@ def test_verify_consent_filters(setup_fixed_child, sessions_page, children):
 
 @allure.issue("MAV-1265")
 def test_recording_notes(setup_fixed_child, sessions_page, schools, children):
-    child = str(children[0])
+    child = children[0]
     NOTE_1 = "Note 1"
     NOTE_2 = "Note 2"
 
     sessions_page.click_consent_tab()
-    sessions_page.search_for(child)
-    sessions_page.click_child(child)
+    sessions_page.search_child(child)
     sessions_page.click_session_activity_and_notes()
     sessions_page.add_note(NOTE_1)
     sessions_page.add_note(NOTE_2)
     sessions_page.click_location(schools[0])
     sessions_page.click_consent_tab()
-    sessions_page.search_for(child)
+    sessions_page.search_for(str(child))
     sessions_page.check_note_appears_in_search(child, NOTE_2)
     sessions_page.click_child(child)
     sessions_page.click_session_activity_and_notes()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -44,10 +44,10 @@ def setup_fixed_child(setup_session_with_file_upload):
 
 
 def test_gillick_competence(setup_fixed_child, schools, sessions_page, children):
-    child_name = str(children[0])
+    child = children[0]
 
     sessions_page.navigate_to_todays_sessions(schools[0])
-    sessions_page.navigate_to_gillick_competence(child_name, Programme.HPV)
+    sessions_page.navigate_to_gillick_competence(child, Programme.HPV)
 
     sessions_page.add_gillick_competence(
         is_competent=True, competence_details="Gillick competent"
@@ -60,10 +60,10 @@ def test_gillick_competence(setup_fixed_child, schools, sessions_page, children)
 
 @allure.issue("MAV-955")
 def test_gillick_competence_notes(setup_fixed_child, schools, sessions_page, children):
-    child_name = str(children[0])
+    child = children[0]
 
     sessions_page.navigate_to_todays_sessions(schools[0])
-    sessions_page.navigate_to_gillick_competence(child_name, Programme.HPV)
+    sessions_page.navigate_to_gillick_competence(child, Programme.HPV)
 
     sessions_page.answer_gillick_competence_questions(is_competent=True)
     sessions_page.fill_assessment_notes_with_string_of_length(1001)
@@ -85,31 +85,31 @@ def test_gillick_competence_notes(setup_fixed_child, schools, sessions_page, chi
 def test_invalid_consent(
     setup_fixed_child, sessions_page, schools, consent_page, children
 ):
-    child_name = str(children[0])
+    child = children[0]
 
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
-    consent_page.parent_verbal_no_response(children[0].parents[0])
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    consent_page.parent_verbal_no_response(child.parents[0])
     sessions_page.select_no_response()
 
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
-    consent_page.parent_verbal_refuse_consent(children[0].parents[1])
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    consent_page.parent_verbal_refuse_consent(child.parents[1])
 
-    sessions_page.click_child(child_name)
+    sessions_page.click_child(child)
     sessions_page.click_programme_tab(Programme.HPV)
-    sessions_page.invalidate_parent_refusal(children[0].parents[1])
+    sessions_page.invalidate_parent_refusal(child.parents[1])
     sessions_page.click_session_activity_and_notes()
 
     sessions_page.expect_main_to_contain_text(
-        f"Consent from {children[0].parents[1].full_name} invalidated"
+        f"Consent from {child.parents[1].full_name} invalidated"
     )
     sessions_page.expect_main_to_contain_text(
-        f"Consent refused by {children[0].parents[1].name_and_relationship}"
+        f"Consent refused by {child.parents[1].name_and_relationship}"
     )
     sessions_page.expect_main_to_contain_text(
-        f"Consent not_provided by {children[0].parents[0].name_and_relationship}"
+        f"Consent not_provided by {child.parents[0].name_and_relationship}"
     )
 
 
@@ -118,35 +118,35 @@ def test_invalid_consent(
 def test_parent_provides_consent_twice(
     setup_fixed_child, sessions_page, schools, consent_page, children
 ):
-    child_name = str(children[0])
+    child = children[0]
 
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
 
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
-    consent_page.parent_written_positive(children[0].parents[0])
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    consent_page.parent_written_positive(child.parents[0])
     sessions_page.select_consent_given()
 
-    sessions_page.navigate_to_update_triage_outcome(child_name, Programme.HPV)
+    sessions_page.navigate_to_update_triage_outcome(child, Programme.HPV)
     consent_page.update_triage_outcome_positive()
 
     sessions_page.click_get_verbal_consent()
-    consent_page.parent_verbal_refuse_consent(children[0].parents[0])
+    consent_page.parent_verbal_refuse_consent(child.parents[0])
     sessions_page.select_consent_refused()
 
-    sessions_page.click_child(child_name)
+    sessions_page.click_child(child)
     sessions_page.click_programme_tab(Programme.HPV)
     sessions_page.expect_main_to_contain_text(
-        f"{children[0].parents[0].relationship} refused to give consent."
+        f"{child.parents[0].relationship} refused to give consent."
     )
     sessions_page.click_session_activity_and_notes()
     sessions_page.expect_main_to_contain_text(
-        f"Consent refused by {children[0].parents[0].name_and_relationship}"
+        f"Consent refused by {child.parents[0].name_and_relationship}"
     )
     sessions_page.expect_main_to_contain_text("Triaged decision: Safe to vaccinate")
     sessions_page.expect_main_to_contain_text(
-        f"Consent given by {children[0].parents[0].name_and_relationship}"
+        f"Consent given by {child.parents[0].name_and_relationship}"
     )
 
 
@@ -155,22 +155,20 @@ def test_parent_provides_consent_twice(
 def test_conflicting_consent_with_gillick_consent(
     setup_fixed_child, sessions_page, schools, consent_page, children
 ):
-    child_name = str(children[0])
+    child = children[0]
 
     sessions_page.navigate_to_scheduled_sessions(schools[0])
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
-    consent_page.parent_verbal_positive(
-        parent=children[0].parents[0], change_phone=False
-    )
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    consent_page.parent_verbal_positive(parent=child.parents[0], change_phone=False)
     sessions_page.select_consent_given()
 
-    sessions_page.navigate_to_consent_response(child_name, Programme.HPV)
-    consent_page.parent_verbal_refuse_consent(children[0].parents[1])
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    consent_page.parent_verbal_refuse_consent(child.parents[1])
     sessions_page.select_conflicting_consent()
 
-    sessions_page.click_child(child_name)
+    sessions_page.click_child(child)
     sessions_page.click_programme_tab(Programme.HPV)
     sessions_page.expect_main_to_contain_text("Conflicting consent")
     sessions_page.expect_main_to_contain_text(
@@ -183,16 +181,16 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.expect_main_to_contain_text("HPV: Safe to vaccinate")
     sessions_page.click_get_verbal_consent()
     consent_page.child_consent_verbal_positive()
-    sessions_page.expect_main_to_contain_text(f"Consent recorded for {child_name}")
+    sessions_page.expect_main_to_contain_text(f"Consent recorded for {str(child)}")
     sessions_page.select_consent_given()
-    sessions_page.click_child(child_name)
+    sessions_page.click_child(child)
     sessions_page.click_programme_tab(Programme.HPV)
     sessions_page.expect_main_to_contain_text("HPV: Safe to vaccinate")
     sessions_page.expect_main_to_contain_text(
-        f"NURSE, Nurse decided that {child_name} is safe to vaccinate."
+        f"NURSE, Nurse decided that {str(child)} is safe to vaccinate."
     )
     sessions_page.expect_main_to_contain_text("Consent given")
     sessions_page.click_session_activity_and_notes()
     sessions_page.expect_main_to_contain_text(
-        f"Consent given by {child_name} (Child (Gillick competent))"
+        f"Consent given by {str(child)} (Child (Gillick competent))"
     )


### PR DESCRIPTION
Functions should use the `Child` object directly, instead of the current mix of `Child` objects, child first/last names and child full names.