### PR TITLE
Move some tests from `test_programmes.py` to `test_sessions.py`

### DIFF
--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -2,7 +2,7 @@ import pytest
 
 from mavis.test.annotations import issue
 from mavis.test.data import ClassFileMapping, CohortsFileMapping, VaccsFileMapping
-from mavis.test.models import Programme, ReportFormat, VaccinationRecord, Vaccine
+from mavis.test.models import Programme, ReportFormat
 
 
 @pytest.fixture
@@ -10,7 +10,6 @@ def setup_cohort_upload(
     log_in_as_nurse,
     dashboard_page,
     programmes_page,
-    import_records_page,
 ):
     dashboard_page.click_programmes()
     programmes_page.navigate_to_cohort_import(Programme.HPV)
@@ -22,29 +21,7 @@ def setup_reports(log_in_as_nurse, dashboard_page):
 
 
 @pytest.fixture
-def setup_record_a_vaccine(
-    log_in_as_nurse,
-    schools,
-    dashboard_page,
-    sessions_page,
-):
-    school = schools[Programme.HPV][0]
-
-    try:
-        dashboard_page.click_sessions()
-        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
-        dashboard_page.click_mavis()
-        dashboard_page.click_sessions()
-        yield
-    finally:
-        dashboard_page.navigate()
-        dashboard_page.click_mavis()
-        dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(school)
-
-
-@pytest.fixture
-def setup_mavis_1729(
+def upload_vaccination(
     log_in_as_nurse,
     schools,
     dashboard_page,
@@ -77,43 +54,6 @@ def setup_mavis_1729(
         dashboard_page.click_mavis()
         dashboard_page.click_programmes()
         yield
-    finally:
-        dashboard_page.navigate()
-        dashboard_page.click_mavis()
-        dashboard_page.click_sessions()
-        sessions_page.delete_all_sessions(school)
-
-
-@pytest.fixture
-def setup_mav_854(
-    log_in_as_nurse,
-    add_vaccine_batch,
-    schools,
-    dashboard_page,
-    import_records_page,
-    sessions_page,
-    year_groups,
-):
-    school = schools[Programme.HPV][0]
-    year_group = year_groups[Programme.HPV]
-
-    try:
-        batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
-        dashboard_page.click_mavis()
-        dashboard_page.click_sessions()
-        sessions_page.click_session_for_programme_group(school, Programme.HPV)
-        sessions_page.schedule_a_valid_session(for_today=True)
-        sessions_page.click_import_class_lists()
-        import_records_page.import_class_list(ClassFileMapping.FIXED_CHILD, year_group)
-        dashboard_page.click_mavis()
-        dashboard_page.click_sessions()
-        sessions_page.ensure_session_scheduled_for_today(
-            "Community clinic",
-            Programme.HPV,
-        )
-        dashboard_page.click_mavis()
-        dashboard_page.click_children()
-        yield batch_name
     finally:
         dashboard_page.navigate()
         dashboard_page.click_mavis()
@@ -232,104 +172,9 @@ def test_archive_and_unarchive_child_via_cohort_upload(
 
 
 @pytest.mark.rav
-def test_triage_consent_given_and_triage_outcome(
-    setup_record_a_vaccine,
-    schools,
-    sessions_page,
-    import_records_page,
-    dashboard_page,
-    verbal_consent_page,
-    children,
-):
-    """
-    Test: Record verbal consent and triage outcome for a child in a session.
-    Steps:
-    1. Schedule session and import class list.
-    2. Record verbal consent for the child.
-    3. Update triage outcome to 'safe to vaccinate'.
-    Verification:
-    - Triage outcome is updated and reflected for the child.
-    """
-    child = children[Programme.HPV][0]
-    school = schools[Programme.HPV][0]
-
-    sessions_page.click_session_for_programme_group(school, Programme.HPV)
-    sessions_page.click_import_class_lists()
-    import_records_page.import_class_list(
-        CohortsFileMapping.FIXED_CHILD,
-        child.year_group,
-    )
-
-    dashboard_page.click_mavis()
-    dashboard_page.click_sessions()
-
-    sessions_page.click_session_for_programme_group(school, Programme.HPV)
-    sessions_page.click_consent_tab()
-    sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_phone_positive(child.parents[0])
-
-    dashboard_page.click_mavis()
-    dashboard_page.click_sessions()
-
-    sessions_page.click_session_for_programme_group(school, Programme.HPV)
-
-    sessions_page.click_register_tab()
-    sessions_page.navigate_to_update_triage_outcome(child, Programme.HPV)
-    sessions_page.select_yes_safe_to_vaccinate()
-    sessions_page.click_save_triage()
-    sessions_page.verify_triage_updated_for_child()
-
-
-@pytest.mark.rav
-def test_triage_consent_refused_and_activity_log(
-    setup_record_a_vaccine,
-    schools,
-    sessions_page,
-    import_records_page,
-    dashboard_page,
-    verbal_consent_page,
-    children,
-):
-    """
-    Test: Record verbal refusal of consent and verify activity log entry.
-    Steps:
-    1. Schedule session and import class list.
-    2. Record verbal refusal for the child.
-    3. Select 'consent refused' in session and check activity log.
-    Verification:
-    - Activity log contains entry for consent refusal by the parent.
-    """
-    child = children[Programme.HPV][0]
-    school = schools[Programme.HPV][0]
-
-    sessions_page.click_session_for_programme_group(school, Programme.HPV)
-    sessions_page.click_import_class_lists()
-    import_records_page.import_class_list(
-        CohortsFileMapping.FIXED_CHILD,
-        child.year_group,
-    )
-
-    dashboard_page.click_mavis()
-    dashboard_page.click_sessions()
-    sessions_page.click_session_for_programme_group(school, Programme.HPV)
-    sessions_page.click_consent_tab()
-    sessions_page.navigate_to_consent_response(child, Programme.HPV)
-
-    verbal_consent_page.parent_paper_refuse_consent(child.parents[0])
-    verbal_consent_page.expect_text_in_alert(str(child))
-
-    sessions_page.select_consent_refused()
-    sessions_page.click_child(child)
-    sessions_page.click_session_activity_and_notes()
-    sessions_page.check_session_activity_entry(
-        f"Consent refused by {child.parents[0].name_and_relationship}",
-    )
-
-
-@pytest.mark.rav
 @pytest.mark.bug
 def test_edit_vaccination_dose_to_not_given(
-    setup_mavis_1729,
+    upload_vaccination,
     programmes_page,
     children_page,
     children,
@@ -356,60 +201,6 @@ def test_edit_vaccination_dose_to_not_given(
     programmes_page.click_continue()
     programmes_page.click_save_changes()
     programmes_page.expect_alert_text("Vaccination outcome recorded for HPV")
-
-
-@pytest.mark.rav
-@pytest.mark.bug
-def test_verify_excel_export_and_clinic_invitation(
-    setup_mav_854,
-    schools,
-    clinics,
-    children_page,
-    sessions_page,
-    dashboard_page,
-    verbal_consent_page,
-    children,
-):
-    """
-    Test: Export session data to Excel and send clinic invitations,
-       then verify vaccination record.
-    Steps:
-    1. Schedule session, import class list, and send clinic invitations.
-    2. Record verbal consent and register child as attending.
-    3. Record vaccination for the child at the clinic.
-    4. Verify vaccination outcome and Excel export.
-    Verification:
-    - Vaccination outcome is recorded and session Excel export is available.
-    """
-    child = children[Programme.HPV][0]
-    school = schools[Programme.HPV][0]
-    batch_name = setup_mav_854
-
-    children_page.search_for_a_child_name(str(child))
-    children_page.click_record_for_child(child)
-    children_page.click_invite_to_community_clinic()
-    children_page.click_session_for_programme(
-        "Community clinic",
-        Programme.HPV,
-        check_date=True,
-    )
-    sessions_page.click_record_a_new_consent_response()
-    verbal_consent_page.parent_verbal_positive(
-        parent=child.parents[0],
-    )
-    sessions_page.register_child_as_attending(child)
-    sessions_page.record_vaccination_for_child(
-        VaccinationRecord(child, Programme.HPV, batch_name),
-        at_school=False,
-    )
-    sessions_page.check_location_radio(clinics[0])
-    sessions_page.click_continue_button()
-    sessions_page.click_confirm_button()
-    sessions_page.expect_alert_text("Vaccination outcome recorded for HPV")
-    dashboard_page.click_mavis()
-    dashboard_page.click_sessions()
-    sessions_page.click_session_for_programme_group(school, Programme.HPV)
-    assert sessions_page.get_session_id_from_offline_excel()
 
 
 @pytest.mark.reports


### PR DESCRIPTION
Some tests that were in `test_programmes.py` did not actually use the programmes page at all. These were moved to `test_sessions.py`. In addition, some fixtures with tickets in names (e.g. `setup_mav_854`) were renamed to be more descriptive,