### PR TITLE
Fix tearing down failed e2e tests

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -8,31 +8,39 @@ pytestmark = pytest.mark.e2e
 
 @pytest.fixture
 def setup_session_with_file_upload(
-    log_in_as_nurse,
     add_vaccine_batch,
     schools,
     dashboard_page,
     sessions_page,
     import_records_page,
     children,
+    log_in_page,
+    nurse,
+    team,
 ):
     def _setup(programme_group):
         school = schools[programme_group][0]
         child = children[programme_group][0]
 
-        batch_names = [
-            add_vaccine_batch(prog.vaccines[0])
-            for prog in Programme
-            if prog.group == programme_group
-        ]
-        dashboard_page.click_mavis()
-        dashboard_page.click_sessions()
-        sessions_page.click_session_for_programme_group(school, programme_group)
-        sessions_page.click_import_class_lists()
-        import_records_page.import_class_list_for_current_year(
-            ClassFileMapping.FIXED_CHILD, child.year_group, programme_group
-        )
-        return batch_names
+        try:
+            log_in_page.navigate()
+            log_in_page.log_in_and_choose_team_if_necessary(nurse, team)
+            batch_names = [
+                add_vaccine_batch(prog.vaccines[0])
+                for prog in Programme
+                if prog.group == programme_group
+            ]
+            dashboard_page.click_mavis()
+            dashboard_page.click_sessions()
+            sessions_page.click_session_for_programme_group(school, programme_group)
+            sessions_page.click_import_class_lists()
+            import_records_page.import_class_list_for_current_year(
+                ClassFileMapping.FIXED_CHILD, child.year_group, programme_group
+            )
+            return batch_names
+        finally:
+            dashboard_page.navigate()
+            log_in_page.log_out()
 
     return _setup
 


### PR DESCRIPTION
When e2e tests fail we get an unhelpful error about failing to find the login page instead of the actual error. This fixes that.