### PR TITLE
Reduce size of sessions page

### DIFF
--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -151,6 +151,7 @@ class ChildrenPage:
 
     @step("Click on {1} vaccination details")
     def click_vaccination_details(self, school: School) -> None:
+        self.page.wait_for_load_state()
         with self.page.expect_navigation():
             self.vaccinations_card_row.filter(has_text=str(school)).get_by_role(
                 "link",

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -19,7 +19,6 @@ from mavis.test.models import (
 )
 from mavis.test.utils import (
     MAVIS_NOTE_LENGTH_LIMIT,
-    generate_random_string,
     get_current_datetime,
     get_current_datetime_compact,
     get_offset_date_compact_format,
@@ -96,18 +95,6 @@ class SessionsPage:
             name="Consent refused",
         )
         self.record_offline_link = self.page.get_by_role("link", name="Record offline")
-        self.assessment_notes_textbox = self.page.get_by_role(
-            "textbox",
-            name="Assessment notes (optional)",
-        )
-        self.complete_assessment_button = self.page.get_by_role(
-            "button",
-            name="Complete your assessment",
-        )
-        self.update_assessment_button = self.page.get_by_role(
-            "button",
-            name="Update your assessment",
-        )
         self.schedule_sessions_link = self.page.get_by_role(
             "link",
             name="Schedule sessions",
@@ -155,9 +142,6 @@ class SessionsPage:
             "#vaccinate-form-vaccine-method-nasal-field",
         )
         self.attending_button = self.page.get_by_role("button", name="Attending").first
-        self.notes_length_error = (
-            page.locator("div").filter(has_text="There is a problemEnter").nth(3)
-        )
         self.vaccination_notes = self.page.get_by_role(
             "textbox",
             name="Notes (optional)",
@@ -208,6 +192,9 @@ class SessionsPage:
         )
         self.change_psd_link = self.page.get_by_role(
             "link", name="Change   use patient specific direction"
+        )
+        self.notes_length_error = (
+            page.locator("div").filter(has_text="There is a problemEnter").nth(3)
         )
 
     def __get_display_formatted_date(self, date_to_format: str) -> str:
@@ -510,26 +497,6 @@ class SessionsPage:
     def click_on_attending(self) -> None:
         self.attending_button.click()
 
-    @step("Click on Complete your assessment")
-    def click_complete_assessment(self) -> None:
-        self.complete_assessment_button.click()
-
-    @step("Click on Update your assessment")
-    def click_update_assessment(self) -> None:
-        self.update_assessment_button.click()
-
-    @step("Check notes length error appears")
-    def check_notes_length_error_appears(self) -> None:
-        expect(self.notes_length_error).to_be_visible()
-
-    @step("Fill assessment notes with {1}")
-    def fill_assessment_notes(self, notes: str) -> None:
-        self.assessment_notes_textbox.fill(notes)
-
-    def fill_assessment_notes_with_string_of_length(self, length: int) -> None:
-        notes = generate_random_string(target_length=length, generate_spaced_words=True)
-        self.fill_assessment_notes(notes)
-
     @step("Click on Add a note")
     def click_add_a_note(self) -> None:
         self.add_a_note_span.click()
@@ -621,68 +588,9 @@ class SessionsPage:
         file_path = self.download_offline_recording_excel()
         return self.test_data.get_session_id(file_path)
 
-    @step("Add Gillick competence details")
-    def add_gillick_competence(
-        self,
-        *,
-        is_competent: bool,
-    ) -> None:
-        self.__set_gillick_competence(
-            new_assessment=True,
-            is_competent=is_competent,
-        )
-
     @step("Click Sessions")
     def click_sessions(self) -> None:
         self.sessions_link.click()
-
-    @step("Edit Gillick competence details")
-    def edit_gillick_competence(
-        self,
-        *,
-        is_competent: bool,
-    ) -> None:
-        self.__set_gillick_competence(
-            new_assessment=False,
-            is_competent=is_competent,
-        )
-
-    def __set_gillick_competence(
-        self,
-        *,
-        new_assessment: bool,
-        is_competent: bool,
-    ) -> None:
-        self.answer_gillick_competence_questions(is_competent=is_competent)
-        competence_assessment = (
-            f"Child assessed as {'' if is_competent else 'not '}Gillick competent"
-        )
-
-        self.assessment_notes_textbox.fill(competence_assessment)
-        if new_assessment:
-            self.click_complete_assessment()
-        else:
-            self.click_update_assessment()
-
-        competence_result_locator = self.page.get_by_role(
-            "heading",
-            name="Gillick assessment",
-        ).locator("xpath=following-sibling::*[1]")
-
-        expect(competence_result_locator).to_contain_text(competence_assessment)
-
-    def answer_gillick_competence_questions(self, *, is_competent: bool) -> None:
-        questions = [
-            "The child knows which vaccination they will have",
-            "The child knows which disease the vaccination protects against",
-            "The child knows what could happen if they got the disease",
-            "The child knows how the injection will be given",
-            "The child knows which side effects they might experience",
-        ]
-        response = "Yes" if is_competent else "No"
-
-        for question in questions:
-            self.page.get_by_role("group", name=question).get_by_label(response).check()
 
     def __schedule_session(self, on_date: str, *, expect_error: bool = False) -> None:
         _day = on_date[-2:]

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -37,13 +37,6 @@ class SessionsPage:
         self.test_data = test_data
         self.page = page
 
-        self.today_tab_link = self.page.get_by_role("link", name="Today")
-        self.scheduled_tab_link = self.page.get_by_role(
-            "link",
-            name="Scheduled",
-            exact=True,
-        )
-        self.unscheduled_tab_link = self.page.get_by_role("link", name="Unscheduled")
         self.no_response_checkbox = self.page.get_by_role(
             "checkbox",
             name="No response",
@@ -69,7 +62,6 @@ class SessionsPage:
             name="Conflicting consent",
         )
 
-        self.programme_tab_link = self.page.get_by_role("link", name="Programme")
         self.import_class_lists_link = self.page.get_by_role(
             "link",
             name="Import class lists",
@@ -149,10 +141,6 @@ class SessionsPage:
             "button",
             name="Record a new consent response",
         )
-        self.update_results_button = self.page.get_by_role(
-            "button",
-            name="Update results",
-        )
         self.confirm_button = self.page.get_by_role("button", name="Confirm")
         self.search_textbox = self.page.get_by_role("textbox", name="Search")
         self.search_button = self.page.get_by_role("button", name="Search")
@@ -178,20 +166,7 @@ class SessionsPage:
         pre_screening = self.page.locator("section").filter(
             has=page.get_by_role("heading", name="Pre-screening checks"),
         )
-        self.change_programmes_link = self.page.get_by_role(
-            "link",
-            name="Change   programmes",
-        )
-        self.flu_programme_checkbox = self.page.get_by_role("checkbox", name="Flu")
-        self.hpv_programme_checkbox = self.page.get_by_role("checkbox", name="HPV")
-        self.menacwy_programme_checkbox = self.page.get_by_role(
-            "checkbox",
-            name="MenACWY",
-        )
-        self.td_ipv_programme_checkbox = self.page.get_by_role(
-            "checkbox",
-            name="Td/IPV",
-        )
+
         self.pre_screening_listitem = pre_screening.get_by_role("listitem")
         self.pre_screening_checkbox = pre_screening.get_by_role("checkbox")
         self.pre_screening_notes = pre_screening.get_by_role(
@@ -202,8 +177,6 @@ class SessionsPage:
             "link",
             name="with no response",
         )
-        self.in_person_radio = self.page.get_by_text("In person")
-        self.no_they_no_not_agree_radio = self.page.get_by_text("No, they do not agree")
         self.consent_refusal_reason_other_radio = self.page.get_by_text("Other")
         self.consent_refusal_details_textbox = self.page.get_by_role(
             "textbox",
@@ -213,7 +186,6 @@ class SessionsPage:
             "link",
             name="Review   consent refused",
         )
-        self.overview_tab_link = self.page.get_by_role("link", name="Overview")
 
         self.note_textbox = self.page.get_by_role("textbox", name="Note")
         self.add_a_note_span = self.page.get_by_text("Add a note")

--- a/mavis/test/pages/verbal_consent.py
+++ b/mavis/test/pages/verbal_consent.py
@@ -8,6 +8,7 @@ from mavis.test.models import (
     Parent,
     Programme,
 )
+from mavis.test.utils import generate_random_string
 
 
 class VerbalConsentPage:
@@ -77,6 +78,21 @@ class VerbalConsentPage:
         self.online_flu_agree_injection_radio = self.page.get_by_role(
             "radio",
             name="Yes, for the injected vaccine only",
+        )
+        self.assessment_notes_textbox = self.page.get_by_role(
+            "textbox",
+            name="Assessment notes (optional)",
+        )
+        self.complete_assessment_button = self.page.get_by_role(
+            "button",
+            name="Complete your assessment",
+        )
+        self.update_assessment_button = self.page.get_by_role(
+            "button",
+            name="Update your assessment",
+        )
+        self.notes_length_error = (
+            page.locator("div").filter(has_text="There is a problemEnter").nth(3)
         )
 
     @step("Click Continue")
@@ -329,3 +345,82 @@ class VerbalConsentPage:
             programme=programme, consent_option=consent_option, psd_option=psd_option
         )
         self.click_continue()
+
+    @step("Add Gillick competence details")
+    def add_gillick_competence(
+        self,
+        *,
+        is_competent: bool,
+    ) -> None:
+        self.__set_gillick_competence(
+            new_assessment=True,
+            is_competent=is_competent,
+        )
+
+    @step("Edit Gillick competence details")
+    def edit_gillick_competence(
+        self,
+        *,
+        is_competent: bool,
+    ) -> None:
+        self.__set_gillick_competence(
+            new_assessment=False,
+            is_competent=is_competent,
+        )
+
+    def __set_gillick_competence(
+        self,
+        *,
+        new_assessment: bool,
+        is_competent: bool,
+    ) -> None:
+        self.answer_gillick_competence_questions(is_competent=is_competent)
+        competence_assessment = (
+            f"Child assessed as {'' if is_competent else 'not '}Gillick competent"
+        )
+
+        self.assessment_notes_textbox.fill(competence_assessment)
+        if new_assessment:
+            self.click_complete_assessment()
+        else:
+            self.click_update_assessment()
+
+        competence_result_locator = self.page.get_by_role(
+            "heading",
+            name="Gillick assessment",
+        ).locator("xpath=following-sibling::*[1]")
+
+        expect(competence_result_locator).to_contain_text(competence_assessment)
+
+    def answer_gillick_competence_questions(self, *, is_competent: bool) -> None:
+        questions = [
+            "The child knows which vaccination they will have",
+            "The child knows which disease the vaccination protects against",
+            "The child knows what could happen if they got the disease",
+            "The child knows how the injection will be given",
+            "The child knows which side effects they might experience",
+        ]
+        response = "Yes" if is_competent else "No"
+
+        for question in questions:
+            self.page.get_by_role("group", name=question).get_by_label(response).check()
+
+    @step("Click on Complete your assessment")
+    def click_complete_assessment(self) -> None:
+        self.complete_assessment_button.click()
+
+    @step("Click on Update your assessment")
+    def click_update_assessment(self) -> None:
+        self.update_assessment_button.click()
+
+    @step("Check notes length error appears")
+    def check_notes_length_error_appears(self) -> None:
+        expect(self.notes_length_error).to_be_visible()
+
+    @step("Fill assessment notes with {1}")
+    def fill_assessment_notes(self, notes: str) -> None:
+        self.assessment_notes_textbox.fill(notes)
+
+    def fill_assessment_notes_with_string_of_length(self, length: int) -> None:
+        notes = generate_random_string(target_length=length, generate_spaced_words=True)
+        self.fill_assessment_notes(notes)

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -7,7 +7,7 @@ from mavis.test.utils import MAVIS_NOTE_LENGTH_LIMIT, generate_random_string
 
 
 @pytest.fixture
-def setup_mav_965(
+def setup_all_programmes(
     log_in_as_nurse,
     add_vaccine_batch,
     schools,
@@ -48,7 +48,7 @@ def setup_mav_965(
 @pytest.mark.rav
 @pytest.mark.bug
 def test_pre_screening_questions_prefilled_for_multiple_vaccinations(
-    setup_mav_965,
+    setup_all_programmes,
     schools,
     dashboard_page,
     sessions_page,
@@ -74,7 +74,7 @@ def test_pre_screening_questions_prefilled_for_multiple_vaccinations(
     """
     child = children["doubles"][0]
     school = schools["doubles"][0]
-    batch_names = setup_mav_965
+    batch_names = setup_all_programmes
 
     for programme_group in [Programme.HPV, "doubles", Programme.FLU]:
         dashboard_page.click_mavis()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -46,7 +46,9 @@ def setup_fixed_child(setup_session_with_file_upload):
     yield from setup_session_with_file_upload(CohortsFileMapping.FIXED_CHILD)
 
 
-def test_gillick_competence(setup_fixed_child, schools, sessions_page, children):
+def test_gillick_competence(
+    setup_fixed_child, schools, sessions_page, verbal_consent_page, children
+):
     """
     Test: Add and edit Gillick competence assessment for a child.
     Steps:
@@ -63,13 +65,15 @@ def test_gillick_competence(setup_fixed_child, schools, sessions_page, children)
     sessions_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_page.navigate_to_gillick_competence(child, Programme.HPV)
 
-    sessions_page.add_gillick_competence(is_competent=True)
+    verbal_consent_page.add_gillick_competence(is_competent=True)
     sessions_page.click_edit_gillick_competence()
-    sessions_page.edit_gillick_competence(is_competent=False)
+    verbal_consent_page.edit_gillick_competence(is_competent=False)
 
 
 @issue("MAV-955")
-def test_gillick_competence_notes(setup_fixed_child, schools, sessions_page, children):
+def test_gillick_competence_notes(
+    setup_fixed_child, schools, sessions_page, verbal_consent_page, children
+):
     """
     Test: Validate Gillick competence assessment notes length and update.
     Steps:
@@ -89,23 +93,23 @@ def test_gillick_competence_notes(setup_fixed_child, schools, sessions_page, chi
     sessions_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_page.navigate_to_gillick_competence(child, Programme.HPV)
 
-    sessions_page.answer_gillick_competence_questions(is_competent=True)
-    sessions_page.fill_assessment_notes_with_string_of_length(
+    verbal_consent_page.answer_gillick_competence_questions(is_competent=True)
+    verbal_consent_page.fill_assessment_notes_with_string_of_length(
         MAVIS_NOTE_LENGTH_LIMIT + 1
     )
-    sessions_page.click_complete_assessment()
-    sessions_page.check_notes_length_error_appears()
+    verbal_consent_page.click_complete_assessment()
+    verbal_consent_page.check_notes_length_error_appears()
 
-    sessions_page.fill_assessment_notes("Gillick competent")
-    sessions_page.click_complete_assessment()
+    verbal_consent_page.fill_assessment_notes("Gillick competent")
+    verbal_consent_page.click_complete_assessment()
 
     sessions_page.click_edit_gillick_competence()
-    sessions_page.answer_gillick_competence_questions(is_competent=True)
-    sessions_page.fill_assessment_notes_with_string_of_length(
+    verbal_consent_page.answer_gillick_competence_questions(is_competent=True)
+    verbal_consent_page.fill_assessment_notes_with_string_of_length(
         MAVIS_NOTE_LENGTH_LIMIT + 1
     )
-    sessions_page.click_update_assessment()
-    sessions_page.check_notes_length_error_appears()
+    verbal_consent_page.click_update_assessment()
+    verbal_consent_page.check_notes_length_error_appears()
 
 
 @pytest.mark.bug
@@ -254,7 +258,7 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.expect_consent_status(Programme.HPV, "Conflicting consent")
     sessions_page.expect_conflicting_consent_text()
     sessions_page.click_assess_gillick_competence()
-    sessions_page.add_gillick_competence(is_competent=True)
+    verbal_consent_page.add_gillick_competence(is_competent=True)
     sessions_page.expect_consent_status(Programme.HPV, "Safe to vaccinate")
     sessions_page.click_record_a_new_consent_response()
     verbal_consent_page.child_consent_verbal_positive()


### PR DESCRIPTION
Reduces the size of `sessions.py` by:
- Removing some unused locators
- Moving Gillick competence checks to `verbal_consent.py`

Also renames the last function which still had a ticket name in.