### PR TITLE
Don't select year 8 by default

### DIFF
--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -112,7 +112,7 @@ class ImportRecordsPage:
 
     def navigate_to_class_list_import(self):
         self.click_import_class_lists()
-        self._select_year_groups(8, 9, 10, 11)
+        self._select_year_groups(9, 10, 11)
 
     def navigate_to_vaccination_records_import(self):
         self.click_import_records()

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -636,7 +636,7 @@ class SessionsPage:
 
     def navigate_to_class_list_import(self, *year_groups: int):
         if not year_groups:
-            year_groups = (8, 9, 10, 11)
+            year_groups = (9, 10, 11)
 
         self.click_import_class_lists()
         self.select_year_groups(*year_groups)

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -24,7 +24,7 @@ def setup_confirm_and_ignore(
 
     def upload_class_list():
         sessions_page.click_import_class_lists()
-        sessions_page.select_year_groups(8, 9, 10, 11)
+        sessions_page.select_year_groups(9, 10, 11)
         sessions_page.choose_file_child_records(input_file_path)
         sessions_page.click_continue_button()
         import_records_page.verify_upload_output(output_file_path)


### PR DESCRIPTION
With how our tests now work, for doubles we may find schools that don't have a year 8. Trying to select it by default causes some tests to fail.