### PR TITLE
Remove team selection

### DIFF
--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -48,7 +48,7 @@ def get_online_consent_url(
     def wrapper(school, *programmes):
         try:
             log_in_page.navigate()
-            log_in_page.log_in_and_select_team(nurse, team)
+            log_in_page.log_in(nurse)
             dashboard_page.click_sessions()
             sessions_page.schedule_a_valid_session(school, programmes[0].group)
             url = sessions_page.get_online_consent_url(*programmes)
@@ -56,7 +56,7 @@ def get_online_consent_url(
             yield url
         finally:
             log_in_page.navigate()
-            log_in_page.log_in_and_select_team(nurse, team)
+            log_in_page.log_in(nurse)
             dashboard_page.click_sessions()
             sessions_page.delete_all_sessions(school)
             log_in_page.log_out()
@@ -68,14 +68,13 @@ def get_online_consent_url(
 def get_online_consent_url_without_cleanup(
     set_feature_flags,
     nurse,
-    team,
     dashboard_page,
     log_in_page,
     sessions_page,
 ):
     def wrapper(school, *programmes):
         log_in_page.navigate()
-        log_in_page.log_in_and_select_team(nurse, team)
+        log_in_page.log_in(nurse)
         dashboard_page.click_sessions()
         sessions_page.schedule_a_valid_session(school, programmes[0].group)
         url = sessions_page.get_online_consent_url(*programmes)
@@ -86,17 +85,17 @@ def get_online_consent_url_without_cleanup(
 
 
 @pytest.fixture
-def log_in_as_admin(set_feature_flags, admin, team, log_in_page):
+def log_in_as_admin(set_feature_flags, admin, log_in_page):
     log_in_page.navigate()
-    log_in_page.log_in_and_select_team(admin, team)
+    log_in_page.log_in(admin)
     yield
     log_in_page.log_out()
 
 
 @pytest.fixture
-def log_in_as_nurse(set_feature_flags, nurse, team, log_in_page):
+def log_in_as_nurse(set_feature_flags, nurse, log_in_page):
     log_in_page.navigate()
-    log_in_page.log_in_and_select_team(nurse, team)
+    log_in_page.log_in(nurse)
     yield
     log_in_page.log_out()
 

--- a/mavis/test/pages/log_in.py
+++ b/mavis/test/pages/log_in.py
@@ -1,6 +1,6 @@
 from playwright.sync_api import Page
 
-from mavis.test.models import Team, User
+from mavis.test.models import User
 from mavis.test.annotations import step
 
 
@@ -27,15 +27,6 @@ class LogInPage:
         self.password_input.fill(user.password)
         self.log_in_button.click()
 
-    @step("Select team {1}")
-    def select_team(self, team: Team):
-        self.page.get_by_role("radio", name=str(team)).check()
-        self.continue_button.click()
-
     @step("Log out")
     def log_out(self):
         self.log_out_button.click()
-
-    def log_in_and_select_team(self, user: User, team: Team):
-        self.log_in(user)
-        self.select_team(team)

--- a/tests/test_log_in.py
+++ b/tests/test_log_in.py
@@ -34,7 +34,6 @@ def test_valid(role, users, team, dashboard_page, log_in_page):
     log_in_page.log_in(users[role])
     expect(log_in_page.log_out_button).to_be_visible()
 
-    log_in_page.select_team(team)
     expect(dashboard_page.mavis_link).to_be_visible()
     expect(dashboard_page.programmes_link).to_be_visible()
     expect(dashboard_page.sessions_link).to_be_visible()


### PR DESCRIPTION
Removes team selection from all tests. This could be added back if we ever test an org with more than one team.