### PR TITLE
Catch screenshot errors

### DIFF
--- a/mavis/test/annotations.py
+++ b/mavis/test/annotations.py
@@ -25,13 +25,20 @@ def step(title: str, attach_screenshot: bool = True):
                     return_value = func(self, *args, **kwargs)
                 except Exception:
                     if attach_screenshot:
-                        screenshot_bytes = self.page.screenshot(full_page=True)
-                        reduced_bytes = _reduce_colors(screenshot_bytes)
-                        allure.attach(
-                            reduced_bytes,
-                            name="Screenshot on failure",
-                            attachment_type=allure.attachment_type.PNG,
-                        )
+                        try:
+                            screenshot_bytes = self.page.screenshot(full_page=True)
+                            reduced_bytes = _reduce_colors(screenshot_bytes)
+                            allure.attach(
+                                reduced_bytes,
+                                name="Screenshot on failure",
+                                attachment_type=allure.attachment_type.PNG,
+                            )
+                        except Exception as screenshot_error:
+                            allure.attach(
+                                str(screenshot_error),
+                                name="Screenshot error",
+                                attachment_type=allure.attachment_type.TEXT,
+                            )
                     raise
 
                 coverage = kwargs.get("coverage")


### PR DESCRIPTION
Catch errors when taking screenshots. Reduces some errors in tests with smaller viewports.