### PR TITLE
Fix reporting expectation when one child present

### DIFF
--- a/mavis/test/pages/reports.py
+++ b/mavis/test/pages/reports.py
@@ -63,21 +63,21 @@ class ReportsVaccinationsPage(ReportsTabsMixin):
         self.page.get_by_role("radio", name=programme).check()
 
     @step("Check cohort has {1} children")
-    def check_cohort_has_n_children(self, expected_value: int) -> None:
+    def check_cohort_has_n_children(self, expected_value_string: str) -> None:
         cohort_heading = self.page.get_by_role("heading", name="Cohort", exact=True)
         cohort_value = cohort_heading.locator("xpath=following-sibling::*[1]")
-        if expected_value == 1:
-            expect(cohort_value).to_contain_text(f"{expected_value}child")
+        if expected_value_string == "1":
+            expect(cohort_value).to_contain_text(f"{expected_value_string}child")
         else:
-            expect(cohort_value).to_contain_text(f"{expected_value}children")
+            expect(cohort_value).to_contain_text(f"{expected_value_string}children")
 
     @step("Check category {1} percentage is {2}%")
     def check_category_percentage(
-        self, category: str, expected_percentage: str
+        self, category: str, expected_percentage_string: str
     ) -> None:
         category_heading = self.page.get_by_role("heading", name=category, exact=True)
         category_value = category_heading.locator("xpath=following-sibling::*[1]")
-        expect(category_value).to_contain_text(f"{expected_percentage}%")
+        expect(category_value).to_contain_text(f"{expected_percentage_string}%")
 
     def get_children_count(self, category: str) -> int:
         category_card = self.page.locator(


### PR DESCRIPTION
This function actually takes `str` rather than `int`, which I did not check when updating this previously. I've updated this and made it more clear