### PR TITLE
Use new URLs for Mavis testing endpoints  (/api/ -> /api/testing/)

### DIFF
--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -55,7 +55,7 @@ def nurse():
 @pytest.fixture(scope="session")
 def schools(base_url) -> dict[str, list[School]]:
     def _get_schools_with_year_groups(year_groups: List[str]) -> list[School]:
-        url = urllib.parse.urljoin(base_url, "api/locations")
+        url = urllib.parse.urljoin(base_url, "api/testing/locations")
         params = {
             "type": "school",
             "status": "open",
@@ -172,20 +172,24 @@ def _check_response_status(response):
 
 @pytest.fixture(scope="session", autouse=True)
 def onboard_and_delete(base_url, onboarding, organisation):
-    url = urllib.parse.urljoin(base_url, "api/onboard")
+    url = urllib.parse.urljoin(base_url, "api/testing/onboard")
     response = requests.post(url, json=onboarding)
     _check_response_status(response)
 
     yield
 
-    url = urllib.parse.urljoin(base_url, f"api/organisations/{organisation.ods_code}")
+    url = urllib.parse.urljoin(
+        base_url, f"api/testing/organisations/{organisation.ods_code}"
+    )
     response = requests.delete(url)
     _check_response_status(response)
 
 
 @pytest.fixture(scope="module", autouse=True)
 def reset_before_each_module(base_url, organisation):
-    url = urllib.parse.urljoin(base_url, f"api/organisations/{organisation.ods_code}")
+    url = urllib.parse.urljoin(
+        base_url, f"api/testing/organisations/{organisation.ods_code}"
+    )
     response = requests.delete(url, params={"keep_itself": "true"})
     _check_response_status(response)
 

--- a/performance-tests/E2E/consent-journey.jmx
+++ b/performance-tests/E2E/consent-journey.jmx
@@ -417,7 +417,7 @@ vars.put(&quot;ConsentSession&quot;, cohortCodes.get(vars.get(&quot;CHILD_SCHOOL
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get school name">
             <stringProp name="TestPlan.comments">Temporarily remove the &apos;open&apos; filter &amp;status=open</stringProp>
-            <stringProp name="HTTPSampler.path">api/locations?type=school</stringProp>
+            <stringProp name="HTTPSampler.path">api/testing/locations?type=school</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.use_keepalive">true</boolProp>

--- a/performance-tests/E2E/nurse-journey.jmx
+++ b/performance-tests/E2E/nurse-journey.jmx
@@ -434,7 +434,7 @@
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get school name">
             <stringProp name="TestPlan.comments">Temporarily remove the &apos;open&apos; filter &amp;status=open</stringProp>
-            <stringProp name="HTTPSampler.path">api/locations?is_attached_to_organisation=true</stringProp>
+            <stringProp name="HTTPSampler.path">api/testing/locations?is_attached_to_organisation=true</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
@@ -899,7 +899,7 @@ vars.put(&quot;SessionId&quot;,props.get(&quot;SessionId&quot;))</stringProp>
               </JSR223Sampler>
               <hashTree/>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get school name" enabled="true">
-                <stringProp name="HTTPSampler.path">api/locations?type=school&amp;status=open</stringProp>
+                <stringProp name="HTTPSampler.path">api/testing/locations?type=school&amp;status=open</stringProp>
                 <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                 <stringProp name="HTTPSampler.method">GET</stringProp>
                 <boolProp name="HTTPSampler.use_keepalive">true</boolProp>


### PR DESCRIPTION
In review of [Mavis PR #3866](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3866) which introduces authentication for the Mavis commissioner reporting component, we identified that the namespace and routing of the new endpoints for reporting could be improved, and the best solution was to consider them alongside the existing `/api/` endpoints.

We decided to make the following changes:

* rename and re-scope the existing `/api/` endpoints to `/api/testing` ([Mavis PR 4106](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4106) - note that the tests will fail on this PR until that PR is merged)
* update the testing repo to use those new endpoints (this PR)
* rename and re-scope the `/reporting-api/` and `/tokens/authorize` endpoints for the reporting component, to both be under `/api/reporting/` ([Mavis auth PR #3866](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3866) will do this)