### PR TITLE
Click catchup import warning if it should appear

### DIFF
--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -34,7 +34,10 @@ def upload_vaccination(
 
     try:
         dashboard_page.click_sessions()
-        sessions_page.ensure_session_scheduled_for_today(school, Programme.HPV)
+        catch_up = sessions_page.is_catch_up(Programme.HPV, year_group)
+        sessions_page.ensure_session_scheduled_for_today(
+            school, Programme.HPV, expect_dates_check=catch_up
+        )
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list(
             ClassFileMapping.RANDOM_CHILD,


### PR DESCRIPTION
Determine if the catchup warning should appear and click "Keep session dates" if it does. ([MAV-2066](https://nhsd-jira.digital.nhs.uk/browse/MAV-2066))

Should fix regression tests