### PR TITLE
Keep reports for each environment

### DIFF
--- a/.github/actions/deploy-reports/action.yml
+++ b/.github/actions/deploy-reports/action.yml
@@ -3,6 +3,8 @@ description: "Generates Allure report and deploys to GitHub Pages"
 inputs:
   device:
     required: true
+  environment:
+    required: true
 runs:
   using: composite
   steps:
@@ -15,7 +17,7 @@ runs:
       id: set-pages-dir
       run: |
         sanitized_device=$(echo "${{ inputs.device }}" | tr -cd '[:alnum:]_-')
-        echo "dir=${{ github.ref_name }}/$sanitized_device" >> $GITHUB_OUTPUT
+        echo "dir=${{ github.ref_name }}/${{ inputs.environment }}/$sanitized_device" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Checkout gh-pages branch

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -50,5 +50,6 @@ jobs:
         uses: ./.github/actions/deploy-reports
         with:
           device: ${{ matrix.device }}
+          environment: qa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/functional_selected_device.yaml
+++ b/.github/workflows/functional_selected_device.yaml
@@ -108,5 +108,6 @@ jobs:
         uses: ./.github/actions/deploy-reports
         with:
           device: ${{ steps.set-variables.outputs.device }}
+          environment: ${{ github.event.inputs.environment }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We'll need to keep some reports for the upcoming disaster recovery demonstration, which will take place on sandbox-beta. We should keep the reports for this environment separate from qa.