### PR TITLE
Delete school session in clinic name test

### DIFF
--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -106,6 +106,7 @@ def setup_vaccs_clinic(
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.delete_all_sessions("Community clinic")
+        sessions_page.delete_all_sessions(school)
 
 
 @pytest.fixture


### PR DESCRIPTION
Deletes a session that is lying around after a test. Shouldn't do anything for now but could affect future tests.