### PR TITLE
Run all programmes by default in workflows

### DIFF
--- a/.github/actions/run-functional-tests/action.yml
+++ b/.github/actions/run-functional-tests/action.yml
@@ -1,5 +1,5 @@
-name: "Run Tests"
-description: "Execute tests"
+name: 'Run Tests'
+description: 'Execute tests'
 inputs:
   tests:
     default: ''
@@ -10,7 +10,7 @@ inputs:
   base_url:
     required: true
   programmes_enabled:
-    required: true
+    default: 'FLU,HPV,MENACWY,MMR,TD_IPV'
   screenshot_all_steps:
     required: true
   set_feature_flags:

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -44,7 +44,6 @@ jobs:
         with:
           device: ${{ matrix.device }}
           base_url: ${{ vars.BASE_URL }}
-          programmes_enabled: ${{ vars.PROGRAMMES_ENABLED }}
           playwright_cache_hit: ${{ steps.playwright-cache.outputs.cache-hit }}
         env:
           BASIC_AUTH_TOKEN: ${{ secrets.HTTP_AUTH_TOKEN_FOR_TESTS }}


### PR DESCRIPTION
Let the workflows use all programmes by default. This will remove the PROGRAMMES_ENABLED variable from github actions which is no longer necessary.