### PR TITLE
Update PDS test to handle incorrect information

### DIFF
--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -136,7 +136,9 @@ def test_create_with_nhs_number(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(child, school)
+    children_page.verify_activity_log_for_created_or_matched_child(
+        child, school, use_all_filters=True
+    )
 
 
 def test_create_with_no_nhs_number(


### PR DESCRIPTION
Some of the test pds information in pds.csv is incorrect. Some patients have an incorrect date of death or date of birth when compared to the entry retrieved from the API. This handles that by using the advanced filters to find deceased or aged out patients.