### PR TITLE
Set team type when onboarding

### DIFF
--- a/mavis/test/models.py
+++ b/mavis/test/models.py
@@ -545,6 +545,7 @@ class Team(NamedTuple):
             "careplus_venue_code": self.careplus_venue_code,
             "privacy_notice_url": "https://example.com/privacy",
             "privacy_policy_url": "https://example.com/privacy",
+            "type": "poc_only",
         }
 
     @classmethod


### PR DESCRIPTION
Set team type when onboarding, so that regression tests can work with https://github.com/nhsuk/manage-vaccinations-in-schools/pull/5080
