### PR TITLE
Refactor child generation

### DIFF
--- a/mavis/test/fixtures/models.py
+++ b/mavis/test/fixtures/models.py
@@ -152,16 +152,9 @@ def team(onboarding) -> Team:
 
 @pytest.fixture
 def children(year_groups) -> dict[str, list[Child]]:
-    def _generate_children(n: int, year_group: int) -> list[Child]:
-        return [
-            Child.generate(year_group)
-            for _ in range(n)
-        ]
-
-    return {
-        programme.group: _generate_children(2, year_groups[programme.group])
-        for programme in Programme
-    }
+    return Child.generate_children_in_year_group_for_each_programme_group(
+        2, year_groups
+    )
 
 
 def _read_imms_api_credentials() -> dict[str, str]:

--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -579,6 +579,21 @@ class Child(NamedTuple):
             parents=(Parent.get(Relationship.DAD), Parent.get(Relationship.MUM)),
         )
 
+    @classmethod
+    def generate_children_for_year_group(cls, n: int, year_group: int) -> list["Child"]:
+        return [cls.generate(year_group) for _ in range(n)]
+
+    @classmethod
+    def generate_children_in_year_group_for_each_programme_group(
+        cls, n: int, year_group_dict: dict[str, int]
+    ) -> dict[str, list["Child"]]:
+        return {
+            programme.group: cls.generate_children_for_year_group(
+                n, year_group_dict[programme.group]
+            )
+            for programme in Programme
+        }
+
 
 class ImmsEndpoints(StrEnum):
     AUTH = "/oauth2/token"


### PR DESCRIPTION
Extracts the child generation to the `Child` class. This makes it more consistent with other classes and also allows child generation to be used elsewhere e.g. in new tests