### PR TITLE
Add flu imms api tests

### DIFF
--- a/mavis/test/imms_api.py
+++ b/mavis/test/imms_api.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 import dateutil.parser
 import requests
 
-from mavis.test.models import Child, DeliverySite, ImmsEndpoints, School
+from mavis.test.models import Child, DeliverySite, ImmsEndpoints, Programme, School
 
 
 class ImmsApiVaccinationRecord(NamedTuple):
@@ -44,6 +44,23 @@ class ImmsApiVaccinationRecord(NamedTuple):
             ),
         )
 
+    @classmethod
+    def from_values(
+        cls,
+        programme: Programme,
+        child: Child,
+        delivery_site: DeliverySite,
+        school: School,
+        vaccination_time: datetime,
+    ) -> "ImmsApiVaccinationRecord":
+        return cls(
+            patient_nhs_number=child.nhs_number,
+            vaccine_code=programme.vaccines[0].imms_api_code,
+            delivery_site=delivery_site,
+            vaccination_location_urn=school.urn,
+            vaccination_time=vaccination_time,
+        )
+
 
 class ImmsApiHelper:
     def __init__(self, token: str) -> None:
@@ -55,8 +72,9 @@ class ImmsApiHelper:
             "Authorization": f"Bearer {token}",
         }
 
-    def check_hpv_record_in_imms_api(
+    def check_record_in_imms_api(
         self,
+        programme: Programme,
         child: Child,
         school: School,
         delivery_site: DeliverySite,
@@ -65,12 +83,13 @@ class ImmsApiHelper:
         max_attempts = 5
         for attempt in range(max_attempts):
             try:
-                imms_vaccination_record = self._get_hpv_imms_api_record_for_child(child)
-                self.check_record_has_expected_fields(
-                    child,
-                    school,
-                    delivery_site,
-                    vaccination_time,
+                imms_vaccination_record = self._get_imms_api_record_for_child(
+                    programme, child
+                )
+                self.check_expected_and_actual_records_match(
+                    ImmsApiVaccinationRecord.from_values(
+                        programme, child, delivery_site, school, vaccination_time
+                    ),
                     imms_vaccination_record,
                 )
                 break  # Success, exit loop
@@ -79,42 +98,42 @@ class ImmsApiHelper:
                     raise
                 time.sleep(3)
 
-    def check_record_has_expected_fields(
+    def check_expected_and_actual_records_match(
         self,
-        child: Child,
-        school: School,
-        delivery_site: DeliverySite,
-        vaccination_time: datetime,
-        imms_vaccination_record: ImmsApiVaccinationRecord | None,
+        expected_record: ImmsApiVaccinationRecord,
+        actual_record: ImmsApiVaccinationRecord | None,
     ) -> None:
-        if imms_vaccination_record is None:
+        if actual_record is None:
             msg = "No immunization record found"
             raise AssertionError(msg)
 
         self._raise_error_if_not_equal(
-            imms_vaccination_record.patient_nhs_number, child.nhs_number, "NHS number"
+            actual_record.patient_nhs_number,
+            expected_record.patient_nhs_number,
+            "NHS number",
         )
 
-        gardasil_9_vaccine_code = "33493111000001108"
         self._raise_error_if_not_equal(
-            imms_vaccination_record.vaccine_code,
-            gardasil_9_vaccine_code,
+            actual_record.vaccine_code,
+            expected_record.vaccine_code,
             "Vaccine code",
         )
 
         self._raise_error_if_not_equal(
-            imms_vaccination_record.delivery_site, delivery_site, "Vaccination site"
+            actual_record.delivery_site,
+            expected_record.delivery_site,
+            "Vaccination site",
         )
 
         self._raise_error_if_not_equal(
-            imms_vaccination_record.vaccination_location_urn,
-            school.urn,
+            actual_record.vaccination_location_urn,
+            expected_record.vaccination_location_urn,
             "Vaccination location urn",
         )
 
         self._raise_error_if_time_not_within_tolerance(
-            vaccination_time,
-            imms_vaccination_record.vaccination_time,
+            actual_record.vaccination_time,
+            expected_record.vaccination_time,
             tolerance_seconds=10,
         )
 
@@ -130,18 +149,21 @@ class ImmsApiHelper:
     ) -> None:
         if abs(actual - expected).total_seconds() >= tolerance_seconds:
             msg = (
-                f"Vaccination time: expected within {tolerance_seconds} seconds ",
+                f"Vaccination time: expected within {tolerance_seconds} seconds "
                 f"of {expected}, got {actual}",
             )
             raise AssertionError(msg)
 
-    def check_hpv_record_is_not_in_imms_api(
+    def check_record_is_not_in_imms_api(
         self,
+        programme: Programme,
         child: Child,
     ) -> None:
         max_attempts = 5
         for attempt in range(max_attempts):
-            imms_vaccination_record = self._get_hpv_imms_api_record_for_child(child)
+            imms_vaccination_record = self._get_imms_api_record_for_child(
+                programme, child
+            )
             if imms_vaccination_record is None:
                 break
             if attempt == max_attempts - 1:
@@ -149,13 +171,14 @@ class ImmsApiHelper:
                 raise AssertionError(msg)
             time.sleep(3)
 
-    def _get_hpv_imms_api_record_for_child(
+    def _get_imms_api_record_for_child(
         self,
+        programme: Programme,
         child: Child,
     ) -> ImmsApiVaccinationRecord | None:
         _params = {
             "_include": "Immunization:patient",
-            "-immunization.target": "HPV",
+            "-immunization.target": programme.upper(),
             "patient.identifier": f"https://fhir.nhs.uk/Id/nhs-number|{child.nhs_number}",
         }
 

--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -206,6 +206,8 @@ class Vaccine(StrEnum):
     def imms_api_code(self) -> str:
         if self is self.SEQUIRUS:
             return "43207411000001105"
+        if self is self.FLUENZ:
+            return "43208811000001106"
         if self is self.GARDASIL_9:
             return "33493111000001108"
         msg = f"Vaccine '{self.value}' is not supported by IMMS API"

--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -92,22 +92,6 @@ class HealthQuestion(StrEnum):
     FLU_PREVIOUSLY = "Has your child had a flu vaccination in the last 3 months?"
 
 
-class Vaccine(StrEnum):
-    # Flu
-    FLUENZ = "Fluenz"
-
-    # HPV
-    GARDASIL_9 = "Gardasil 9"
-
-    # MenACWY
-    MENQUADFI = "MenQuadfi"
-    MENVEO = "Menveo"
-    NIMENRIX = "Nimenrix"
-
-    # Td/IPV
-    REVAXIS = "Revaxis"
-
-
 class Programme(StrEnum):
     FLU = "flu"
     HPV = "HPV"
@@ -119,18 +103,6 @@ class Programme(StrEnum):
         if self in {Programme.MENACWY, Programme.TD_IPV}:
             return "doubles"
         return self.value
-
-    @property
-    def vaccines(self) -> list[Vaccine]:
-        match self:
-            case self.FLU:
-                return [Vaccine.FLUENZ]
-            case self.HPV:
-                return [Vaccine.GARDASIL_9]
-            case self.MENACWY:
-                return [Vaccine.MENQUADFI, Vaccine.MENVEO, Vaccine.NIMENRIX]
-            case self.TD_IPV:
-                return [Vaccine.REVAXIS]
 
     def health_questions(
         self, consent_option: ConsentOption = ConsentOption.INJECTION
@@ -214,17 +186,58 @@ class Programme(StrEnum):
                 return list(range(9, 12))
 
 
+class Vaccine(StrEnum):
+    # Flu
+    FLUENZ = "Fluenz"
+    SEQUIRUS = "Cell-based Trivalent Influenza Vaccine Seqirus"
+
+    # HPV
+    GARDASIL_9 = "Gardasil 9"
+
+    # MenACWY
+    MENQUADFI = "MenQuadfi"
+    MENVEO = "Menveo"
+    NIMENRIX = "Nimenrix"
+
+    # Td/IPV
+    REVAXIS = "Revaxis"
+
+    @property
+    def imms_api_code(self) -> str:
+        if self is self.SEQUIRUS:
+            return "43207411000001105"
+        if self is self.GARDASIL_9:
+            return "33493111000001108"
+        msg = f"Vaccine '{self.value}' is not supported by IMMS API"
+        raise ValueError(msg)
+
+    @property
+    def programme(self) -> Programme:
+        programme_mapping = {
+            Vaccine.FLUENZ: Programme.FLU,
+            Vaccine.SEQUIRUS: Programme.FLU,
+            Vaccine.GARDASIL_9: Programme.HPV,
+            Vaccine.MENQUADFI: Programme.MENACWY,
+            Vaccine.MENVEO: Programme.MENACWY,
+            Vaccine.NIMENRIX: Programme.MENACWY,
+            Vaccine.REVAXIS: Programme.TD_IPV,
+        }
+        return programme_mapping[self]
+
+
 class DeliverySite(StrEnum):
     LEFT_ARM_UPPER = "Left arm (upper position)"
     RIGHT_ARM_UPPER = "Right arm (upper position)"
     LEFT_ARM_LOWER = "Left arm (lower position)"
     RIGHT_ARM_LOWER = "Right arm (lower position)"
+    NOSE = "Nose"
 
     @classmethod
-    def from_code(cls, code: str) -> "DeliverySite":
+    def from_imms_api_code(cls, code: str) -> "DeliverySite":
         sites = {
             "368208006": DeliverySite.LEFT_ARM_UPPER,
             "368209003": DeliverySite.RIGHT_ARM_UPPER,
+            "279549004": DeliverySite.NOSE,
         }
         return sites[code]
 

--- a/mavis/test/pages/programmes.py
+++ b/mavis/test/pages/programmes.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from io import StringIO
 
 import pandas as pd
@@ -37,6 +38,9 @@ class ProgrammesPage:
         }
         self.change_outcome_link = page.get_by_role("link", name="Change   outcome")
         self.change_site_link = page.get_by_role("link", name="Change   site")
+        self.change_time_link = page.get_by_role("link", name="Change   time")
+        self.hour_textbox = page.get_by_role("textbox", name="Hour")
+        self.minute_textbox = page.get_by_role("textbox", name="Minute")
         self.they_refused_it_radio_button = page.get_by_role(
             "radio",
             name="They refused it",
@@ -85,6 +89,15 @@ class ProgrammesPage:
     @step("Click on Change site")
     def click_change_site(self) -> None:
         self.change_site_link.click()
+
+    @step("Click on Change time")
+    def click_change_time(self) -> None:
+        self.change_time_link.click()
+
+    @step("Change time of delivery")
+    def change_time_of_delivery(self, new_vaccination_time: datetime) -> None:
+        self.hour_textbox.fill(str(new_vaccination_time.hour))
+        self.minute_textbox.fill(str(new_vaccination_time.minute))
 
     @step("Click delivery site {1}")
     def click_delivery_site(self, delivery_site: DeliverySite) -> None:

--- a/mavis/test/utils.py
+++ b/mavis/test/utils.py
@@ -1,3 +1,4 @@
+import random
 import re
 import time
 from datetime import date, datetime, timedelta
@@ -77,6 +78,14 @@ def get_date_of_birth_for_year_group(year_group: int) -> date:
     end_date = date(academic_year + 1, 8, 31)
 
     return faker.date_between(start_date, end_date)
+
+
+def random_datetime_earlier_today(input_time: datetime) -> datetime:
+    midnight = input_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    delta_minutes = int((input_time - midnight).total_seconds() // 60)
+    random_offset = random.randint(0, delta_minutes)
+    random_dt = input_time - timedelta(minutes=random_offset)
+    return random_dt.replace(second=0, microsecond=0)
 
 
 def generate_random_string(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2,7 +2,7 @@ import pytest
 
 from mavis.test.annotations import issue
 from mavis.test.data import ClassFileMapping
-from mavis.test.models import ConsentOption, Programme, VaccinationRecord
+from mavis.test.models import ConsentOption, Programme, VaccinationRecord, Vaccine
 
 pytestmark = pytest.mark.e2e
 
@@ -27,9 +27,9 @@ def setup_session_with_file_upload(
             log_in_page.navigate()
             log_in_page.log_in_and_choose_team_if_necessary(nurse, team)
             batch_names = [
-                add_vaccine_batch(prog.vaccines[0])
-                for prog in Programme
-                if prog.group == programme_group
+                add_vaccine_batch(vaccine)
+                for vaccine in Vaccine
+                if vaccine.programme.group == programme_group
             ]
             dashboard_page.click_mavis()
             dashboard_page.click_sessions()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -27,7 +27,7 @@ def setup_session_with_file_upload(
             log_in_page.navigate()
             log_in_page.log_in_and_choose_team_if_necessary(nurse, team)
             batch_names = [
-                add_vaccine_batch(vaccine)
+                add_vaccine_batch(vaccine, vaccine.replace(" ", "") + "123")
                 for vaccine in Vaccine
                 if vaccine.programme.group == programme_group
             ]
@@ -166,7 +166,9 @@ def test_recording_doubles_vaccination_e2e(
     """
     child = children["doubles"][0]
     schools = schools["doubles"]
-    menquadfi_batch_name, revaxis_batch_name = setup_session_for_doubles
+    menquadfi_batch_name = setup_session_for_doubles[0]
+    revaxis_batch_name = setup_session_for_doubles[-1]
+
     number_of_health_questions = (
         online_consent_page.get_number_of_health_questions_for_programmes(
             [Programme.MENACWY, Programme.TD_IPV],

--- a/tests/test_imms_api_flu.py
+++ b/tests/test_imms_api_flu.py
@@ -4,11 +4,13 @@ from mavis.test.data import ClassFileMapping
 from mavis.test.imms_api import ImmsApiHelper
 from mavis.test.models import (
     ConsentMethod,
+    ConsentOption,
     DeliverySite,
     Programme,
     VaccinationRecord,
     Vaccine,
 )
+from mavis.test.utils import random_datetime_earlier_today
 
 
 @pytest.fixture(scope="session")
@@ -30,7 +32,10 @@ def setup_recording_flu(
     year_group = year_groups[Programme.FLU]
 
     try:
-        batch_name = add_vaccine_batch(Vaccine.SEQUIRUS)
+        batch_names = {
+            vaccine: add_vaccine_batch(vaccine)
+            for vaccine in [Vaccine.SEQUIRUS, Vaccine.FLUENZ]
+        }
         dashboard_page.click_mavis()
         dashboard_page.click_sessions()
         sessions_page.ensure_session_scheduled_for_today(school, Programme.FLU)
@@ -42,7 +47,7 @@ def setup_recording_flu(
         dashboard_page.click_sessions()
         sessions_page.click_session_for_programme_group(school, Programme.FLU)
         sessions_page.click_consent_tab()
-        yield batch_name
+        yield batch_names
     finally:
         dashboard_page.navigate()
         dashboard_page.click_mavis()
@@ -51,32 +56,52 @@ def setup_recording_flu(
 
 
 @pytest.fixture
-def record_flu(
+def record_flu_with_consent_option(
     setup_recording_flu,
     children_page,
     sessions_page,
     verbal_consent_page,
     children,
 ):
-    child = children[Programme.FLU][0]
-    batch_name = setup_recording_flu
+    def _factory(consent_option):
+        child = children[Programme.FLU][0]
+        batch_names = setup_recording_flu
 
-    children_page.search_with_all_filters_for_child_name(str(child))
-    sessions_page.navigate_to_consent_response(child, Programme.FLU)
-    verbal_consent_page.select_parent(child.parents[0])
-    verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
-    verbal_consent_page.record_parent_positive_consent(Programme.FLU)
-    sessions_page.register_child_as_attending(child)
-    vaccination_time = sessions_page.record_vaccination_for_child(
-        VaccinationRecord(
-            child, Programme.FLU, batch_name, delivery_site=DeliverySite.LEFT_ARM_UPPER
+        children_page.search_with_all_filters_for_child_name(str(child))
+        sessions_page.navigate_to_consent_response(child, Programme.FLU)
+        verbal_consent_page.select_parent(child.parents[0])
+        verbal_consent_page.select_consent_method(ConsentMethod.IN_PERSON)
+        verbal_consent_page.record_parent_positive_consent(
+            Programme.FLU, consent_option
         )
-    )
-    return child, vaccination_time
+        sessions_page.register_child_as_attending(child)
+
+        vaccine = (
+            Vaccine.SEQUIRUS
+            if consent_option is ConsentOption.INJECTION
+            else Vaccine.FLUENZ
+        )
+        delivery_site = (
+            DeliverySite.LEFT_ARM_UPPER
+            if consent_option is ConsentOption.INJECTION
+            else DeliverySite.NOSE
+        )
+        vaccination_time = sessions_page.record_vaccination_for_child(
+            VaccinationRecord(
+                child,
+                Programme.FLU,
+                batch_names[vaccine],
+                consent_option=consent_option,
+                delivery_site=delivery_site,
+            )
+        )
+        return child, vaccination_time
+
+    return _factory
 
 
-def test_create_edit_delete_flu_vaccination_and_verify_imms_api(
-    record_flu,
+def test_create_edit_delete_injected_flu_vaccination_and_verify_imms_api(
+    record_flu_with_consent_option,
     schools,
     imms_api_helper,
     sessions_page,
@@ -84,8 +109,8 @@ def test_create_edit_delete_flu_vaccination_and_verify_imms_api(
     children_page,
 ):
     """
-    Test: Create, edit, and delete a flu vaccination record and verify changes in
-       the IMMS API and Mavis status.
+    Test: Create, edit, and delete an injected flu vaccination record and verify changes
+    in the IMMS API and Mavis status.
     Steps:
     1. Setup: Schedule flu session, import class list, add vaccine batch, and
        register child with verbal consent.
@@ -99,7 +124,7 @@ def test_create_edit_delete_flu_vaccination_and_verify_imms_api(
     7. Verify: Check the vaccination record is removed from the IMMS API.
        Check Mavis shows "Not synced".
     """
-    child, vaccination_time = record_flu
+    child, vaccination_time = record_flu_with_consent_option(ConsentOption.INJECTION)
     school = schools[Programme.FLU][0]
 
     # Step 3: Verify creation in IMMS API
@@ -142,5 +167,78 @@ def test_create_edit_delete_flu_vaccination_and_verify_imms_api(
 
     # Step 7: Verify deletion in IMMS API
     imms_api_helper.check_record_is_not_in_imms_api(Vaccine.SEQUIRUS, child)
+    sessions_page.click_vaccination_details(school)
+    children_page.expect_vaccination_details("Synced with NHS England?", "Not synced")
+
+
+def test_create_edit_delete_nasal_flu_vaccination_and_verify_imms_api(
+    record_flu_with_consent_option,
+    schools,
+    imms_api_helper,
+    sessions_page,
+    programmes_page,
+    children_page,
+):
+    """
+    Test: Create, edit, and delete an injected flu vaccination record and verify changes
+    in the IMMS API and Mavis status.
+    Steps:
+    1. Setup: Schedule flu session, import class list, add vaccine batch, and
+       register child with verbal consent.
+    2. Create: Record flu vaccination for the child (LEFT_ARM_UPPER).
+    3. Verify: Check the vaccination record exists in the IMMS API.
+       Check Mavis shows "Synced".
+    4. Edit: Change the delivery site to RIGHT_ARM_LOWER and save.
+    5. Verify: Check the updated vaccination record in the IMMS API.
+       Check Mavis still shows "Synced".
+    6. Edit: Change the outcome to "They refused it" and save.
+    7. Verify: Check the vaccination record is removed from the IMMS API.
+       Check Mavis shows "Not synced".
+    """
+    child, vaccination_time = record_flu_with_consent_option(ConsentOption.BOTH)
+    school = schools[Programme.FLU][0]
+
+    # Step 3: Verify creation in IMMS API
+    imms_api_helper.check_record_in_imms_api(
+        Vaccine.FLUENZ,
+        child,
+        school,
+        DeliverySite.NOSE,
+        vaccination_time,
+    )
+
+    # Step 4: Edit delivery site to RIGHT_ARM_LOWER
+    sessions_page.click_vaccination_details(school)
+    children_page.expect_vaccination_details("Synced with NHS England?", "Synced")
+
+    programmes_page.click_edit_vaccination_record()
+    programmes_page.page.pause()
+    programmes_page.click_change_time()
+    new_vaccination_time = random_datetime_earlier_today(vaccination_time)
+    programmes_page.change_time_of_delivery(new_vaccination_time)
+    programmes_page.click_continue()
+    programmes_page.click_save_changes()
+
+    # Step 5: Verify update in IMMS API
+    imms_api_helper.check_record_in_imms_api(
+        Vaccine.FLUENZ,
+        child,
+        school,
+        DeliverySite.NOSE,
+        new_vaccination_time,
+    )
+
+    # Step 6: Edit outcome to refused
+    sessions_page.click_vaccination_details(school)
+    children_page.expect_vaccination_details("Synced with NHS England?", "Synced")
+
+    programmes_page.click_edit_vaccination_record()
+    programmes_page.click_change_outcome()
+    programmes_page.click_they_refused_it()
+    programmes_page.click_continue()
+    programmes_page.click_save_changes()
+
+    # Step 7: Verify deletion in IMMS API
+    imms_api_helper.check_record_is_not_in_imms_api(Vaccine.FLUENZ, child)
     sessions_page.click_vaccination_details(school)
     children_page.expect_vaccination_details("Synced with NHS England?", "Not synced")

--- a/tests/test_imms_api_hpv.py
+++ b/tests/test_imms_api_hpv.py
@@ -101,7 +101,8 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
     school = schools[Programme.HPV][0]
 
     # Step 3: Verify creation in IMMS API
-    imms_api_helper.check_hpv_record_in_imms_api(
+    imms_api_helper.check_record_in_imms_api(
+        Programme.HPV,
         child,
         school,
         DeliverySite.LEFT_ARM_UPPER,
@@ -119,7 +120,8 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
     programmes_page.click_save_changes()
 
     # Step 5: Verify update in IMMS API
-    imms_api_helper.check_hpv_record_in_imms_api(
+    imms_api_helper.check_record_in_imms_api(
+        Programme.HPV,
         child,
         school,
         DeliverySite.RIGHT_ARM_UPPER,
@@ -137,6 +139,6 @@ def test_create_edit_delete_hpv_vaccination_and_verify_imms_api(
     programmes_page.click_save_changes()
 
     # Step 7: Verify deletion in IMMS API
-    imms_api_helper.check_hpv_record_is_not_in_imms_api(child)
+    imms_api_helper.check_record_is_not_in_imms_api(Programme.HPV, child)
     sessions_page.click_vaccination_details(school)
     children_page.expect_vaccination_details("Synced with NHS England?", "Not synced")


### PR DESCRIPTION
Adds imms API tests for flu, covering both nasal and injected flu.
Required large refactoring of how the imms API test was working and the relationship between Programmes and Vaccines.
