### PR TITLE
Update consent_url fixture for tests that record vaccinations

### DIFF
--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -74,13 +74,20 @@ def get_online_consent_url_without_cleanup(
     sessions_page,
 ):
     def wrapper(school, *programmes):
-        log_in_page.navigate()
-        log_in_page.log_in_and_choose_team_if_necessary(nurse, team)
-        dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, programmes[0].group)
-        url = sessions_page.get_online_consent_url(*programmes)
-        log_in_page.log_out()
-        yield url
+        try:
+            log_in_page.navigate()
+            log_in_page.log_in_and_choose_team_if_necessary(nurse, team)
+            dashboard_page.click_sessions()
+            sessions_page.schedule_a_valid_session(school, programmes[0].group)
+            url = sessions_page.get_online_consent_url(*programmes)
+            log_in_page.log_out()
+            yield url
+        except Exception:
+            log_in_page.navigate()
+            log_in_page.log_in_and_choose_team_if_necessary(nurse, team)
+            dashboard_page.click_sessions()
+            sessions_page.delete_all_sessions(school)
+            log_in_page.log_out()
 
     return wrapper
 


### PR DESCRIPTION
This fixture currently doesn't delete any sessions, as sessions that have recorded an outcome cannot be deleted. However, if the tests fail after setting up a session, any retries will immediately fail as a session will already exist.

Instead I think we should delete the sessions if an exception occurs, so that the test can successfully retry if the test fails before recording the vaccination. This is where all of the flaky test errors occur anyway, so it should be very useful.