### PR TITLE
Allows tests to ensure a session is scheduled for today instead of always scheduling

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -701,6 +701,12 @@ class SessionsPage:
 
         expect(detail_value).to_contain_text(value)
 
+    def ensure_session_scheduled_for_today(self, location: str, programme_group: str):
+        self.click_session_for_programme_group(location, programme_group)
+        todays_date = datetime.now().strftime("%Y%m%d")
+        if not self.page.get_by_role("listitem", name=str(todays_date)).is_visible():
+            self.schedule_a_valid_session(location, programme_group, for_today=True)
+
     def schedule_a_valid_session(
         self,
         location: str,

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -23,9 +23,7 @@ def setup_children_session(
         try:
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.schedule_a_valid_session(
-                school, Programme.HPV, for_today=True
-            )
+            sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_session_for_programme_group(school, Programme.HPV)
@@ -75,7 +73,7 @@ def setup_mav_853(
 
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list_for_current_year(
             ClassFileMapping.RANDOM_CHILD, year_group

--- a/tests/test_imms.py
+++ b/tests/test_imms.py
@@ -27,7 +27,7 @@ def setup_recording_hpv(
         batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list_for_current_year(
             ClassFileMapping.FIXED_CHILD, year_group

--- a/tests/test_import_records.py
+++ b/tests/test_import_records.py
@@ -47,7 +47,7 @@ def setup_vaccs(
 
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list_for_current_year(
             ClassFileMapping.RANDOM_CHILD, year_group
@@ -81,7 +81,7 @@ def setup_vaccs_clinic(
 
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list_for_current_year(
             ClassFileMapping.RANDOM_CHILD, year_group
@@ -112,7 +112,7 @@ def setup_vaccs_systmone(
     school = schools[Programme.HPV][0]
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         dashboard_page.click_mavis()
         dashboard_page.click_import_records()
         import_records_page.navigate_to_vaccination_records_import()

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -29,7 +29,7 @@ def setup_record_a_vaccine(
 
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         yield
@@ -54,7 +54,7 @@ def setup_mavis_1729(
 
     try:
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(school, Programme.HPV, for_today=True)
+        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list_for_current_year(
             ClassFileMapping.RANDOM_CHILD,
@@ -104,8 +104,8 @@ def setup_mav_854(
         )
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
-        sessions_page.schedule_a_valid_session(
-            "Community clinic", Programme.HPV, for_today=True
+        sessions_page.ensure_session_scheduled_for_today(
+            "Community clinic", Programme.HPV
         )
         dashboard_page.click_mavis()
         yield batch_name

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -28,9 +28,7 @@ def setup_mav_965(
         for programme_group in [Programme.HPV, "doubles", Programme.FLU]:
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
-            sessions_page.schedule_a_valid_session(
-                school, programme_group, for_today=True
-            )
+            sessions_page.ensure_session_scheduled_for_today(school, programme_group)
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list_for_current_year(
             ClassFileMapping.FIXED_CHILD, child.year_group, "doubles"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -27,9 +27,7 @@ def setup_session_with_file_upload(
 
     def _setup(class_list_file):
         try:
-            sessions_page.schedule_a_valid_session(
-                school, Programme.HPV, for_today=True
-            )
+            sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_session_for_programme_group(school, Programme.HPV)

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -22,9 +22,7 @@ def setup_session_with_file_upload(
     def _setup(class_list_file):
         try:
             dashboard_page.click_sessions()
-            sessions_page.schedule_a_valid_session(
-                school, Programme.HPV, for_today=True
-            )
+            sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()
             sessions_page.click_session_for_programme_group(school, Programme.HPV)


### PR DESCRIPTION
There are some modules that cannot "clean up" after running due to vaccinations being recorded (e.g. `test_imms.py`, `test_e2e.py`, `test_reset.py`). These will leave sessions in progress after running, and if another test then tries to schedule a session for today at the same location, an error will occur. We will instead only schedule a session if required.