### PR TITLE
Make clicking filter more robust

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -282,6 +282,7 @@ class SessionsPage:
         self,
         programme: Programme,
     ) -> None:
+        self.page.wait_for_load_state()
         if programme is not Programme.FLU:
             for locator in [
                 self.consent_given_for_injected_vaccine_checkbox,


### PR DESCRIPTION
Seeing this fail locally due to clicking too quickly