### PR TITLE
Make providing a basic auth username/password or token optional

### DIFF
--- a/.env.generic
+++ b/.env.generic
@@ -1,6 +1,7 @@
 PROGRAMMES_ENABLED=FLU,HPV,MENACWY,MMR,TD_IPV
 BASE_URL=https://qa.mavistesting.com
 
+# if running tests against an environment behind basic auth (e.g. qa)
 # provide either a token or a username/password pair
 BASIC_AUTH_USERNAME=
 BASIC_AUTH_PASSWORD=

--- a/mavis/test/fixtures/playwright.py
+++ b/mavis/test/fixtures/playwright.py
@@ -40,5 +40,7 @@ def browser_context_args(
             **browser_context_args,
             "extra_http_headers": {"Authorization": f"Basic {basic_auth_token}"},
         }
+    if basic_auth_credentials["username"] and basic_auth_credentials["password"]:
+        return {**browser_context_args, "http_credentials": basic_auth_credentials}
 
-    return {**browser_context_args, "http_credentials": basic_auth_credentials}
+    return browser_context_args


### PR DESCRIPTION
This saves some setup when running against environments without basic auth, e.g. when testing a locally running Mavis.