### PR TITLE
Use synthetic nhs numbers

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -238,7 +238,7 @@ class TestData:
 
     def get_new_nhs_no(self, valid=True) -> str:
         return nhs_number.generate(
-            valid=valid, for_region=nhs_number.REGION_ENGLAND, quantity=1
+            valid=valid, for_region=nhs_number.REGION_SYNTHETIC, quantity=1
         )[0]
 
     def get_expected_errors(self, file_path: Path) -> Optional[list[str]]:

--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -87,7 +87,7 @@ def children():
                 first_name=onboarding_faker.first_name(),
                 last_name=onboarding_faker.last_name().upper(),
                 nhs_number=nhs_number.generate(
-                    for_region=nhs_number.REGION_ENGLAND,
+                    for_region=nhs_number.REGION_SYNTHETIC,
                 )[0],
                 address=(
                     onboarding_faker.secondary_address(),


### PR DESCRIPTION
This PR changes nhs number generation to ensure only unassigned NHS numbers are generated for tests.