### PR TITLE
Make vaccination record loading more robust

### DIFF
--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -1,4 +1,4 @@
-import re
+import time
 from pathlib import Path
 
 from playwright.sync_api import Page, expect
@@ -163,12 +163,11 @@ class ChildrenPage:
         )
 
         self.page.wait_for_load_state()
-        expect(vaccination_details_locator).to_have_attribute(
-            "href", re.compile(r"^/vaccination-records/")
-        )
-        self.page.wait_for_selector(
-            'div.nhsuk-card__content:has(h3.nhsuk-card__heading.nhsuk-heading-m:has-text("Vaccinations"))'
-        )
+
+        # clicking this link too quickly with non-chromium browsers
+        # can cause the page to refresh instead of navigating to
+        # the vaccination details page
+        time.sleep(1)
 
         with self.page.expect_navigation(url="**/vaccination-records/**"):
             vaccination_details_locator.click()

--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from playwright.sync_api import Page, expect
@@ -87,6 +88,10 @@ class ChildrenPage:
             "button",
             name="Invite to community clinic",
         )
+        self.vaccination_details_heading = self.page.get_by_role(
+            "heading",
+            name="Vaccination details",
+        )
 
     def verify_headers(self) -> None:
         expect(self.children_heading).to_be_visible()
@@ -151,16 +156,28 @@ class ChildrenPage:
 
     @step("Click on {1} vaccination details")
     def click_vaccination_details(self, school: School) -> None:
+        vaccination_details_locator = self.vaccinations_card_row.filter(
+            has_text=str(school)
+        ).get_by_role(
+            "link",
+        )
+
         self.page.wait_for_load_state()
-        with self.page.expect_navigation():
-            self.vaccinations_card_row.filter(has_text=str(school)).get_by_role(
-                "link",
-            ).click()
+        expect(vaccination_details_locator).to_have_attribute(
+            "href", re.compile(r"^/vaccination-records/")
+        )
+        self.page.wait_for_selector(
+            'div.nhsuk-card__content:has(h3.nhsuk-card__heading.nhsuk-heading-m:has-text("Vaccinations"))'
+        )
+
+        with self.page.expect_navigation(url="**/vaccination-records/**"):
+            vaccination_details_locator.click()
 
     @step("Click on Child record")
     def click_child_record(self) -> None:
         self.child_record_link.click()
         self.child_record_link.get_by_role("strong").wait_for()
+        self.page.wait_for_load_state()
 
     @step("Click on Change NHS number")
     def click_change_nhs_no(self) -> None:
@@ -195,7 +212,12 @@ class ChildrenPage:
         detail_key = self.page.locator(".nhsuk-summary-list__key", has_text=key)
         detail_value = detail_key.locator("xpath=following-sibling::*[1]")
 
+        self.check_vaccination_details_heading_appears()
         expect(detail_value).to_contain_text(value)
+
+    @step("Check Vaccination details heading appears")
+    def check_vaccination_details_heading_appears(self) -> None:
+        expect(self.vaccination_details_heading).to_be_visible()
 
     def expect_text_in_alert(self, text: str) -> None:
         expect(self.page.get_by_role("alert")).to_contain_text(text)

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -415,7 +415,7 @@ class SessionsPage:
     @step("Click on Record a new consent response")
     def click_record_a_new_consent_response(self) -> None:
         # temporary wait before clicking the button to prevent errors
-        time.sleep(3)
+        time.sleep(1)
         self.record_a_new_consent_response_button.click()
 
     @step("Click {1} radio button")


### PR DESCRIPTION
* Adds an explicit 1 second wait before navigating to vaccination record page
  * It seems that in non-chromium browsers on the CI, clicking this link too quickly just reloads this page. Trying all the various Playwright methods to wait for the page to fully load, wait for the link to be enabled/clickable etc. still results in the page reloading if this link is clicked too quickly. The only way this works consistently is if a short wait is added
  * Vaccination record checking has also been made slightly more robust, checking that the Vaccination Record header has appeared first
* To compensate, another explicit wait was reduced from 3 seconds to 1 second, which will speed up the tests overall.