### PR TITLE
add click to choose academic year

### DIFF
--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -22,6 +22,8 @@ class ImportRecordsPage:
         self.test_data = test_data
         self.page = page
 
+        self.current_year_radio = page.get_by_role("radio", name="2024 to 2025")
+
         self.alert_success = self.page.get_by_text("Import processing started")
         self.completed_tag = self.page.get_by_role("strong").get_by_text("Completed")
         self.invalid_tag = self.page.get_by_role("strong").get_by_text("Invalid")
@@ -103,6 +105,8 @@ class ImportRecordsPage:
         self.click_import_records()
         self.select_class_list_records()
         self.click_continue()
+        self.click_add_to_current_year()
+        self.click_continue()
 
         self.page.wait_for_load_state()
 
@@ -111,6 +115,10 @@ class ImportRecordsPage:
 
         self.click_continue()
         self._select_year_groups(*year_groups)
+
+    @step("Click on 2024 to 2025")
+    def click_add_to_current_year(self):
+        self.current_year_radio.check()
 
     def navigate_to_vaccination_records_import(self):
         self.click_import_records()

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -93,6 +93,8 @@ class ImportRecordsPage:
         self.click_import_records()
         self.select_child_records()
         self.click_continue()
+        self.click_add_to_current_year()
+        self.click_continue()
 
     def navigate_to_class_list_record_import(
         self,
@@ -105,14 +107,14 @@ class ImportRecordsPage:
         self.click_import_records()
         self.select_class_list_records()
         self.click_continue()
-        self.click_add_to_current_year()
-        self.click_continue()
 
         self.page.wait_for_load_state()
 
         self.fill_location(location)
         self.page.get_by_role("option", name=str(location)).first.click()
 
+        self.click_continue()
+        self.click_add_to_current_year()
         self.click_continue()
         self._select_year_groups(*year_groups)
 

--- a/mavis/test/pages/programmes.py
+++ b/mavis/test/pages/programmes.py
@@ -18,6 +18,7 @@ class ProgrammesPage:
             .filter(has_text="2024 to 2025")
             .locator("xpath=following-sibling::table[1]")
         )
+        self.current_year_radio = page.get_by_role("radio", name="2024 to 2025")
 
         programme_page_links = (
             page.get_by_role("main").get_by_role("listitem").get_by_role("link")
@@ -97,6 +98,12 @@ class ProgrammesPage:
         self.click_programme_current_year(programme)
         self.click_children()
         self.click_import_child_records()
+        self.click_add_to_current_year()
+        self.click_continue()
+
+    @step("Click on 2024 to 2025")
+    def click_add_to_current_year(self):
+        self.current_year_radio.check()
 
     @step("Click on Save changes")
     def click_save_changes(self):

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -49,6 +49,7 @@ class SessionsPage:
         self.conflicting_consent_checkbox = self.page.get_by_role(
             "checkbox", name="Conflicting consent"
         )
+        self.current_year_radio = page.get_by_role("radio", name="2024 to 2025")
 
         self.programme_tab_link = self.page.get_by_role("link", name="Programme")
         self.import_class_lists_link = self.page.get_by_role(
@@ -617,8 +618,16 @@ class SessionsPage:
         self.expect_main_to_contain_text(message)
         self.click_continue_link()
 
+    @step("Click on 2024 to 2025")
+    def click_add_to_current_year(self):
+        self.current_year_radio.check()
+        self.click_continue_button()
+
     def select_year_groups_for_programme(self, programme: Programme):
         self.select_year_groups(*map(int, programme.year_groups))
+
+    def select_current_year(self):
+        self.page.get_by_role("radio", name="2024 to 2025").check()
 
     def schedule_a_valid_session(
         self, location: str, programme_group: str, for_today: bool = False

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -26,6 +26,7 @@ def setup_children_session(
             dashboard_page.click_sessions()
             sessions_page.click_session_for_programme_group(school, Programme.HPV)
             sessions_page.click_import_class_lists()
+            sessions_page.click_add_to_current_year()
             sessions_page.select_year_groups_for_programme(Programme.HPV)
             import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()
@@ -63,6 +64,7 @@ def setup_mav_853(
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
         sessions_page.click_import_class_lists()
+        sessions_page.click_add_to_current_year()
         sessions_page.select_year_groups_for_programme(Programme.HPV)
         import_records_page.upload_and_verify_output(
             ClassFileMapping.RANDOM_CHILD_YEAR_9

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -29,6 +29,7 @@ def setup_session_with_file_upload(
         dashboard_page.click_sessions()
         sessions_page.click_session_for_programme_group(school, programme_group)
         sessions_page.click_import_class_lists()
+        sessions_page.click_add_to_current_year()
         sessions_page.select_year_groups(child.year_group)
         import_records_page.upload_and_verify_output(
             CohortsFileMapping.FIXED_CHILD, programme_group=programme_group

--- a/tests/test_imms.py
+++ b/tests/test_imms.py
@@ -25,6 +25,7 @@ def setup_recording_hpv(
     dashboard_page.click_sessions()
     sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
     sessions_page.click_import_class_lists()
+    sessions_page.click_add_to_current_year()
     sessions_page.select_year_groups_for_programme(Programme.HPV)
     import_records_page.upload_and_verify_output(ClassFileMapping.FIXED_CHILD)
     dashboard_page.click_mavis()

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -45,6 +45,7 @@ def setup_vaccs(
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
         sessions_page.click_import_class_lists()
+        sessions_page.click_add_to_current_year()
         sessions_page.select_year_groups_for_programme(Programme.HPV)
         import_records_page.upload_and_verify_output(
             ClassFileMapping.RANDOM_CHILD_YEAR_9

--- a/tests/test_online_consent_flu.py
+++ b/tests/test_online_consent_flu.py
@@ -33,6 +33,7 @@ def setup_session_with_file_upload(
     dashboard_page.click_sessions()
     sessions_page.click_session_for_programme_group(school, Programme.FLU)
     sessions_page.click_import_class_lists()
+    sessions_page.click_add_to_current_year()
     sessions_page.select_year_groups_for_programme(Programme.FLU)
     import_records_page.upload_and_verify_output(
         CohortsFileMapping.FIXED_CHILD, programme_group=Programme.FLU.group

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -51,6 +51,7 @@ def setup_mavis_1729(
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
         sessions_page.click_import_class_lists()
+        sessions_page.click_add_to_current_year()
         sessions_page.select_year_groups_for_programme(Programme.HPV)
         import_records_page.upload_and_verify_output(
             ClassFileMapping.RANDOM_CHILD_YEAR_9
@@ -91,6 +92,7 @@ def setup_mav_854(
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
         sessions_page.click_import_class_lists()
+        sessions_page.click_add_to_current_year()
         sessions_page.select_year_groups_for_programme(Programme.HPV)
         import_records_page.upload_and_verify_output(ClassFileMapping.FIXED_CHILD)
         dashboard_page.click_mavis()
@@ -204,6 +206,7 @@ def test_rav_triage_consent_given(
 
     sessions_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_page.click_import_class_lists()
+    sessions_page.click_add_to_current_year()
     sessions_page.select_year_groups_for_programme(Programme.HPV)
 
     import_records_page.upload_and_verify_output(CohortsFileMapping.FIXED_CHILD)
@@ -242,6 +245,7 @@ def test_rav_triage_consent_refused(
 
     sessions_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_page.click_import_class_lists()
+    sessions_page.click_add_to_current_year()
     sessions_page.select_year_groups_for_programme(Programme.HPV)
 
     import_records_page.upload_and_verify_output(CohortsFileMapping.FIXED_CHILD)

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -30,6 +30,7 @@ def setup_mav_965(
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(school, programme_group, for_today=True)
     sessions_page.click_import_class_lists()
+    sessions_page.click_add_to_current_year()
     sessions_page.select_year_groups(child.year_group)
     import_records_page.upload_and_verify_output(
         ClassFileMapping.FIXED_CHILD, programme_group="doubles"

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -24,6 +24,7 @@ def setup_confirm_and_ignore(
 
     def upload_class_list():
         sessions_page.click_import_class_lists()
+        sessions_page.click_add_to_current_year()
         sessions_page.select_year_groups_for_programme(Programme.HPV)
         sessions_page.choose_file_child_records(input_file_path)
         sessions_page.click_continue_button()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -31,6 +31,7 @@ def setup_session_with_file_upload(
             dashboard_page.click_sessions()
             sessions_page.click_session_for_programme_group(school, Programme.HPV)
             sessions_page.click_import_class_lists()
+            sessions_page.click_add_to_current_year()
             sessions_page.select_year_groups_for_programme(Programme.HPV)
             import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -27,6 +27,7 @@ def setup_session_with_file_upload(
             dashboard_page.click_sessions()
             sessions_page.click_session_for_programme_group(school, Programme.HPV)
             sessions_page.click_import_class_lists()
+            sessions_page.click_add_to_current_year()
             sessions_page.select_year_groups_for_programme(Programme.HPV)
             import_records_page.upload_and_verify_output(class_list_file)
             dashboard_page.click_mavis()


### PR DESCRIPTION
Updates the tests to select the current academic year when importing records.

The fact that I had to change this in so many places to basically add one click was not great. I'm going to follow this up with a refactor PR