### PR TITLE
Refactor delete endpoint to use team workgroup

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -8,7 +8,7 @@ import nhs_number
 import pandas as pd
 from faker import Faker
 
-from mavis.test.models import Child, Clinic, Organisation, Programme, School, Team, User
+from mavis.test.models import Child, Clinic, Organisation, Programme, School, User
 from mavis.test.wrappers import (
     get_current_datetime,
     get_current_time,
@@ -109,7 +109,6 @@ class TestData:
 
     def __init__(
         self,
-        team: Team,
         organisation: Organisation,
         schools: dict[str, list[School]],
         nurse: User,
@@ -123,7 +122,6 @@ class TestData:
         self.children = children
         self.clinics = clinics
         self.year_groups = year_groups
-        self.team = team
 
         self.faker = Faker(locale="en_GB")
 

--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -102,8 +102,8 @@ def log_in_as_nurse(set_feature_flags, nurse, team, log_in_page):
 
 
 @pytest.fixture
-def test_data(team, organisation, schools, nurse, children, clinics, year_groups):
-    return TestData(team, organisation, schools, nurse, children, clinics, year_groups)
+def test_data(organisation, schools, nurse, children, clinics, year_groups):
+    return TestData(organisation, schools, nurse, children, clinics, year_groups)
 
 
 @pytest.fixture

--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -189,21 +189,21 @@ def _check_response_status(response):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def onboard_and_delete(base_url, onboarding, organisation):
+def onboard_and_delete(base_url, onboarding, team):
     url = urllib.parse.urljoin(base_url, "api/testing/onboard")
     response = requests.post(url, json=onboarding)
     _check_response_status(response)
 
     yield
 
-    url = urllib.parse.urljoin(base_url, f"api/testing/teams/{organisation.ods_code}")
+    url = urllib.parse.urljoin(base_url, f"api/testing/teams/{team.workgroup}")
     response = requests.delete(url)
     _check_response_status(response)
 
 
 @pytest.fixture(scope="module", autouse=True)
-def reset_before_each_module(base_url, organisation):
-    url = urllib.parse.urljoin(base_url, f"api/testing/teams/{organisation.ods_code}")
+def reset_before_each_module(base_url, team):
+    url = urllib.parse.urljoin(base_url, f"api/testing/teams/{team.workgroup}")
     response = requests.delete(url, params={"keep_itself": "true"})
     _check_response_status(response)
 


### PR DESCRIPTION
Uses the team workgroup instead of the org code for the delete endpoint. Currently these are just the same value so it works, but this is more clear.

Also removes the team fixture from TestData as this was unused