### PR TITLE
Create orphan commit gh pages

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -89,8 +89,10 @@ jobs:
           cd gh-pages
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git stash
+          git pull --rebase origin gh-pages
           git checkout --orphan temp-pages
-          git add .
+          git stash apply && git checkout --theirs -- . && git add .
           git diff --cached --quiet || git commit -m "Deploy fresh pages"
           git push --force origin HEAD:gh-pages
         env:

--- a/.github/workflows/functional_selected_device.yaml
+++ b/.github/workflows/functional_selected_device.yaml
@@ -125,8 +125,10 @@ jobs:
           cd gh-pages
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git stash
+          git pull --rebase origin gh-pages
           git checkout --orphan temp-pages
-          git add .
+          git stash apply && git checkout --theirs -- . && git add .
           git diff --cached --quiet || git commit -m "Deploy fresh pages"
           git push --force origin HEAD:gh-pages
         env:


### PR DESCRIPTION
Follows #455 

Ensures that the `gh-pages` branch only has one "orphan" commit, so we don't build up huge amounts of git history