### PR TITLE
Switch to using css scaling for screenshots

### DIFF
--- a/mavis/test/annotations.py
+++ b/mavis/test/annotations.py
@@ -25,20 +25,15 @@ def step(title: str, attach_screenshot: bool = True):
                     return_value = func(self, *args, **kwargs)
                 except Exception:
                     if attach_screenshot:
-                        try:
-                            screenshot_bytes = self.page.screenshot(full_page=True)
-                            reduced_bytes = _reduce_colors(screenshot_bytes)
-                            allure.attach(
-                                reduced_bytes,
-                                name="Screenshot on failure",
-                                attachment_type=allure.attachment_type.PNG,
-                            )
-                        except Exception as screenshot_error:
-                            allure.attach(
-                                str(screenshot_error),
-                                name="Screenshot error",
-                                attachment_type=allure.attachment_type.TEXT,
-                            )
+                        screenshot_bytes = self.page.screenshot(
+                            full_page=True, scale="css"
+                        )
+                        reduced_bytes = _reduce_colors(screenshot_bytes)
+                        allure.attach(
+                            reduced_bytes,
+                            name="Screenshot on failure",
+                            attachment_type=allure.attachment_type.PNG,
+                        )
                     raise
 
                 coverage = kwargs.get("coverage")
@@ -50,7 +45,7 @@ def step(title: str, attach_screenshot: bool = True):
                     )
 
                 if attach_screenshot:
-                    screenshot_bytes = self.page.screenshot(full_page=True)
+                    screenshot_bytes = self.page.screenshot(full_page=True, scale="css")
                     reduced_bytes = _reduce_colors(screenshot_bytes)
                     allure.attach(
                         reduced_bytes,


### PR DESCRIPTION
Undoes the change from #595 as this was preventing screenshots from appearing after test errors (rather than just screenshot errors as intended)

Instead introduces css scaling for screenshots, which dramatically decreases the dimensions of screenshots and should prevent errors from appearing.

