### PR TITLE
Rename decision to response

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -673,11 +673,11 @@ class SessionsPage:
         self.click_mark_as_invalid_link()
         self.fill_notes(invalidation_notes)
         self.click_mark_as_invalid_button()
-        self.expect_details("Decision", "Consent refusedInvalid")
+        self.expect_details("Response", "Consent refusedInvalid")
         self.expect_details("Notes", invalidation_notes)
 
         self.click_back()
-        self.expect_details("Decision", "Consent refusedInvalid")
+        self.expect_details("Response", "Consent refusedInvalid")
         expect(self.page.get_by_text("No requests have been sent.")).to_be_visible()
 
     def expect_details(self, key: str, value: str) -> None:

--- a/tests/test_verbal_consent.py
+++ b/tests/test_verbal_consent.py
@@ -201,7 +201,6 @@ def test_parent_provides_consent_twice(
     verbal_consent_page.record_parent_positive_consent(yes_to_health_questions=True)
     sessions_page.select_consent_given()
 
-    sessions_page.page.pause()
     sessions_page.navigate_to_update_triage_outcome(child, Programme.HPV)
     verbal_consent_page.update_triage_outcome_positive()
 


### PR DESCRIPTION
Rename "Decision" to "Response", following https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4798