### PR TITLE
navigate to vaccination record via child record

### DIFF
--- a/mavis/test/pages/programmes.py
+++ b/mavis/test/pages/programmes.py
@@ -22,8 +22,8 @@ class ProgrammesPage:
         programme_page_links = (
             page.get_by_role("main").get_by_role("listitem").get_by_role("link")
         )
-        self.vaccination_link = programme_page_links.get_by_text("Vaccinations")
         self.cohorts_link = programme_page_links.get_by_text("Cohorts")
+        self.children_link = programme_page_links.get_by_text("Children")
 
         self.import_child_records_link = page.get_by_text("Import child records")
 
@@ -53,14 +53,16 @@ class ProgrammesPage:
         self.import_processing_started_alert = page.get_by_role(
             "alert", name="Import processing started"
         )
+        self.search_textbox = page.get_by_role("textbox", name="Search")
+        self.search_button = page.get_by_role("button", name="Search")
 
     @step("Click on {1}")
     def click_programme_current_year(self, programme: Programme):
         self.current_year_programmes_card.get_by_role("link", name=programme).click()
 
-    @step("Click on Vaccinations")
-    def click_vaccinations(self):
-        self.vaccination_link.click()
+    @step("Click on Children")
+    def click_children(self):
+        self.children_link.click()
 
     @step("Click on Cohorts")
     def click_cohorts(self):
@@ -89,6 +91,11 @@ class ProgrammesPage:
     @step("Click on {1}")
     def click_child(self, child: Child):
         self.page.get_by_role("link", name=str(child)).click()
+
+    @step("Click on {1}")
+    def search_for_child(self, child: Child):
+        self.search_textbox.fill(str(child))
+        self.search_button.click()
 
     def navigate_to_cohort_import(self, programme: Programme):
         self.click_programme_current_year(programme)

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -262,12 +262,16 @@ def test_rav_triage_consent_refused(
 
 @pytest.mark.rav
 @pytest.mark.bug
-def test_rav_edit_dose_to_not_given(setup_mavis_1729, programmes_page, children):
+def test_rav_edit_dose_to_not_given(
+    setup_mavis_1729, programmes_page, children_page, children
+):
     child = children[Programme.HPV][0]
 
     programmes_page.click_programme_current_year(Programme.HPV)
-    programmes_page.click_vaccinations()
+    programmes_page.click_children()
+    programmes_page.search_for_child(child)
     programmes_page.click_child(child)
+    children_page.click_vaccination_details(Programme.HPV)
     programmes_page.click_edit_vaccination_record()
     programmes_page.click_change_outcome()
     programmes_page.click_they_refused_it()


### PR DESCRIPTION
Updates tests to handle removal of vaccination tab from programmes page in [MAV-1509](https://nhsd-jira.digital.nhs.uk/browse/MAV-1509)