### PR TITLE
Support locations with a site

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -165,7 +165,7 @@ class TestData:
             schools = self.schools[programme_group]
             for index, school in enumerate(schools):
                 static_replacements[f"<<SCHOOL_{index}_NAME>>"] = school.name
-                static_replacements[f"<<SCHOOL_{index}_URN>>"] = school.urn
+                static_replacements[f"<<SCHOOL_{index}_URN>>"] = school.urn_and_site
 
         if self.nurse:
             static_replacements["<<NURSE_EMAIL>>"] = self.nurse.username

--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -79,7 +79,9 @@ def schools(base_url, year_groups) -> dict[str, list[School]]:
 
         return [
             School(
-                name=normalize_whitespace(school_data["name"]), urn=school_data["urn"]
+                name=normalize_whitespace(school_data["name"]),
+                urn=school_data["urn"],
+                site=school_data["site"],
             )
             for school_data in schools_data
         ]

--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -230,12 +230,20 @@ class Clinic(NamedTuple):
 class School(NamedTuple):
     name: str
     urn: str
+    site: str
 
     def __str__(self):
         return self.name
 
+    @property
+    def urn_and_site(self):
+        if self.site:
+            return self.urn + self.site
+        else:
+            return self.urn
+
     def to_onboarding(self):
-        return self.urn
+        return self.urn_and_site
 
 
 class Organisation(NamedTuple):


### PR DESCRIPTION
In https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4297 we added support for multiple distinct locations to exist at the same URN by introducing an optional site code that is appended to the end of the URN when identifying the location. This updates the tests to support the possibility to working with a school that has a site code.