### PR TITLE
Increase wait time when making requests to the Imms API

### DIFF
--- a/mavis/test/imms_api.py
+++ b/mavis/test/imms_api.py
@@ -112,8 +112,8 @@ class ImmsApiHelper:
             "patient.identifier": f"https://fhir.nhs.uk/Id/nhs-number|{child.nhs_number}",
         }
 
-        # wait 5 seconds for the API to be updated with the latest information
-        time.sleep(5)
+        # wait 15 seconds for the API to be updated with the latest information
+        time.sleep(15)
 
         response = requests.get(
             url=ImmsEndpoints.READ.to_url, headers=self.headers, params=_params


### PR DESCRIPTION
It is taking much longer for the Imms API to get updated with the correct information (possibly due to rate limiting etc). As a first step, I'm increasing the wait time. 

This could be improved by refreshing/waiting for the sync status to update in Mavis instead of waiting, which can be done in a follow up