### PR TITLE
Update imms api test to wait less and check more

### DIFF
--- a/mavis/test/pages/programmes.py
+++ b/mavis/test/pages/programmes.py
@@ -20,12 +20,6 @@ class ProgrammesPage:
             .locator("xpath=following-sibling::table[1]")
         )
 
-        programme_page_links = (
-            page.get_by_role("main").get_by_role("listitem").get_by_role("link")
-        )
-        self.cohorts_link = programme_page_links.get_by_text("Cohorts")
-        self.children_link = programme_page_links.get_by_text("Children")
-
         self.import_child_records_link = page.get_by_text("Import child records")
 
         self.continue_button = page.get_by_role("button", name="Continue")
@@ -63,21 +57,26 @@ class ProgrammesPage:
         )
         self.search_textbox = page.get_by_role("textbox", name="Search")
         self.search_button = page.get_by_role("button", name="Search")
-        self.sessions_link = page.get_by_role("link", name="Sessions")
+        self.programmes_sessions_tab = page.get_by_label("Secondary menu").get_by_role(
+            "link", name="Sessions"
+        )
+        self.programmes_children_tab = page.get_by_label("Secondary menu").get_by_role(
+            "link", name="Children"
+        )
 
     @step("Click on {1}")
     def click_programme_for_current_year(self, programme: Programme) -> None:
         self.current_year_programmes_card.get_by_role("link", name=programme).click()
 
     @step("Click on Children")
-    def click_children(self) -> None:
-        self.children_link.click()
-        self.children_link.get_by_role("strong").wait_for()
+    def click_children_tab(self) -> None:
+        self.programmes_children_tab.click()
+        self.programmes_children_tab.get_by_role("strong").wait_for()
 
     @step("Click on Sessions")
-    def click_sessions(self) -> None:
-        self.sessions_link.click()
-        self.sessions_link.get_by_role("strong").wait_for()
+    def click_sessions_tab(self) -> None:
+        self.programmes_sessions_tab.click()
+        self.programmes_sessions_tab.get_by_role("strong").wait_for()
 
     @step("Click on Edit vaccination record")
     def click_edit_vaccination_record(self) -> None:
@@ -111,7 +110,7 @@ class ProgrammesPage:
 
     def navigate_to_cohort_import(self, programme: Programme) -> None:
         self.click_programme_for_current_year(programme)
-        self.click_children()
+        self.click_children_tab()
         self.click_import_child_records()
 
     @step("Click on Save changes")

--- a/mavis/test/pages/programmes.py
+++ b/mavis/test/pages/programmes.py
@@ -63,6 +63,7 @@ class ProgrammesPage:
         )
         self.search_textbox = page.get_by_role("textbox", name="Search")
         self.search_button = page.get_by_role("button", name="Search")
+        self.sessions_link = page.get_by_role("link", name="Sessions")
 
     @step("Click on {1}")
     def click_programme_for_current_year(self, programme: Programme) -> None:
@@ -71,6 +72,12 @@ class ProgrammesPage:
     @step("Click on Children")
     def click_children(self) -> None:
         self.children_link.click()
+        self.children_link.get_by_role("strong").wait_for()
+
+    @step("Click on Sessions")
+    def click_sessions(self) -> None:
+        self.sessions_link.click()
+        self.sessions_link.get_by_role("strong").wait_for()
 
     @step("Click on Edit vaccination record")
     def click_edit_vaccination_record(self) -> None:

--- a/mavis/test/pages/school_moves.py
+++ b/mavis/test/pages/school_moves.py
@@ -56,7 +56,7 @@ class DownloadSchoolMovesPage:
         self.to_year = to_group.get_by_role("textbox", name="Year")
 
         self.continue_button = page.get_by_role("button", name="Continue")
-        self.confirm_button = page.get_by_role("button", name="Download CSV")
+        self.download_csv_button = page.get_by_role("button", name="Download CSV")
 
     def enter_date_range(
         self,
@@ -73,7 +73,7 @@ class DownloadSchoolMovesPage:
             self.to_month.fill(str(to_date.month))
             self.to_year.fill(str(to_date.year))
 
-        self.continue_button.click()
+        self.click_continue()
 
     def confirm_and_get_school_moves_csv(self) -> DataFrame:
         browser = getattr(self.page.context, "browser", None)
@@ -86,13 +86,13 @@ class DownloadSchoolMovesPage:
         # Playwright's webkit browser always opens CSVs in the browser
         # unlike Chromium and Firefox
         if browser_type_name == "webkit":
-            self.confirm_button.click()
+            self.click_download_csv()
             csv_content = self.page.locator("pre").inner_text()
             self.page.go_back()
             return pd.read_csv(StringIO(csv_content), dtype={"NHS_REF": str})
 
         with self.page.expect_download() as download_info:
-            self.confirm_button.click()
+            self.click_download_csv()
         return pd.read_csv(download_info.value.path(), dtype={"NHS_REF": str})
 
     def verify_school_moves_csv_contents(
@@ -133,6 +133,14 @@ class DownloadSchoolMovesPage:
         for col, expected in fields_to_check:
             actual = str(row_data[col])
             assert actual == expected, f"{col}: expected '{expected}', got '{actual}'"
+
+    @step("Click Download CSV")
+    def click_download_csv(self) -> None:
+        self.download_csv_button.click()
+
+    @step("Click Continue")
+    def click_continue(self) -> None:
+        self.continue_button.click()
 
 
 class ReviewSchoolMovePage:

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -263,7 +263,7 @@ class SessionsPage:
         self.update_results_button.click()
 
     def _select_tab(self, name: str) -> None:
-        link = self.page.get_by_role("navigation").get_by_role("link", name=name)
+        link = self.page.get_by_label("Secondary menu").get_by_role("link", name=name)
         if link.get_by_role("strong").is_visible():
             return
         link.click()
@@ -345,6 +345,14 @@ class SessionsPage:
     @step("Click on Consent tab")
     def click_consent_tab(self) -> None:
         self._select_tab("Consent")
+
+    @step("Click on Children tab")
+    def click_children_tab(self) -> None:
+        self._select_tab("Children")
+
+    @step("Click on Triage tab")
+    def click_triage_tab(self) -> None:
+        self._select_tab("Triage")
 
     @step("Click on Assess Gillick competence")
     def click_assess_gillick_competence(self) -> None:

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -209,6 +209,10 @@ class SessionsPage:
             "button",
             name="Yes, add PSDs",
         )
+        self.record_vaccinations_breadcrumb = self.page.get_by_role(
+            "link",
+            name="Record vaccinations",
+        )
 
     def __get_display_formatted_date(self, date_to_format: str) -> str:
         _parsed_date = datetime.strptime(date_to_format, "%Y%m%d").replace(
@@ -548,7 +552,6 @@ class SessionsPage:
             self.click_save_note()
 
         self.expect_alert_text("Note added")
-        self.page.reload()
         reload_until_element_is_visible(self.page, self.page.get_by_text(note))
 
     @step("Click on Set session in progress for today")
@@ -822,8 +825,7 @@ class SessionsPage:
             self.pre_screening_notes.fill("Prescreening notes")
             self.click_continue_button()
 
-        self.page.get_by_role("radio", name=vaccination_record.batch_name).check()
-        self.click_continue_button()
+        self.choose_batch(vaccination_record.batch_name)
 
         if at_school:  # only skips MAV-854
             if psd_option:
@@ -843,6 +845,11 @@ class SessionsPage:
                 f"Vaccination outcome recorded for {vaccination_record.programme}"
             )
         return get_current_datetime()
+
+    @step("Choose batch {1}")
+    def choose_batch(self, batch_name: str) -> None:
+        self.page.get_by_role("radio", name=batch_name).check()
+        self.click_continue_button()
 
     def expect_alert_text(self, text: str) -> None:
         expect(self.page.get_by_role("alert")).to_contain_text(text)
@@ -909,3 +916,7 @@ class SessionsPage:
     @step("Click Yes, add PSDs")
     def click_yes_add_psds(self) -> None:
         self.yes_add_psds_button.click()
+
+    @step("Go back to Record Vaccinations")
+    def click_back_to_record_vaccinations(self) -> None:
+        self.record_vaccinations_breadcrumb.click()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -203,6 +203,7 @@ def test_recording_doubles_vaccination_e2e(
     sessions_page.record_vaccination_for_child(
         VaccinationRecord(child, Programme.MENACWY, menquadfi_batch_name)
     )
+    sessions_page.click_back_to_record_vaccinations()
     sessions_page.record_vaccination_for_child(
         VaccinationRecord(child, Programme.TD_IPV, revaxis_batch_name)
     )

--- a/tests/test_imms.py
+++ b/tests/test_imms.py
@@ -79,19 +79,23 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
     imms_api_helper,
     sessions_page,
     programmes_page,
+    children_page,
 ):
     """
     Test: Create, edit, and delete an HPV vaccination record and verify changes in
-       the IMMS API.
+       the IMMS API and Mavis status.
     Steps:
     1. Setup: Schedule HPV session, import class list, add vaccine batch, and
        register child with verbal consent.
     2. Create: Record HPV vaccination for the child (LEFT_ARM_UPPER).
     3. Verify: Check the vaccination record exists in the IMMS API.
+       Check Mavis shows "Synced".
     4. Edit: Change the delivery site to RIGHT_ARM_LOWER and save.
     5. Verify: Check the updated vaccination record in the IMMS API.
+       Check Mavis still shows "Synced".
     6. Edit: Change the outcome to "They refused it" and save.
     7. Verify: Check the vaccination record is removed from the IMMS API.
+       Check Mavis shows "Not synced".
     """
     child, vaccination_time = record_hpv
     school = schools[Programme.HPV][0]
@@ -104,8 +108,10 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
         vaccination_time,
     )
 
-    # Step 4: Edit delivery site
+    # Step 4: Edit delivery site to RIGHT_ARM_LOWER
     sessions_page.click_vaccination_details(school)
+    children_page.expect_vaccination_details("Synced with NHS England?", "Synced")
+
     programmes_page.click_edit_vaccination_record()
     programmes_page.click_change_site()
     programmes_page.click_delivery_site(DeliverySite.RIGHT_ARM_LOWER)
@@ -122,6 +128,8 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
 
     # Step 6: Edit outcome to refused
     sessions_page.click_vaccination_details(school)
+    children_page.expect_vaccination_details("Synced with NHS England?", "Synced")
+
     programmes_page.click_edit_vaccination_record()
     programmes_page.click_change_outcome()
     programmes_page.click_they_refused_it()
@@ -130,3 +138,5 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
 
     # Step 7: Verify deletion in IMMS API
     imms_api_helper.check_hpv_record_is_not_in_imms_api(child)
+    sessions_page.click_vaccination_details(school)
+    children_page.expect_vaccination_details("Synced with NHS England?", "Not synced")

--- a/tests/test_online_consent_school_moves.py
+++ b/tests/test_online_consent_school_moves.py
@@ -213,6 +213,7 @@ def test_accessibility(
     accessibility_helper.check_accessibility()
 
     online_consent_page.fill_parent_details(child.parents[0])
+
     accessibility_helper.check_accessibility()
 
     online_consent_page.agree_to_flu_vaccination(consent_option=ConsentOption.BOTH)
@@ -221,9 +222,13 @@ def test_accessibility(
     online_consent_page.fill_address_details(*child.address)
     accessibility_helper.check_accessibility()
 
+    online_consent_page.answer_yes()
+    accessibility_helper.check_accessibility()
+
     online_consent_page.answer_health_questions(
-        online_consent_page.get_number_of_health_questions_for_flu(ConsentOption.BOTH),
-        yes_to_health_questions=False,
+        online_consent_page.get_number_of_health_questions_for_flu(ConsentOption.BOTH)
+        + 1,
+        yes_to_health_questions=True,
     )
     accessibility_helper.check_accessibility()
 

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -191,7 +191,7 @@ def test_edit_vaccination_dose_to_not_given(
     child = children[Programme.HPV][0]
 
     programmes_page.click_programme_for_current_year(Programme.HPV)
-    programmes_page.click_children()
+    programmes_page.click_children_tab()
     programmes_page.search_for_child(child)
     programmes_page.click_child(child)
     children_page.click_vaccination_details(Programme.HPV)
@@ -343,8 +343,8 @@ def test_accessibility(
     dashboard_page.click_programmes()
     programmes_page.click_programme_for_current_year(Programme.FLU)
 
-    programmes_page.click_sessions()
+    programmes_page.click_sessions_tab()
     accessibility_helper.check_accessibility()
 
-    programmes_page.click_children()
+    programmes_page.click_children_tab()
     accessibility_helper.check_accessibility()

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -315,3 +315,36 @@ def test_verify_systmone_report_for_menacwy(setup_reports, programmes_page):
         programme=Programme.MENACWY,
         report_format=ReportFormat.SYSTMONE,
     )
+
+
+@pytest.mark.accessibility
+def test_accessibility(
+    setup_reports, dashboard_page, accessibility_helper, programmes_page
+):
+    """
+    Test: Check accessibility of the programmes page.
+    Steps:
+    1. Navigate to programmes page.
+    Verification:
+    - Page passes accessibility checks.
+    """
+    accessibility_helper.check_accessibility()
+
+    programmes_page.click_programme_for_current_year(Programme.FLU)
+    accessibility_helper.check_accessibility()
+
+    programmes_page.click_download_report()
+    accessibility_helper.check_accessibility()
+
+    programmes_page.click_continue()
+    accessibility_helper.check_accessibility()
+
+    dashboard_page.click_mavis()
+    dashboard_page.click_programmes()
+    programmes_page.click_programme_for_current_year(Programme.FLU)
+
+    programmes_page.click_sessions()
+    accessibility_helper.check_accessibility()
+
+    programmes_page.click_children()
+    accessibility_helper.check_accessibility()

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -141,3 +141,39 @@ def test_download_school_moves_csv(
     download_school_moves_page.verify_school_moves_csv_contents(
         school_moves_csv, children, school
     )
+
+
+@pytest.mark.accessibility
+def test_accessibility(
+    setup_confirm_and_ignore,
+    dashboard_page,
+    accessibility_helper,
+    school_moves_page,
+    download_school_moves_page,
+    children,
+):
+    """
+    Test: Check accessibility of the school moves page.
+    Steps:
+    1. Setup: Ensure school moves exist by confirming/ignoring moves for two children.
+    2. Navigate to the school moves page.
+    3. Run accessibility checks on the page.
+    Verification:
+    - The school moves page passes accessibility checks.
+    """
+    child = children[Programme.HPV][0]
+
+    dashboard_page.click_mavis()
+    dashboard_page.click_school_moves()
+    accessibility_helper.check_accessibility()
+
+    school_moves_page.click_download()
+    accessibility_helper.check_accessibility()
+
+    download_school_moves_page.click_continue()
+    accessibility_helper.check_accessibility()
+
+    dashboard_page.click_mavis()
+    dashboard_page.click_school_moves()
+    school_moves_page.click_child(*child.name)
+    accessibility_helper.check_accessibility()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -366,3 +366,58 @@ def test_session_verify_consent_reminders_and_pdf_downloads(
 
     sessions_page.click_send_reminders(school)
     sessions_page.download_consent_form(Programme.HPV)
+
+
+@pytest.mark.accessibility
+def test_accessibility(
+    setup_fixed_child,
+    dashboard_page,
+    accessibility_helper,
+    sessions_page,
+    schools,
+    children,
+):
+    """
+    Test: Validate accessibility of the sessions page.
+    Steps:
+    1. Navigate to sessions page.
+    2. Run accessibility checks on the page.
+    Verification:
+    - No accessibility violations found.
+    """
+    school = schools[Programme.HPV][0]
+    child = children[Programme.HPV][0]
+
+    dashboard_page.click_mavis()
+    dashboard_page.click_sessions()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_session_for_programme_group(school, Programme.HPV)
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_edit_session()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_change_session_dates()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_back()
+    sessions_page.click_continue_link()
+
+    sessions_page.click_children_tab()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_consent_tab()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_triage_tab()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_register_tab()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_child(child)
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_session_activity_and_notes()
+    accessibility_helper.check_accessibility()

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -2,7 +2,7 @@ import pytest
 
 from mavis.test.annotations import issue
 from mavis.test.data import CohortsFileMapping
-from mavis.test.models import ConsentMethod, Programme
+from mavis.test.models import ConsentMethod, DeliverySite, Programme, Vaccine
 from mavis.test.utils import MAVIS_NOTE_LENGTH_LIMIT
 
 pytestmark = pytest.mark.consent
@@ -289,3 +289,75 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_page.check_session_activity_entry(
         f"Consent given by {child!s} (Child (Gillick competent))",
     )
+
+
+@pytest.mark.accessibility
+def test_accessibility(
+    setup_fixed_child,
+    add_vaccine_batch,
+    sessions_page,
+    schools,
+    verbal_consent_page,
+    children,
+    accessibility_helper,
+    dashboard_page,
+):
+    child = children[Programme.HPV][0]
+    school = schools[Programme.HPV][0]
+    batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
+
+    dashboard_page.navigate()
+    dashboard_page.click_sessions()
+    sessions_page.click_session_for_programme_group(school, Programme.HPV)
+    sessions_page.click_consent_tab()
+    sessions_page.select_no_response()
+
+    sessions_page.navigate_to_consent_response(child, Programme.HPV)
+    accessibility_helper.check_accessibility()
+
+    verbal_consent_page.click_radio_button(child.parents[0].name_and_relationship)
+    verbal_consent_page.click_continue()
+
+    accessibility_helper.check_accessibility()
+    verbal_consent_page.click_continue()
+
+    accessibility_helper.check_accessibility()
+
+    verbal_consent_page.select_consent_method(ConsentMethod.PAPER)
+    accessibility_helper.check_accessibility()
+
+    verbal_consent_page.click_yes_they_agree()
+    verbal_consent_page.click_continue()
+    accessibility_helper.check_accessibility()
+
+    verbal_consent_page.answer_all_health_questions(
+        programme=Programme.HPV,
+    )
+    verbal_consent_page.click_continue()
+    accessibility_helper.check_accessibility()
+
+    verbal_consent_page.click_confirm()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.register_child_as_attending(child)
+    sessions_page.click_record_vaccinations_tab()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_child(child)
+    accessibility_helper.check_accessibility()
+
+    sessions_page.confirm_pre_screening_checks(Programme.HPV)
+    sessions_page.select_identity_confirmed_by_child(child)
+    sessions_page.select_ready_for_vaccination()
+    sessions_page.select_delivery_site(DeliverySite.LEFT_ARM_UPPER)
+    sessions_page.click_continue_button()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.choose_batch(batch_name)
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_confirm_button()
+    accessibility_helper.check_accessibility()
+
+    sessions_page.click_vaccination_details(school)
+    accessibility_helper.check_accessibility()


### PR DESCRIPTION
Imms API test now retries retrieving information from the API instead of waiting, massively speeding up the test.
It now also checks the status in Mavis, which was missed before.
