### PR TITLE
For school move test, double check that patients are imported into first school

### DIFF
--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -16,9 +16,12 @@ def setup_confirm_and_ignore(
     sessions_page,
     import_records_page,
     year_groups,
+    children_page,
+    children,
 ):
     schools = schools[Programme.HPV]
     year_group = year_groups[Programme.HPV]
+    children = children[Programme.HPV]
     # We need to make sure we're uploading the same class with the same NHS numbers.
     input_file_path, output_file_path = test_data.get_file_paths(
         ClassFileMapping.TWO_FIXED_CHILDREN
@@ -42,6 +45,11 @@ def setup_confirm_and_ignore(
         dashboard_page.click_sessions()
         sessions_page.click_session_for_programme_group(schools[0], Programme.HPV)
         upload_class_list()
+        children_page.click_record_for_child(children[0])
+        children_page.click_activity_log()
+        children_page.expect_activity_log_header(
+            f"Added to the session at {schools[0]}", any=True
+        )
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.click_session_for_programme_group(schools[1], Programme.HPV)


### PR DESCRIPTION
Double checks that at least one patient is imported into the correct school in this test.

Makes test more consistent.