### PR TITLE
Refactor verbal consent methods

### DIFF
--- a/tests/test_imms.py
+++ b/tests/test_imms.py
@@ -2,7 +2,13 @@ import pytest
 
 from mavis.test.data import ClassFileMapping
 from mavis.test.imms_api import ImmsApiHelper
-from mavis.test.models import DeliverySite, Programme, VaccinationRecord, Vaccine
+from mavis.test.models import (
+    ConsentMethod,
+    DeliverySite,
+    Programme,
+    VaccinationRecord,
+    Vaccine,
+)
 
 
 @pytest.fixture(scope="session")
@@ -55,9 +61,9 @@ def record_hpv(
 
     children_page.search_with_all_filters_for_child_name(str(child))
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_verbal_positive(
-        parent=child.parents[0],
-    )
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_positive_consent()
     sessions_page.register_child_as_attending(child)
     vaccination_time = sessions_page.record_vaccination_for_child(
         VaccinationRecord(

--- a/tests/test_psd.py
+++ b/tests/test_psd.py
@@ -1,7 +1,13 @@
 import pytest
 
 from mavis.test.data import ClassFileMapping
-from mavis.test.models import ConsentOption, Programme, VaccinationRecord, Vaccine
+from mavis.test.models import (
+    ConsentMethod,
+    ConsentOption,
+    Programme,
+    VaccinationRecord,
+    Vaccine,
+)
 
 
 @pytest.fixture
@@ -104,9 +110,9 @@ def test_delivering_vaccination_after_psd(
     sessions_page.search_child(child)
     sessions_page.click_programme_tab(Programme.FLU)
     sessions_page.click_record_a_new_consent_response()
-    verbal_consent_page.parent_verbal_positive(
-        parent=child.parents[0],
-        change_phone=False,
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_positive_consent(
         programme=Programme.FLU,
         consent_option=ConsentOption.BOTH,
         psd_option=True,

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -2,7 +2,13 @@ import pytest
 
 from mavis.test.annotations import issue
 from mavis.test.data import ClassFileMapping
-from mavis.test.models import ConsentOption, Programme, VaccinationRecord, Vaccine
+from mavis.test.models import (
+    ConsentMethod,
+    ConsentOption,
+    Programme,
+    VaccinationRecord,
+    Vaccine,
+)
 from mavis.test.utils import MAVIS_NOTE_LENGTH_LIMIT, generate_random_string
 
 
@@ -98,8 +104,9 @@ def test_pre_screening_questions_prefilled_for_multiple_vaccinations(
 
             sessions_page.click_programme_tab(programme)
             sessions_page.click_record_a_new_consent_response()
-            verbal_consent_page.parent_verbal_positive(
-                parent=child.parents[0],
+            verbal_consent_page.select_parent(child.parents[0])
+            verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+            verbal_consent_page.record_parent_positive_consent(
                 programme=programme,
                 consent_option=consent_option,
             )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,7 +3,7 @@ from playwright.sync_api import expect
 
 from mavis.test.annotations import issue
 from mavis.test.data import ClassFileMapping
-from mavis.test.models import Programme, VaccinationRecord, Vaccine
+from mavis.test.models import ConsentMethod, Programme, VaccinationRecord, Vaccine
 
 pytestmark = pytest.mark.sessions
 
@@ -159,7 +159,11 @@ def test_consent_filters_and_refusal_checkbox(
     sessions_page.review_child_with_no_response()
     sessions_page.click_child(child)
     sessions_page.click_record_a_new_consent_response()
-    verbal_consent_page.parent_paper_refuse_consent(parent=child.parents[0])
+
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.PAPER)
+    verbal_consent_page.record_parent_refuse_consent()
+
     sessions_page.click_overview_tab()
     sessions_page.click_review_consent_refused()
     sessions_page.expect_consent_refused_checkbox_to_be_checked()
@@ -227,9 +231,10 @@ def test_triage_consent_given_and_triage_outcome(
 
     sessions_page.click_consent_tab()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_phone_positive(
-        child.parents[0], yes_to_health_questions=True
-    )
+
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.PHONE)
+    verbal_consent_page.record_parent_positive_consent(yes_to_health_questions=True)
 
     dashboard_page.click_mavis()
     dashboard_page.click_sessions()
@@ -264,7 +269,9 @@ def test_consent_refused_and_activity_log(
     sessions_page.click_consent_tab()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
 
-    verbal_consent_page.parent_paper_refuse_consent(child.parents[0])
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.PAPER)
+    verbal_consent_page.record_parent_refuse_consent()
     verbal_consent_page.expect_text_in_alert(str(child))
 
     sessions_page.select_consent_refused()
@@ -321,9 +328,9 @@ def test_verify_excel_export_and_clinic_invitation(
         check_date=True,
     )
     sessions_page.click_record_a_new_consent_response()
-    verbal_consent_page.parent_verbal_positive(
-        parent=child.parents[0],
-    )
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_positive_consent()
     sessions_page.register_child_as_attending(child)
     sessions_page.record_vaccination_for_child(
         VaccinationRecord(child, Programme.HPV, batch_name),

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -2,7 +2,7 @@ import pytest
 
 from mavis.test.annotations import issue
 from mavis.test.data import CohortsFileMapping
-from mavis.test.models import Programme
+from mavis.test.models import ConsentMethod, Programme
 from mavis.test.utils import MAVIS_NOTE_LENGTH_LIMIT
 
 pytestmark = pytest.mark.consent
@@ -138,11 +138,17 @@ def test_invalid_consent(
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_verbal_no_response(child.parents[0])
+
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_no_response()
+
     sessions_page.select_no_response()
 
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_verbal_refuse_consent(child.parents[1])
+    verbal_consent_page.select_parent(child.parents[1])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_refuse_consent()
 
     sessions_page.select_consent_refused()
     sessions_page.click_child(child)
@@ -190,9 +196,9 @@ def test_parent_provides_consent_twice(
     sessions_page.select_no_response()
 
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_written_positive(
-        child.parents[0], yes_to_health_questions=True
-    )
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.PAPER)
+    verbal_consent_page.record_parent_positive_consent(yes_to_health_questions=True)
     sessions_page.select_consent_given()
 
     sessions_page.page.pause()
@@ -200,7 +206,11 @@ def test_parent_provides_consent_twice(
     verbal_consent_page.update_triage_outcome_positive()
 
     sessions_page.click_record_a_new_consent_response()
-    verbal_consent_page.parent_verbal_refuse_consent(child.parents[0])
+
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_refuse_consent()
+
     sessions_page.select_consent_refused()
 
     sessions_page.click_child(child)
@@ -246,14 +256,18 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.click_consent_tab()
     sessions_page.select_no_response()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_verbal_positive(
-        parent=child.parents[0],
-        change_phone=False,
-    )
-    sessions_page.select_consent_given()
 
+    verbal_consent_page.select_parent(child.parents[0])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_positive_consent()
+
+    sessions_page.select_consent_given()
     sessions_page.navigate_to_consent_response(child, Programme.HPV)
-    verbal_consent_page.parent_verbal_refuse_consent(child.parents[1])
+
+    verbal_consent_page.select_parent(child.parents[1])
+    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+    verbal_consent_page.record_parent_refuse_consent()
+
     sessions_page.select_conflicting_consent()
 
     sessions_page.click_child(child)
@@ -263,8 +277,11 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.click_assess_gillick_competence()
     verbal_consent_page.add_gillick_competence(is_competent=True)
     sessions_page.click_record_a_new_consent_response()
-    verbal_consent_page.child_consent_verbal_positive()
-    sessions_page.expect_alert_text(f"Consent recorded for {child!s}")
+
+    verbal_consent_page.select_gillick_competent_child()
+    verbal_consent_page.record_child_positive_consent()
+    verbal_consent_page.expect_text_in_alert(f"Consent recorded for {child!s}")
+
     sessions_page.select_consent_given()
     sessions_page.click_child(child)
     sessions_page.click_programme_tab(Programme.HPV)


### PR DESCRIPTION
Removes unused methods and fields from the verbal consent page. Also refactors methods that give consent here so that many functions can be removed