### PR TITLE
Revert tallying changes

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -242,9 +242,9 @@ class SessionsPage:
     def click_psds_tab(self) -> None:
         self._select_tab("PSDs")
 
-    @step("Click Did not consent")
-    def click_did_not_consent(self) -> None:
-        self.did_not_consent_link.click()
+    @step("Click Review consent refused")
+    def click_review_consent_refused(self) -> None:
+        self.review_consent_refused_link.click()
 
     @step("Expect Consent refused checkbox to be checked")
     def expect_consent_refused_checkbox_to_be_checked(self) -> None:
@@ -418,7 +418,7 @@ class SessionsPage:
 
     def expect_session_to_have_programmes(self, programmes: list[Programme]) -> None:
         for programme in programmes:
-            expect(self.page.get_by_role("heading", name=programme)).to_be_visible()
+            expect(self.page.get_by_text(programme)).to_be_visible()
 
     @step("Click on Change session dates")
     def click_change_session_dates(self) -> None:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -171,7 +171,7 @@ def test_consent_filters(
     verbal_consent_page.record_parent_refuse_consent()
 
     sessions_page.click_overview_tab()
-    sessions_page.click_did_not_consent()
+    sessions_page.click_review_consent_refused()
     sessions_page.expect_consent_refused_checkbox_to_be_checked()
 
 

--- a/tests/test_tallying.py
+++ b/tests/test_tallying.py
@@ -66,6 +66,7 @@ def setup_fixed_child(setup_session_with_file_upload):
 
 @issue("MAV-1669")
 @pytest.mark.bug
+@pytest.mark.skip
 def test_tallying(
     setup_fixed_child,
     sessions_page,


### PR DESCRIPTION
This reverts the changes that were made for tallying. It can be reverted when tallying is back on qa/test