### PR TITLE
Use all filters when matching records

### DIFF
--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -206,12 +206,11 @@ class ChildrenPage:
                 filter.uncheck()
 
     def verify_activity_log_for_created_or_matched_child(
-        self, child: Child, location: str, use_all_filters: bool = False
+        self,
+        child: Child,
+        location: str,
     ):
-        if use_all_filters:
-            self.search_with_all_filters_for_child_name(str(child))
-        else:
-            self.search_for_a_child_name(str(child))
+        self.search_with_all_filters_for_child_name(str(child))
 
         self.click_record_for_child(child)
         self.click_activity_log()

--- a/mavis/test/pages/consent_responses.py
+++ b/mavis/test/pages/consent_responses.py
@@ -104,10 +104,12 @@ class MatchConsentResponsePage:
 
         self.search_textbox.fill(str(child))
         self.search_button.click()
+        self.page.wait_for_load_state()
 
         if not child_locator.is_visible():
-            self.advanced_filters_link.click()
             for filter in filter_locators:
+                if not filter.is_visible():
+                    self.advanced_filters_link.click()
                 filter.check()
                 self.search_button.click()
                 self.page.wait_for_load_state()

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -153,7 +153,7 @@ def test_change_nhsno(setup_change_nhsno, children_page, children):
 def test_merge_does_not_crash(setup_child_merge, children_page, children):
     child1 = children[Programme.HPV][0]
     child2 = children[Programme.HPV][1]
-    children_page.search_for_a_child_name(str(child1))
+    children_page.search_with_all_filters_for_child_name(str(child1))
     children_page.click_record_for_child(child1)
     children_page.click_archive_child_record()
     children_page.click_its_a_duplicate(child2.nhs_number)

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -136,9 +136,7 @@ def test_create_with_nhs_number(
 
     dashboard_page.click_mavis()
     dashboard_page.click_children()
-    children_page.verify_activity_log_for_created_or_matched_child(
-        child, school, use_all_filters=True
-    )
+    children_page.verify_activity_log_for_created_or_matched_child(child, school)
 
 
 def test_create_with_no_nhs_number(


### PR DESCRIPTION
Try all filters when searching for patients to ensure we find "aged out" or deceased patients.