### PR TITLE
Install playwright webkit dependencies when necessary

### DIFF
--- a/.github/actions/run-functional-tests/action.yml
+++ b/.github/actions/run-functional-tests/action.yml
@@ -20,9 +20,14 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
 
-    - name: Install Playwright
+    - name: Install Playwright if not cached
       if: inputs.playwright_cache_hit != 'true'
-      run: uv run playwright install --with-deps
+      run: uv run playwright install
+      shell: bash
+
+    - name: Install Playwright dependencies if using webkit
+      if: inputs.device == 'Desktop Safari' || inputs.device == 'iPad (gen 7) landscape' || inputs.device == 'iPhone 15'
+      run: uv run playwright install-deps webkit
       shell: bash
 
     - name: Run tests


### PR DESCRIPTION
We cache the playwright installation and any browsers. However, we always need to install webkit dependencies for any ios device testing. 

It seems that running `uv run playwright install-deps` can hang and take quite a long time, especially when running multiple workflows at once. To account for this, we'll only run it when necessary.