### PR TITLE
Refactor TestData fixture

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -331,47 +331,53 @@ class TestData:
 
         return _input_file_path, _output_file_path
 
-    def read_scenario_list_from_file(self, input_file_path: Path) -> str | None:
-        try:
-            _df = pd.read_csv(input_file_path)
-            return (
-                ", ".join(_df["TEST_DESC_IGNORED"].tolist())
-                if "TEST_DESC_IGNORED" in _df.columns
-                else None
-            )
-        except pd.errors.EmptyDataError:
-            return None
 
-    def create_child_list_from_file(
-        self,
-        file_path: Path,
-        *,
-        is_vaccinations: bool,
-    ) -> list[str]:
-        _file_df = pd.read_csv(file_path)
+# test data utility functions
 
-        if is_vaccinations:
-            _cols = ["PERSON_SURNAME", "PERSON_FORENAME"]
-        else:
-            _cols = ["CHILD_LAST_NAME", "CHILD_FIRST_NAME"]
 
-        last_name_list = _file_df[_cols[0]].apply(normalize_whitespace)
-        first_name_list = _file_df[_cols[1]].apply(normalize_whitespace)
-        return (last_name_list + ", " + first_name_list).tolist()
+def read_scenario_list_from_file(input_file_path: Path) -> str | None:
+    try:
+        _df = pd.read_csv(input_file_path)
+        return (
+            ", ".join(_df["TEST_DESC_IGNORED"].tolist())
+            if "TEST_DESC_IGNORED" in _df.columns
+            else None
+        )
+    except pd.errors.EmptyDataError:
+        return None
 
-    def get_session_id(self, path: Path) -> str:
-        data_frame = pd.read_excel(path, sheet_name="Vaccinations", dtype=str)
-        session_ids = data_frame["SESSION_ID"].dropna()
-        session_ids = session_ids[session_ids.str.strip() != ""]
 
-        if session_ids.empty:
-            msg = "No valid SESSION_ID found in the file."
-            raise ValueError(msg)
-        return session_ids.iloc[0]
+def get_session_id(path: Path) -> str:
+    data_frame = pd.read_excel(path, sheet_name="Vaccinations", dtype=str)
+    session_ids = data_frame["SESSION_ID"].dropna()
+    session_ids = session_ids[session_ids.str.strip() != ""]
 
-    def increment_date_of_birth_for_records(self, file_path: Path) -> None:
-        _file_df = pd.read_csv(file_path)
-        _file_df["CHILD_DATE_OF_BIRTH"] = pd.to_datetime(
-            _file_df["CHILD_DATE_OF_BIRTH"],
-        ) + pd.Timedelta(days=1)
-        _file_df.to_csv(file_path, index=False)
+    if session_ids.empty:
+        msg = "No valid SESSION_ID found in the file."
+        raise ValueError(msg)
+    return session_ids.iloc[0]
+
+
+def create_child_list_from_file(
+    file_path: Path,
+    *,
+    is_vaccinations: bool,
+) -> list[str]:
+    _file_df = pd.read_csv(file_path)
+
+    if is_vaccinations:
+        _cols = ["PERSON_SURNAME", "PERSON_FORENAME"]
+    else:
+        _cols = ["CHILD_LAST_NAME", "CHILD_FIRST_NAME"]
+
+    last_name_list = _file_df[_cols[0]].apply(normalize_whitespace)
+    first_name_list = _file_df[_cols[1]].apply(normalize_whitespace)
+    return (last_name_list + ", " + first_name_list).tolist()
+
+
+def increment_date_of_birth_for_records(file_path: Path) -> None:
+    _file_df = pd.read_csv(file_path)
+    _file_df["CHILD_DATE_OF_BIRTH"] = pd.to_datetime(
+        _file_df["CHILD_DATE_OF_BIRTH"],
+    ) + pd.Timedelta(days=1)
+    _file_df.to_csv(file_path, index=False)

--- a/mavis/test/fixtures/pages.py
+++ b/mavis/test/fixtures/pages.py
@@ -77,8 +77,8 @@ def child_edit_page(page: Page) -> ChildEditPage:
 
 
 @pytest.fixture
-def children_search_page(page: Page, test_data: TestData) -> ChildrenSearchPage:
-    return ChildrenSearchPage(page, test_data)
+def children_search_page(page: Page) -> ChildrenSearchPage:
+    return ChildrenSearchPage(page)
 
 
 @pytest.fixture
@@ -179,8 +179,8 @@ def school_moves_page(page: Page) -> SchoolMovesPage:
 
 
 @pytest.fixture
-def sessions_page(page: Page, test_data: TestData) -> SessionsPage:
-    return SessionsPage(page, test_data)
+def sessions_page(page: Page) -> SessionsPage:
+    return SessionsPage(page)
 
 
 @pytest.fixture

--- a/mavis/test/pages/children.py
+++ b/mavis/test/pages/children.py
@@ -4,15 +4,14 @@ from pathlib import Path
 from playwright.sync_api import Page, expect
 
 from mavis.test.annotations import step
-from mavis.test.data import TestData
+from mavis.test.data import create_child_list_from_file
 from mavis.test.models import Child, Programme, School
 from mavis.test.utils import get_current_datetime, reload_until_element_is_visible
 
 
 class ChildrenSearchPage:
-    def __init__(self, page: Page, test_data: TestData) -> None:
+    def __init__(self, page: Page) -> None:
         self.page = page
-        self.test_data = test_data
 
         self.children_heading = self.page.get_by_role(
             "heading",
@@ -57,7 +56,7 @@ class ChildrenSearchPage:
         *,
         is_vaccinations: bool,
     ) -> None:
-        child_names = self.test_data.create_child_list_from_file(
+        child_names = create_child_list_from_file(
             file_path,
             is_vaccinations=is_vaccinations,
         )

--- a/mavis/test/pages/import_records.py
+++ b/mavis/test/pages/import_records.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from playwright.sync_api import Page, expect
 
 from mavis.test.annotations import step
-from mavis.test.data import FileMapping, TestData
+from mavis.test.data import FileMapping, TestData, read_scenario_list_from_file
 from mavis.test.models import Programme
 from mavis.test.utils import (
     format_datetime_for_upload_link,
@@ -126,7 +126,7 @@ class ImportRecordsPage:
             session_id=session_id,
             programme_group=programme_group,
         )
-        _scenario_list = self.test_data.read_scenario_list_from_file(_input_file_path)
+        _scenario_list = read_scenario_list_from_file(_input_file_path)
 
         self.set_input_file(_input_file_path)
         # temporary sleep to ensure urn appears in Mavis

--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -8,7 +8,7 @@ import pandas as pd
 from playwright.sync_api import Locator, Page, expect
 
 from mavis.test.annotations import step
-from mavis.test.data import TestData
+from mavis.test.data import get_session_id
 from mavis.test.models import (
     Child,
     ConsentOption,
@@ -33,9 +33,7 @@ class SessionsPage:
     def __init__(
         self,
         page: Page,
-        test_data: TestData,
     ) -> None:
-        self.test_data = test_data
         self.page = page
 
         self.no_response_checkbox = self.page.get_by_role(
@@ -708,7 +706,7 @@ class SessionsPage:
 
     def get_session_id_from_offline_excel(self) -> str:
         file_path = self.download_offline_recording_excel()
-        return self.test_data.get_session_id(file_path)
+        return get_session_id(file_path)
 
     @step("Click Sessions")
     def click_sessions(self) -> None:


### PR DESCRIPTION
The TestData fixture was unnecessarily being passed into other fixtures. The TestData class also had various utility functions which were not relevant to data for tests (just random file utility functions). These have now been moved and now only the ImportRecordsPage relies on the TestData fixture.