### PR TITLE
allow reruns to be configured on github action

### DIFF
--- a/.github/actions/run-functional-tests/action.yml
+++ b/.github/actions/run-functional-tests/action.yml
@@ -13,6 +13,8 @@ inputs:
     default: 'FLU,HPV,MENACWY,MMR,TD_IPV'
   screenshot_all_steps:
     required: true
+  enable_reruns:
+    default: 'true'
   set_feature_flags:
     default: 'false'
   additional_feature_flags:
@@ -46,8 +48,18 @@ runs:
         fi
       shell: bash
 
+    - name: Determine if reruns are enabled
+      id: reruns
+      run: |
+        if [ "${{ inputs.enable_reruns }}" = "true" ]; then
+          echo "reruns=--reruns 2" >> $GITHUB_OUTPUT
+        else
+          echo "reruns=" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
     - name: Run tests
-      run: uv run pytest --reruns 2 -m "${{ steps.marker.outputs.marker }}" --device "${{ inputs.device }}" ${{ inputs.tests }}
+      run: uv run pytest ${{ steps.reruns.outputs.reruns }} -m "${{ steps.marker.outputs.marker }}" --device "${{ inputs.device }}" ${{ inputs.tests }}
       shell: bash
       env:
         BASE_URL: ${{ inputs.base_url }}

--- a/.github/workflows/functional_selected_device.yaml
+++ b/.github/workflows/functional_selected_device.yaml
@@ -43,6 +43,14 @@ on:
         options:
           - true
           - false
+      enable_reruns:
+        description: 'Enable test reruns on failure (up to 3 attempts)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - true
+          - false
       set_feature_flags:
         description: 'Set feature flags in the flipper page before running tests (affects all users of the environment being tested!)'
         required: true
@@ -87,6 +95,7 @@ jobs:
             echo "additional_feature_flags=" >> $GITHUB_OUTPUT
             echo "deploy_report=false" >> $GITHUB_OUTPUT
             echo "screenshot_all_steps=false" >> $GITHUB_OUTPUT
+            echo "enable_reruns=true" >> $GITHUB_OUTPUT
           else
             echo "tests=${{ github.event.inputs.tests }}" >> $GITHUB_OUTPUT
             echo "device=${{ github.event.inputs.device }}" >> $GITHUB_OUTPUT
@@ -100,6 +109,7 @@ jobs:
             echo "additional_feature_flags=${{ github.event.inputs.additional_feature_flags }}" >> $GITHUB_OUTPUT
             echo "deploy_report=true" >> $GITHUB_OUTPUT
             echo "screenshot_all_steps=${{ github.event.inputs.screenshot_all_steps }}" >> $GITHUB_OUTPUT
+            echo "enable_reruns=${{ github.event.inputs.enable_reruns }}" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@v5
@@ -119,6 +129,7 @@ jobs:
           base_url: ${{ steps.set-variables.outputs.environment }}
           programmes_enabled: ${{ steps.set-variables.outputs.programmes }}
           screenshot_all_steps: ${{ steps.set-variables.outputs.screenshot_all_steps }}
+          enable_reruns: ${{ steps.set-variables.outputs.enable_reruns }}
           set_feature_flags: ${{ steps.set-variables.outputs.set_feature_flags }}
           additional_feature_flags: ${{ steps.set-variables.outputs.additional_feature_flags }}
           playwright_cache_hit: ${{ steps.playwright-cache.outputs.cache-hit }}


### PR DESCRIPTION
Allows the user to choose whether reruns are enabled for the workflow. Usually you would want this in case of rare flaky/random errors, but it would also be useful to disable this so that I could get faster feedback on why e.g. certain tests only fail on CI but not locally.