### PR TITLE
Always click keep changes button if it appears

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -751,7 +751,9 @@ class SessionsPage:
         expect(detail_value).to_contain_text(value)
 
     def ensure_session_scheduled_for_today(
-        self, location: str, programme_group: str, *, expect_dates_check: bool = False
+        self,
+        location: str,
+        programme_group: str,
     ) -> None:
         self.click_session_for_programme_group(location, programme_group)
         todays_date = get_todays_date().strftime("%Y%m%d")
@@ -759,22 +761,20 @@ class SessionsPage:
             self.__get_display_formatted_date(date_to_format=todays_date),
         ).is_visible():
             self.schedule_a_valid_session(
-                offset_days=0, expect_dates_check=expect_dates_check
+                offset_days=0,
             )
 
     def schedule_a_valid_session(
         self,
         offset_days: int = 7,
-        *,
-        expect_dates_check: bool = False,
     ) -> None:
         _future_date = get_offset_date_compact_format(
             offset_days=offset_days, skip_weekends=True
         )
         self.__schedule_session(date=_future_date)
 
-        if expect_dates_check:
-            self.click_keep_session_dates()
+        if self.keep_session_dates_button.is_visible():
+            self.click_keep_session_dates()  # MAV-2066
 
         self.expect_details(
             "Session dates",

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -34,9 +34,9 @@ def upload_vaccination(
 
     try:
         dashboard_page.click_sessions()
-        catch_up = sessions_page.is_catch_up(Programme.HPV, year_group)
         sessions_page.ensure_session_scheduled_for_today(
-            school, Programme.HPV, expect_dates_check=catch_up
+            school,
+            Programme.HPV,
         )
         sessions_page.click_import_class_lists()
         import_records_page.import_class_list(


### PR DESCRIPTION
The circumstances in which the warning from https://nhsd-jira.digital.nhs.uk/browse/MAV-2066 appears are quite specific (needs specific year group/programme combinations and a session with at least one child in where the number of children that do not have historical records surpasses some threshold)

Since tests within a module can have an effect on each other, it's quite hard to get this right. For now, we'll always dismiss this warning if it appears and, in the future, add a test that specifically tests this warning