### PR TITLE
Use updated query parameter

### DIFF
--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -414,7 +414,7 @@ class School(NamedTuple):
                 "type": "school",
                 "status": "open",
                 "is_attached_to_team": "false",
-                "year_groups[]": [str(year_group)],
+                "gias_year_groups[]": [str(year_group)],
             }
 
             response = requests.get(url, params=params, timeout=30)


### PR DESCRIPTION
The `year_groups` query parameter has been renamed to `gias_year_groups` to better reflect what it refers to.