### PR TITLE
Use appropriate schools for each programme

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -8,7 +8,7 @@ import nhs_number
 import pandas as pd
 from faker import Faker
 
-from mavis.test.models import Child, Organisation, School, User
+from mavis.test.models import Child, Organisation, School, User, Programme
 from mavis.test.wrappers import (
     get_current_datetime,
     get_current_time,
@@ -109,7 +109,7 @@ class TestData:
     def __init__(
         self,
         organisation: Organisation,
-        schools: List[School],
+        schools: dict[str, list[School]],
         nurse: User,
         children: List[Child],
     ):
@@ -130,6 +130,7 @@ class TestData:
         template_path: Path,
         file_name_prefix: str,
         session_id: Optional[str] = None,
+        programme_group: str = Programme.HPV.group,
     ) -> Path:
         static_replacements = {
             "<<VACCS_DATE>>": get_current_datetime()[:8],
@@ -142,7 +143,8 @@ class TestData:
             static_replacements["<<ORG_CODE>>"] = self.organisation.ods_code
 
         if self.schools:
-            for index, school in enumerate(self.schools):
+            schools = self.schools[programme_group]
+            for index, school in enumerate(schools):
                 static_replacements[f"<<SCHOOL_{index}_NAME>>"] = school.name
                 static_replacements[f"<<SCHOOL_{index}_URN>>"] = school.urn
 
@@ -247,11 +249,13 @@ class TestData:
         self,
         file_mapping: FileMapping,
         session_id: Optional[str] = None,
+        programme_group: str = Programme.HPV.group,
     ) -> tuple[Path, Path]:
         _input_file_path = self.create_file_from_template(
             template_path=file_mapping.input_template_path,
             file_name_prefix=str(file_mapping),
             session_id=session_id,
+            programme_group=programme_group,
         )
 
         _output_file_path = file_mapping.output_path

--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -48,11 +48,12 @@ def get_online_consent_url(
     programmes_enabled,
 ):
     def wrapper(*programmes):
+        school = schools[programmes[0].group][0]
         try:
             log_in_page.navigate()
             log_in_page.log_in_and_select_organisation(nurse, organisation)
             dashboard_page.click_sessions()
-            sessions_page.schedule_a_valid_session(schools[0], programmes_enabled)
+            sessions_page.schedule_a_valid_session(school, programmes_enabled)
             url = sessions_page.get_online_consent_url(*programmes)
             log_in_page.log_out()
             yield url
@@ -60,7 +61,7 @@ def get_online_consent_url(
             log_in_page.navigate()
             log_in_page.log_in_and_select_organisation(nurse, organisation)
             dashboard_page.click_sessions()
-            sessions_page.delete_all_sessions(schools[0])
+            sessions_page.delete_all_sessions(school)
             log_in_page.log_out()
 
     return wrapper

--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -13,8 +13,10 @@ class Programme(StrEnum):
     TD_IPV = "Td/IPV"
 
     @property
-    def is_doubles(self) -> bool:
-        return self == self.MENACWY or self == self.TD_IPV
+    def group(self):
+        if self in {Programme.MENACWY, Programme.TD_IPV}:
+            return "doubles"
+        return self.value
 
     @property
     def vaccines(self):
@@ -59,13 +61,23 @@ class Programme(StrEnum):
             PreScreeningCheck.KNOW_VACCINATION,
         ]
 
-        if self.is_doubles:
+        if self.group == "doubles":
             checks.append(PreScreeningCheck.NO_RELEVANT_MEDICATION)
 
         if self == self.TD_IPV:
             checks.append(PreScreeningCheck.NOT_PREGNANT)
 
         return checks
+
+    @property
+    def year_groups(self) -> list[str]:
+        match self:
+            case self.FLU:
+                return ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]
+            case self.HPV:
+                return ["8", "9", "10", "11"]
+            case self.MENACWY | self.TD_IPV:
+                return ["9", "10", "11"]
 
 
 class Vaccine(StrEnum):

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -10,6 +10,7 @@ from mavis.test.wrappers import (
     format_datetime_for_upload_link,
     reload_until_element_is_visible,
 )
+from mavis.test.models import Programme
 
 
 class ImportRecordsPage:
@@ -122,9 +123,12 @@ class ImportRecordsPage:
         self,
         file_mapping: FileMapping,
         session_id: Optional[str] = None,
+        programme_group: str = Programme.HPV.group,
     ) -> tuple[Path, Path]:
         _input_file_path, _output_file_path = self.test_data.get_file_paths(
-            file_mapping=file_mapping, session_id=session_id
+            file_mapping=file_mapping,
+            session_id=session_id,
+            programme_group=programme_group,
         )
         _scenario_list = self.test_data.read_scenario_list_from_file(_input_file_path)
 

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -17,14 +17,15 @@ def setup_children_session(
     programmes_enabled,
 ):
     def _setup(class_list_file):
+        school = schools[Programme.HPV][0]
         try:
             dashboard_page.click_sessions()
             sessions_page.schedule_a_valid_session(
-                schools[0], programmes_enabled, for_today=True
+                school, programmes_enabled, for_today=True
             )
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.click_location(schools[0])
+            sessions_page.click_location(school)
             sessions_page.navigate_to_class_list_import()
             import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
@@ -33,7 +34,7 @@ def setup_children_session(
         finally:
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.delete_all_sessions(schools[0])
+            sessions_page.delete_all_sessions(school)
 
     return _setup
 
@@ -58,16 +59,17 @@ def setup_mav_853(
     sessions_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
-            schools[0], programmes_enabled, for_today=True
+            school, programmes_enabled, for_today=True
         )
         import_records_page.navigate_to_class_list_import()
         import_records_page.upload_and_verify_output(
             ClassFileMapping.RANDOM_CHILD_YEAR_9
         )
-        sessions_page.click_location(schools[0])
+        sessions_page.click_location(school)
         session_id = sessions_page.get_session_id_from_offline_excel()
         dashboard_page.click_mavis()
         dashboard_page.click_programmes()
@@ -88,7 +90,7 @@ def setup_mav_853(
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 def test_headers_and_filter(setup_children_page, children_page, children):
@@ -109,6 +111,7 @@ def test_details_mav_853(setup_mav_853, children_page, schools, children):
     Actual: crash
     """
     child = children[0]
+    school = schools[Programme.HPV][0]
 
     children_page.search_for_a_child_name(str(child))
     children_page.click_record_for_child(child)
@@ -117,7 +120,7 @@ def test_details_mav_853(setup_mav_853, children_page, schools, children):
     children_page.expect_text_in_main("Vaccinated with Gardasil 9")
     # Verify vaccination record
     children_page.click_child_record()
-    children_page.click_vaccination_details(schools[0])
+    children_page.click_vaccination_details(school)
     children_page.expect_text_in_main("OutcomeVaccinated")
 
 

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -24,10 +24,11 @@ def give_online_consent(
     schools,
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
     page.goto(online_consent_url)
     start_page.start()
-    consent_page.fill_details(child, child.parents[0], schools)
+    consent_page.fill_details(child, child.parents[0], school)
     consent_page.agree_to_hpv_vaccination()
     consent_page.fill_address_details(*child.address)
     consent_page.answer_health_questions(4, health_question=False)
@@ -67,6 +68,8 @@ def test_match(
     import_records_page,
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
+
     dashboard_page.click_mavis()
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
@@ -85,7 +88,7 @@ def test_match(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(child, schools[0])
+    children_page.verify_activity_log_for_created_or_matched_child(child, school)
 
 
 patient = random.choice(pds_test_data.child_patients_without_date_of_death)
@@ -116,6 +119,8 @@ def test_create_with_nhs_number(
     unmatched_consent_responses_page,
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
+
     unmatched_consent_responses_page.click_child(child)
 
     consent_response_page.click_create_new_record()
@@ -126,7 +131,7 @@ def test_create_with_nhs_number(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(child, schools[0])
+    children_page.verify_activity_log_for_created_or_matched_child(child, school)
 
 
 def test_create_with_no_nhs_number(
@@ -139,6 +144,7 @@ def test_create_with_no_nhs_number(
     unmatched_consent_responses_page,
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
     unmatched_consent_responses_page.click_child(child)
 
     consent_response_page.click_create_new_record()
@@ -149,4 +155,4 @@ def test_create_with_no_nhs_number(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(child, schools[0])
+    children_page.verify_activity_log_for_created_or_matched_child(child, school)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -10,12 +10,14 @@ pytestmark = pytest.mark.e2e
 def setup_tests(
     nurse, organisation, schools, log_in_page, dashboard_page, sessions_page, start_page
 ):
+    school = schools[Programme.HPV][0]
+
     start_page.navigate_and_start()
     log_in_page.log_in_and_select_organisation(nurse, organisation)
     yield
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.delete_all_sessions(schools[0])
+    sessions_page.delete_all_sessions(school)
     log_in_page.log_out()
 
 
@@ -30,13 +32,14 @@ def test_e2e(
     programmes_enabled,
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
     import_records_page.upload_and_verify_output(CohortsFileMapping.FIXED_CHILD_YEAR_9)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.schedule_a_valid_session(schools[0], programmes_enabled)
+    sessions_page.schedule_a_valid_session(school, programmes_enabled)
     sessions_page.click_consent_tab()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
     consent_page.parent_verbal_positive(

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mavis.test.data import ChildFileMapping, ClassFileMapping, VaccsFileMapping
+from mavis.test.models import Programme
 
 
 @pytest.fixture
@@ -18,16 +19,17 @@ def setup_class_list(
     import_records_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(schools[0], programmes_enabled)
+        sessions_page.schedule_a_valid_session(school, programmes_enabled)
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
         yield
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 @pytest.fixture
@@ -39,16 +41,17 @@ def setup_vaccs(
     import_records_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
-            schools[0], programmes_enabled, for_today=True
+            school, programmes_enabled, for_today=True
         )
         import_records_page.navigate_to_class_list_import()
         import_records_page.upload_and_verify_output(
             ClassFileMapping.RANDOM_CHILD_YEAR_9
         )
-        sessions_page.click_location(schools[0])
+        sessions_page.click_location(school)
         session_id = sessions_page.get_session_id_from_offline_excel()
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
@@ -57,7 +60,7 @@ def setup_vaccs(
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 @pytest.fixture
@@ -69,10 +72,11 @@ def setup_vaccs_systmone(
     import_records_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
-            schools[0], programmes_enabled, for_today=True
+            school, programmes_enabled, for_today=True
         )
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
@@ -81,7 +85,7 @@ def setup_vaccs_systmone(
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 ########################################### CHILD LIST ###########################################
@@ -130,7 +134,8 @@ def test_child_list_space_normalization(
 def test_class_list_file_upload_positive(
     setup_class_list, schools, import_records_page
 ):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school))
     import_records_page.upload_and_verify_output(ClassFileMapping.POSITIVE)
 
 
@@ -138,31 +143,36 @@ def test_class_list_file_upload_positive(
 def test_class_list_file_upload_negative(
     setup_class_list, schools, import_records_page
 ):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school))
     import_records_page.upload_and_verify_output(ClassFileMapping.NEGATIVE)
 
 
 @pytest.mark.classlist
 def test_class_list_file_structure(setup_class_list, schools, import_records_page):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school))
     import_records_page.upload_and_verify_output(ClassFileMapping.INVALID_STRUCTURE)
 
 
 @pytest.mark.classlist
 def test_class_list_no_record(setup_class_list, schools, import_records_page):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school))
     import_records_page.upload_and_verify_output(ClassFileMapping.HEADER_ONLY)
 
 
 @pytest.mark.classlist
 def test_class_list_empty_file(setup_class_list, schools, import_records_page):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school))
     import_records_page.upload_and_verify_output(ClassFileMapping.EMPTY_FILE)
 
 
 @pytest.mark.classlist
 def test_class_list_year_group(setup_class_list, schools, import_records_page):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]), [8])
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school), [8])
     import_records_page.upload_and_verify_output(ClassFileMapping.WRONG_YEAR_GROUP)
 
 
@@ -171,7 +181,8 @@ def test_class_list_year_group(setup_class_list, schools, import_records_page):
 def test_class_list_space_normalization(
     setup_class_list, schools, import_records_page, children_page, dashboard_page
 ):
-    import_records_page.navigate_to_class_list_record_import(str(schools[0]))
+    school = schools[Programme.HPV][0]
+    import_records_page.navigate_to_class_list_record_import(str(school))
     input_file, _ = import_records_page.upload_and_verify_output(
         ClassFileMapping.WHITESPACE
     )
@@ -243,6 +254,7 @@ def test_vaccs_historic_no_urn_mav_855(
     setup_vaccs, schools, dashboard_page, import_records_page, children_page, children
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
     import_records_page.upload_and_verify_output(VaccsFileMapping.MAV_855)
     dashboard_page.click_mavis()
@@ -250,8 +262,8 @@ def test_vaccs_historic_no_urn_mav_855(
 
     children_page.search_for_a_child_name(str(child))
     children_page.click_record_for_child(child)
-    children_page.click_vaccination_details(schools[0])
-    children_page.expect_text_in_main(str(schools[0]))
+    children_page.click_vaccination_details(school)
+    children_page.expect_text_in_main(str(school))
 
 
 @pytest.mark.vaccinations

--- a/tests/test_online_consent_doubles.py
+++ b/tests/test_online_consent_doubles.py
@@ -18,6 +18,7 @@ def start_consent(url, page, start_page):
 
 def test_refused(consent_page, schools, children):
     child = children[0]
+    schools = schools["doubles"]
 
     consent_page.fill_details(child, child.parents[0], schools)
     consent_page.dont_agree_to_vaccination()
@@ -51,6 +52,7 @@ def test_given(
     children,
 ):
     child = children[0]
+    schools = schools["doubles"]
 
     consent_page.fill_details(child, child.parents[0], schools, change_school)
     consent_page.agree_to_doubles_vaccinations(*programmes)

--- a/tests/test_online_consent_flu.py
+++ b/tests/test_online_consent_flu.py
@@ -22,17 +22,23 @@ def start_consent(url, page, start_page):
 def setup_session_with_file_upload(
     url, log_in_as_nurse, schools, dashboard_page, sessions_page, import_records_page
 ):
+    school = schools[Programme.FLU][0]
+
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     sessions_page.click_scheduled()
-    sessions_page.click_location(schools[0])
+    sessions_page.click_location(school)
     sessions_page.navigate_to_class_list_import()
-    import_records_page.upload_and_verify_output(CohortsFileMapping.FIXED_CHILD_YEAR_9)
+    import_records_page.upload_and_verify_output(
+        CohortsFileMapping.FIXED_CHILD_YEAR_9, programme_group=Programme.FLU.group
+    )
     yield url
 
 
 def test_refused(start_consent, consent_page, schools, children):
     child = children[0]
+    schools = schools[Programme.FLU]
+
     consent_page.fill_details(child, child.parents[0], schools)
     consent_page.dont_agree_to_vaccination()
     consent_page.select_consent_not_given_reason(
@@ -58,6 +64,7 @@ def test_given(
     children,
 ):
     child = children[0]
+    schools = schools[Programme.FLU]
 
     consent_page.fill_details(child, child.parents[0], schools, False)
     consent_page.agree_to_flu_vaccination(injection=injection)
@@ -112,6 +119,7 @@ def test_correct_method_shown(
     sessions_page,
 ):
     child = children[0]
+    schools = schools[Programme.FLU]
     url = setup_session_with_file_upload
     number_of_health_questions = {
         BOTH: 11,

--- a/tests/test_online_consent_hpv.py
+++ b/tests/test_online_consent_hpv.py
@@ -18,6 +18,8 @@ def start_consent(url, page, start_page):
 
 def test_refused(consent_page, schools, children):
     child = children[0]
+    schools = schools[Programme.HPV]
+
     consent_page.fill_details(child, child.parents[0], schools)
     consent_page.dont_agree_to_vaccination()
     consent_page.select_consent_not_given_reason(
@@ -44,6 +46,8 @@ def test_given(
     children,
 ):
     child = children[0]
+    schools = schools[Programme.HPV]
+
     consent_page.fill_details(child, child.parents[0], schools, change_school)
     consent_page.agree_to_hpv_vaccination()
     consent_page.fill_address_details(*child.address)

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -20,10 +20,12 @@ def setup_reports(log_in_as_nurse, dashboard_page):
 def setup_record_a_vaccine(
     log_in_as_nurse, schools, dashboard_page, sessions_page, programmes_enabled
 ):
+    school = schools[Programme.HPV][0]
+
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
-            schools[0], programmes_enabled, for_today=True
+            school, programmes_enabled, for_today=True
         )
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
@@ -31,7 +33,7 @@ def setup_record_a_vaccine(
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 @pytest.fixture
@@ -43,16 +45,18 @@ def setup_mavis_1729(
     sessions_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
+
     try:
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
-            schools[0], programmes_enabled, for_today=True
+            school, programmes_enabled, for_today=True
         )
         import_records_page.navigate_to_class_list_import()
         import_records_page.upload_and_verify_output(
             ClassFileMapping.RANDOM_CHILD_YEAR_9
         )
-        sessions_page.click_location(schools[0])
+        sessions_page.click_location(school)
         session_id = sessions_page.get_session_id_from_offline_excel()
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
@@ -66,7 +70,7 @@ def setup_mavis_1729(
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 @pytest.fixture
@@ -79,18 +83,20 @@ def setup_mav_854(
     sessions_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
+
     try:
         batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
-            schools[0], programmes_enabled, for_today=True
+            school, programmes_enabled, for_today=True
         )
         import_records_page.navigate_to_class_list_import()
         import_records_page.upload_and_verify_output(
             ClassFileMapping.FIXED_CHILD_YEAR_9
         )
-        sessions_page.click_location(schools[0])
+        sessions_page.click_location(school)
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(
@@ -102,7 +108,7 @@ def setup_mav_854(
     finally:
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(schools[0])
+        sessions_page.delete_all_sessions(school)
 
 
 @pytest.mark.cohorts
@@ -198,14 +204,16 @@ def test_rav_triage_consent_given(
     children,
 ):
     child = children[0]
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    school = schools[Programme.HPV][0]
+
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.navigate_to_class_list_import()
 
     import_records_page.upload_and_verify_output(CohortsFileMapping.FIXED_CHILD_YEAR_9)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
 
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.click_consent_tab()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
     consent_page.parent_phone_positive(child.parents[0])
@@ -213,7 +221,7 @@ def test_rav_triage_consent_given(
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
 
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    sessions_page.navigate_to_scheduled_sessions(school)
 
     sessions_page.click_register_tab()
     sessions_page.navigate_to_update_triage_outcome(child, Programme.HPV)
@@ -233,13 +241,15 @@ def test_rav_triage_consent_refused(
     children,
 ):
     child = children[0]
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    school = schools[Programme.HPV][0]
+
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.navigate_to_class_list_import()
 
     import_records_page.upload_and_verify_output(CohortsFileMapping.FIXED_CHILD_YEAR_9)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.click_consent_tab()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
 
@@ -283,6 +293,7 @@ def test_rav_verify_excel_mav_854(
     children,
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
     batch_name = setup_mav_854
 
     children_page.search_for_a_child_name(str(child))
@@ -304,7 +315,7 @@ def test_rav_verify_excel_mav_854(
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     sessions_page.click_scheduled()
-    sessions_page.click_location(schools[0])
+    sessions_page.click_location(school)
     assert sessions_page.get_session_id_from_offline_excel()
 
 

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -16,16 +16,18 @@ def setup_mav_965(
     sessions_page,
     programmes_enabled,
 ):
+    school = schools["doubles"][0]
+
     gardasil_9_batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
     menquadfi_batch_name = add_vaccine_batch(Vaccine.MENQUADFI)
     revaxis_batch_name = add_vaccine_batch(Vaccine.REVAXIS)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.schedule_a_valid_session(
-        schools[0], programmes_enabled, for_today=True
-    )
+    sessions_page.schedule_a_valid_session(school, programmes_enabled, for_today=True)
     import_records_page.navigate_to_class_list_import()
-    import_records_page.upload_and_verify_output(ClassFileMapping.FIXED_CHILD_YEAR_10)
+    import_records_page.upload_and_verify_output(
+        ClassFileMapping.FIXED_CHILD_YEAR_10, programme_group="doubles"
+    )
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
     return gardasil_9_batch_name, menquadfi_batch_name, revaxis_batch_name
@@ -59,11 +61,12 @@ def test_programmes_rav_pre_screening_questions(
     """
 
     child = children[0]
+    school = schools["doubles"][0]
     gardasil_9_batch_name, menquadfi_batch_name, revaxis_batch_name = setup_mav_965
 
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.click_location(schools[0])
+    sessions_page.click_location(school)
     sessions_page.click_consent_tab()
     sessions_page.search_child(child)
     sessions_page.click_programme_tab(Programme.HPV)

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -2,6 +2,7 @@ import pytest
 from playwright.sync_api import expect
 
 from mavis.test.data import ClassFileMapping
+from mavis.test.models import Programme
 
 pytestmark = pytest.mark.school_moves
 
@@ -16,6 +17,7 @@ def setup_confirm_and_ignore(
     import_records_page,
     programmes_enabled,
 ):
+    schools = schools[Programme.HPV]
     # We need to make sure we're uploading the same class with the same NHS numbers.
     input_file_path, output_file_path = test_data.get_file_paths(
         ClassFileMapping.TWO_FIXED_CHILDREN_YEAR_9
@@ -63,6 +65,7 @@ def test_confirm_and_ignore(
     review_school_move_page,
     children,
 ):
+    schools = schools[Programme.HPV]
     child_1, child_2 = children[0], children[1]
 
     row1 = school_moves_page.get_row_for_child(*child_1.name)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2,6 +2,7 @@ import pytest
 
 from mavis.test.data import ClassFileMapping
 from mavis.test.annotations import issue
+from mavis.test.models import Programme
 
 pytestmark = pytest.mark.sessions
 
@@ -20,25 +21,27 @@ def setup_session_with_file_upload(
     import_records_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
+
     def _setup(class_list_file):
         try:
             sessions_page.schedule_a_valid_session(
-                schools[0], programmes_enabled, for_today=True
+                school, programmes_enabled, for_today=True
             )
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.click_location(schools[0])
+            sessions_page.click_location(school)
             sessions_page.navigate_to_class_list_import()
             import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_today()
-            sessions_page.click_location(schools[0])
+            sessions_page.click_location(school)
             yield
         finally:
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.delete_all_sessions(schools[0])
+            sessions_page.delete_all_sessions(school)
 
     return _setup
 
@@ -61,17 +64,20 @@ def setup_fixed_child(setup_session_with_file_upload):
 def test_lifecycle(
     setup_tests, schools, dashboard_page, sessions_page, programmes_enabled
 ):
-    sessions_page.schedule_a_valid_session(schools[0], programmes_enabled)
+    school = schools[Programme.HPV][0]
+
+    sessions_page.schedule_a_valid_session(school, programmes_enabled)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.edit_a_session_to_today(schools[0])
+    sessions_page.edit_a_session_to_today(school)
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
-    sessions_page.delete_all_sessions(schools[0])
+    sessions_page.delete_all_sessions(school)
 
 
 def test_invalid(setup_tests, schools, sessions_page, programmes_enabled):
-    sessions_page.create_invalid_session(schools[0], programmes_enabled)
+    school = schools[Programme.HPV][0]
+    sessions_page.create_invalid_session(school, programmes_enabled)
 
 
 @pytest.mark.bug
@@ -94,6 +100,7 @@ def test_verify_consent_filters(setup_fixed_child, sessions_page, children):
 @issue("MAV-1265")
 def test_recording_notes(setup_fixed_child, sessions_page, schools, children):
     child = children[0]
+    school = schools[Programme.HPV][0]
     NOTE_1 = "Note 1"
     NOTE_2 = "Note 2"
 
@@ -102,7 +109,7 @@ def test_recording_notes(setup_fixed_child, sessions_page, schools, children):
     sessions_page.click_session_activity_and_notes()
     sessions_page.add_note(NOTE_1)
     sessions_page.add_note(NOTE_2)
-    sessions_page.click_location(schools[0])
+    sessions_page.click_location(school)
     sessions_page.click_consent_tab()
     sessions_page.search_for(str(child))
     sessions_page.check_note_appears_in_search(child, NOTE_2)

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -16,15 +16,17 @@ def setup_session_with_file_upload(
     import_records_page,
     programmes_enabled,
 ):
+    school = schools[Programme.HPV][0]
+
     def _setup(class_list_file):
         try:
             dashboard_page.click_sessions()
             sessions_page.schedule_a_valid_session(
-                schools[0], programmes_enabled, for_today=True
+                school, programmes_enabled, for_today=True
             )
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.click_location(schools[0])
+            sessions_page.click_location(school)
             sessions_page.navigate_to_class_list_import()
             import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
@@ -33,7 +35,7 @@ def setup_session_with_file_upload(
         finally:
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.delete_all_sessions(schools[0])
+            sessions_page.delete_all_sessions(school)
 
     return _setup
 
@@ -45,8 +47,9 @@ def setup_fixed_child(setup_session_with_file_upload):
 
 def test_gillick_competence(setup_fixed_child, schools, sessions_page, children):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
-    sessions_page.navigate_to_todays_sessions(schools[0])
+    sessions_page.navigate_to_todays_sessions(school)
     sessions_page.navigate_to_gillick_competence(child, Programme.HPV)
 
     sessions_page.add_gillick_competence(
@@ -61,8 +64,9 @@ def test_gillick_competence(setup_fixed_child, schools, sessions_page, children)
 @issue("MAV-955")
 def test_gillick_competence_notes(setup_fixed_child, schools, sessions_page, children):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
-    sessions_page.navigate_to_todays_sessions(schools[0])
+    sessions_page.navigate_to_todays_sessions(school)
     sessions_page.navigate_to_gillick_competence(child, Programme.HPV)
 
     sessions_page.answer_gillick_competence_questions(is_competent=True)
@@ -85,8 +89,9 @@ def test_invalid_consent(
     setup_fixed_child, sessions_page, schools, consent_page, children
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
@@ -117,8 +122,9 @@ def test_parent_provides_consent_twice(
     setup_fixed_child, sessions_page, schools, consent_page, children
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
 
@@ -153,8 +159,9 @@ def test_conflicting_consent_with_gillick_consent(
     setup_fixed_child, sessions_page, schools, consent_page, children
 ):
     child = children[0]
+    school = schools[Programme.HPV][0]
 
-    sessions_page.navigate_to_scheduled_sessions(schools[0])
+    sessions_page.navigate_to_scheduled_sessions(school)
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)


### PR DESCRIPTION
For each programme, retrieve schools that contain the year groups that the programme can be administered to.

This is to prepare for a follow up PR that will make tests use children from a random year group instead of the mostly fixed year groups currently being used.

A slight downside of this PR is that flu will always be tested with schools that have years 0-11. There seems to be enough of these to not cause problems, but we could implement a smarter mechanism (choosing a year at random from 0-11 and then just finding a school with this year group?). This PR is already quite large though.