### PR TITLE
Perftest use cached binaries

### DIFF
--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -74,7 +74,7 @@ jobs:
         env:
           cache-name: cache-jmeter
         with:
-          path: ~/jmeter
+          path: jmeter
           key: jmeter
 
 #Having run each step separately, it's only the curl request that takes time. So including the unzip and move means I can cache the 'jmeter' folder entirely

--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -68,16 +68,40 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install JMeter
+      - name: Install JMeter (Get zip file)
+        run: curl -sSO https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
+
+      - name: Install JMeter (unzip and move)
         run: |
-          curl -sSO https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
           tar xzf apache-jmeter-${{ env.jmeter_version }}.tgz
           mv apache-jmeter-${{ env.jmeter_version }} jmeter
+          
+      - name: Install JMeter (get cmdrunner)
+        run: |
           curl -sSO --output-dir jmeter/lib https://repo1.maven.org/maven2/kg/apc/cmdrunner/${{ env.cmdrunner_version }}/cmdrunner-${{ env.cmdrunner_version }}.jar
+
+
+      - name: Install JMeter (Get plugins manager)
+        run: |
           curl -LsS --output jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version  }}.jar https://jmeter-plugins.org/get/
+
+      - name: Install JMeter (Install plugins manager)
+        run: |
           java -cp jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version }}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
           chmod +x jmeter/bin/PluginsManagerCMD.sh
           sed -i '/<Logger name="org.apache.jmeter.junit" level="debug" \/>/a \    <Logger name="org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase" level="info" additivity="false"\/>' jmeter/bin/log4j2.xml
+
+
+#      - name: Install JMeter
+#        run: |
+#          curl -sSO https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
+#          tar xzf apache-jmeter-${{ env.jmeter_version }}.tgz
+#          mv apache-jmeter-${{ env.jmeter_version }} jmeter
+#          curl -sSO --output-dir jmeter/lib https://repo1.maven.org/maven2/kg/apc/cmdrunner/${{ env.cmdrunner_version }}/cmdrunner-${{ env.cmdrunner_version }}.jar
+#          curl -LsS --output jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version  }}.jar https://jmeter-plugins.org/get/
+#          java -cp jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version }}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+#          chmod +x jmeter/bin/PluginsManagerCMD.sh
+#          sed -i '/<Logger name="org.apache.jmeter.junit" level="debug" \/>/a \    <Logger name="org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase" level="info" additivity="false"\/>' jmeter/bin/log4j2.xml
 
       - name: Install JMeter plugins
         if: env.jmeter_plugins != ''

--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -74,7 +74,7 @@ jobs:
         env:
           cache-name: cache-jmeter
         with:
-          path: ~/jmeter_home
+          path: ~/jmeter
           key: jmeter
 
 #Having run each step separately, it's only the curl request that takes time. So including the unzip and move means I can cache the 'jmeter' folder entirely

--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install JMeter (Get zip file)
-        run: curl -sSO https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
+        run: curl -O https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
 
       - name: Install JMeter (unzip and move)
         run: |

--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -67,41 +67,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      
+      - name: Cache jmeter
+        id: cache-jmeter
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-jmeter
+        with:
+          path: ~/jmeter_home
+          key: jmeter
 
-      - name: Install JMeter (Get zip file)
-        run: curl -O https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
+#Having run each step separately, it's only the curl request that takes time. So including the unzip and move means I can cache the 'jmeter' folder entirely
 
-      - name: Install JMeter (unzip and move)
+      - name: Install JMeter
+        if: ${{ steps.cache-jmeter.outputs.cache-hit != 'true'}}
         run: |
+          curl -sSO https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
           tar xzf apache-jmeter-${{ env.jmeter_version }}.tgz
           mv apache-jmeter-${{ env.jmeter_version }} jmeter
-          
-      - name: Install JMeter (get cmdrunner)
-        run: |
           curl -sSO --output-dir jmeter/lib https://repo1.maven.org/maven2/kg/apc/cmdrunner/${{ env.cmdrunner_version }}/cmdrunner-${{ env.cmdrunner_version }}.jar
-
-
-      - name: Install JMeter (Get plugins manager)
-        run: |
           curl -LsS --output jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version  }}.jar https://jmeter-plugins.org/get/
-
-      - name: Install JMeter (Install plugins manager)
-        run: |
           java -cp jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version }}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
           chmod +x jmeter/bin/PluginsManagerCMD.sh
           sed -i '/<Logger name="org.apache.jmeter.junit" level="debug" \/>/a \    <Logger name="org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase" level="info" additivity="false"\/>' jmeter/bin/log4j2.xml
 
-
-#      - name: Install JMeter
-#        run: |
-#          curl -sSO https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${{ env.jmeter_version }}.tgz
-#          tar xzf apache-jmeter-${{ env.jmeter_version }}.tgz
-#          mv apache-jmeter-${{ env.jmeter_version }} jmeter
-#          curl -sSO --output-dir jmeter/lib https://repo1.maven.org/maven2/kg/apc/cmdrunner/${{ env.cmdrunner_version }}/cmdrunner-${{ env.cmdrunner_version }}.jar
-#          curl -LsS --output jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version  }}.jar https://jmeter-plugins.org/get/
-#          java -cp jmeter/lib/ext/jmeter-plugins-manager-${{ env.jmeter_plugins_manager_version }}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
-#          chmod +x jmeter/bin/PluginsManagerCMD.sh
-#          sed -i '/<Logger name="org.apache.jmeter.junit" level="debug" \/>/a \    <Logger name="org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase" level="info" additivity="false"\/>' jmeter/bin/log4j2.xml
 
       - name: Install JMeter plugins
         if: env.jmeter_plugins != ''


### PR DESCRIPTION
Use GHA cache to speed up the performance test. The cache key 'could' be named better but getting it working was the first step. 