### PR TITLE
Do not set up session at alternate school when changing schools during online consent

### DIFF
--- a/tests/test_online_consent_doubles.py
+++ b/tests/test_online_consent_doubles.py
@@ -89,7 +89,7 @@ def test_consent_refused_for_doubles_vaccination(
     ids=lambda v: f"yes_to_health_questions: {v}",
 )
 def test_consent_given_for_doubles_vaccination(
-    start_consent_with_all_sessions_scheduled,
+    start_consent_with_one_session_scheduled,
     online_consent_page,
     schools,
     programmes,

--- a/tests/test_online_consent_flu.py
+++ b/tests/test_online_consent_flu.py
@@ -108,7 +108,7 @@ def test_consent_refused_for_flu_vaccination(
     ids=lambda v: f"yes_to_health_questions: {v}",
 )
 def test_consent_given_for_flu_vaccination(
-    start_consent_with_all_sessions_scheduled,
+    start_consent_with_one_session_scheduled,
     online_consent_page,
     schools,
     consent_option,

--- a/tests/test_online_consent_hpv.py
+++ b/tests/test_online_consent_hpv.py
@@ -78,7 +78,7 @@ def test_consent_refused_for_hpv_vaccination(
     ids=lambda v: f"yes_to_health_questions: {v}",
 )
 def test_consent_given_for_hpv_vaccination(
-    start_consent_with_all_sessions_scheduled,
+    start_consent_with_one_session_scheduled,
     online_consent_page,
     schools,
     change_school,


### PR DESCRIPTION
For now, do not set up session at alternate school when changing schools during online consent

This leaves some fixtures unused for now, but they can be utilised in the future to check different behaviour when schools are changed during online consent
