### PR TITLE
Add OWASP ZAP security scan

### DIFF
--- a/.github/workflows/owasp_zap.yaml
+++ b/.github/workflows/owasp_zap.yaml
@@ -2,7 +2,8 @@ name: Run full OWASP ZAP scan against QA
 
 on:
   workflow_dispatch:
-  push:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   zap_scan:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Testing for Manage vaccinations in schools
 
-This repository contains automated functional and performance tests for the [Manage vaccinations in schools][mavis] application.
+This repository contains automated functional, performance and security tests for the [Manage vaccinations in schools][mavis] application.
 
 [mavis]: https://github.com/nhsuk/manage-vaccinations-in-schools/
 
 [![Functional tests](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/functional_selected_device.yaml/badge.svg?branch=main)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/functional_selected_device.yaml?branch=main)
 
 [![Performance (end to end) tests](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/performance-e2e.yaml/badge.svg)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/performance-e2e.yaml)
+
+[![Run full OWASP ZAP scan against QA](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/owasp_zap.yaml/badge.svg)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/owasp_zap.yaml)
 
 ## Functional tests
 


### PR DESCRIPTION
Adds a new action which runs a vulnerability scan against QA once per week:
https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/owasp_zap.yaml

The reports from this are archived and can easily be viewed in the browser. The workflow also creates and maintains its own issue: #639 

I tried to use a feature where a username/password could be supplied to the runner and it would be able to scan pages that only a logged in user can see. However, this didn't really provide any useful feedback and required a lot of extra config. For now, I think we'll keep to this basic test that scans "from the outside"

