### PR TITLE
Remove unnecessary check from note test

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -540,9 +540,8 @@ class SessionsPage:
             self.click_save_note()
 
         self.expect_alert_text("Note added")
+        self.page.reload()
         reload_until_element_is_visible(self.page, self.page.get_by_text(note))
-
-        self.check_notes_appear_in_order([note])
 
     @step("Click on Set session in progress for today")
     def click_set_session_in_progress_for_today(self) -> None:


### PR DESCRIPTION
Adding two notes in extremely quick succession can sometimes cause the notes to appear out of order. However this is always fixed by a reload and would therefore appear correctly for other users. To improve the stability of this test, we'll only do this check after navigating back to the patient.