### PR TITLE
Add wait before recording consent response

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -1,4 +1,5 @@
 import re
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import List
@@ -112,7 +113,7 @@ class SessionsPage:
             "button", name="Mark as invalid"
         )
         self.notes_textbox = self.page.get_by_role("textbox", name="Notes")
-        self.get_verbal_consent_button = self.page.get_by_role(
+        self.record_a_new_consent_response_button = self.page.get_by_role(
             "button", name="Record a new consent response"
         )
         self.update_results_button = self.page.get_by_role(
@@ -373,8 +374,8 @@ class SessionsPage:
         self.notes_textbox.fill(notes)
 
     @step("Click on Record a new consent response")
-    def click_get_verbal_consent(self):
-        self.get_verbal_consent_button.click()
+    def click_record_a_new_consent_response(self):
+        self.record_a_new_consent_response_button.click()
 
     @step("Click {1} radio button")
     def click_parent_radio_button(self, name: str) -> None:
@@ -389,7 +390,7 @@ class SessionsPage:
     def navigate_to_consent_response(self, child: Child, programme: Programme):
         self.click_child(child)
         self.click_programme_tab(programme)
-        self.click_get_verbal_consent()
+        self.click_record_a_new_consent_response()
 
     def navigate_to_update_triage_outcome(self, child: Child, programme: Programme):
         self.click_child(child)

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -375,6 +375,8 @@ class SessionsPage:
 
     @step("Click on Record a new consent response")
     def click_record_a_new_consent_response(self):
+        # temporary wait before clicking the button to prevent errors
+        time.sleep(3)
         self.record_a_new_consent_response_button.click()
 
     @step("Click {1} radio button")

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -299,7 +299,7 @@ def test_rav_verify_excel_mav_854(
     children_page.click_session_for_programme(
         "Community clinic", Programme.HPV, check_date=True
     )
-    sessions_page.click_get_verbal_consent()
+    sessions_page.click_record_a_new_consent_response()
     consent_page.parent_verbal_positive(parent=child.parents[0], change_phone=False)
     sessions_page.register_child_as_attending(child)
     sessions_page.record_vaccs_for_child(

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -87,7 +87,7 @@ def test_programmes_rav_pre_screening_questions(
             )
 
             sessions_page.click_programme_tab(programme)
-            sessions_page.click_get_verbal_consent()
+            sessions_page.click_record_a_new_consent_response()
             consent_page.parent_verbal_positive(
                 parent=child.parents[0],
                 change_phone=False,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -121,7 +121,7 @@ def test_verify_consent_filters(
     child = children[Programme.HPV][0]
     sessions_page.review_child_with_no_response()
     sessions_page.click_child(child)
-    sessions_page.click_get_verbal_consent()
+    sessions_page.click_record_a_new_consent_response()
     consent_page.parent_paper_refuse_consent(parent=child.parents[0])
     sessions_page.click_overview_tab()
     sessions_page.click_review_consent_refused()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -97,7 +97,7 @@ def test_verify_attendance_filters(setup_mavis_1822, sessions_page, year_groups)
     sessions_page.check_year_checkbox(year_group)
     sessions_page.click_on_update_results()
 
-    expect(search_summary).to_have_text("Showing 1 to")
+    expect(search_summary).to_contain_text("Showing 1 to")
 
     sessions_page.uncheck_year_checkbox(year_group)
     sessions_page.click_advanced_filters()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -139,7 +139,7 @@ def test_parent_provides_consent_twice(
     sessions_page.navigate_to_update_triage_outcome(child, Programme.HPV)
     consent_page.update_triage_outcome_positive()
 
-    sessions_page.click_get_verbal_consent()
+    sessions_page.click_record_a_new_consent_response()
     consent_page.parent_verbal_refuse_consent(child.parents[0])
     sessions_page.select_consent_refused()
 
@@ -187,7 +187,7 @@ def test_conflicting_consent_with_gillick_consent(
         is_competent=True, competence_details="Gillick competent"
     )
     sessions_page.expect_main_to_contain_text("HPV: Safe to vaccinate")
-    sessions_page.click_get_verbal_consent()
+    sessions_page.click_record_a_new_consent_response()
     consent_page.child_consent_verbal_positive()
     sessions_page.expect_main_to_contain_text(f"Consent recorded for {str(child)}")
     sessions_page.select_consent_given()


### PR DESCRIPTION
Fixes an issue where quickly clicking the record a consent response button could result in breaking the test.

Also updates the name of the function