### PR TITLE
Search for children instead of assuming they appear by default

### DIFF
--- a/mavis/test/pages/sessions.py
+++ b/mavis/test/pages/sessions.py
@@ -60,13 +60,13 @@ class SearchBarMixin:
             self.page.get_by_text("No children matching search criteria found"),
         ).to_be_visible()
 
-    def search_child(self, child: Child) -> None:
+    def search_and_click_child(self, child: Child) -> None:
         self.search_for(str(child))
         child_locator = self.page.get_by_role("link", name=str(child))
         reload_until_element_is_visible(self.page, child_locator)
         child_locator.click()
 
-    def search_child_that_should_not_exist(self, child: Child) -> None:
+    def search_for_child_that_should_not_exist(self, child: Child) -> None:
         self.search_for(str(child))
         child_locator = self.page.get_by_role("link", name=str(child))
         expect(child_locator).not_to_be_visible()
@@ -78,13 +78,6 @@ class SearchBarMixin:
     @step("Check Archived records")
     def check_archived_records_checkbox(self) -> None:
         self.archived_records_checkbox.check()
-
-    @step("Click on child {1}")
-    def click_child(self, child: Child) -> None:
-        with self.page.expect_navigation():
-            self.page.get_by_role("heading", name=str(child)).get_by_role(
-                "link",
-            ).first.click()
 
     @step("Check box for year {1}")
     def check_year_checkbox(self, year: int) -> None:

--- a/tests/test_e2e_doubles.py
+++ b/tests/test_e2e_doubles.py
@@ -91,7 +91,7 @@ def test_recording_doubles_vaccination_e2e(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(
         child, Programme.MENACWY, menquadfi_batch_name

--- a/tests/test_e2e_flu.py
+++ b/tests/test_e2e_flu.py
@@ -101,7 +101,7 @@ def test_recording_flu_vaccination_e2e(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(
         child, Programme.FLU, batch_name, consent_option

--- a/tests/test_e2e_hpv.py
+++ b/tests/test_e2e_hpv.py
@@ -79,7 +79,7 @@ def test_recording_hpv_vaccination_e2e(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(child, Programme.HPV, gardasil_9_batch_name)
     sessions_patient_page.set_up_vaccination(vaccination_record)

--- a/tests/test_e2e_mmr.py
+++ b/tests/test_e2e_mmr.py
@@ -81,7 +81,7 @@ def test_recording_mmr_vaccination_e2e_with_triage(
     # Triage step added for MMR
     sessions_search_page.click_session_for_programme_group(schools[0], Programme.MMR)
     sessions_overview_page.click_triage_tab()
-    sessions_triage_page.search_child(child)
+    sessions_triage_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.MMR)
     sessions_patient_page.triage_mmr_patient(ConsentOption.MMR_EITHER)
     dashboard_page.navigate()
@@ -93,7 +93,7 @@ def test_recording_mmr_vaccination_e2e_with_triage(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(child, Programme.MMR, mmr_batch_name)
     sessions_patient_page.set_up_vaccination(vaccination_record)
@@ -170,7 +170,7 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(child, Programme.MMR, mmr_batch_name)
     sessions_patient_page.set_up_vaccination(vaccination_record)
@@ -181,7 +181,7 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     dashboard_page.click_sessions()
     sessions_search_page.click_session_for_programme_group(schools[0], Programme.MMR)
     sessions_overview_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child_that_should_not_exist(child)
+    sessions_record_vaccinations_page.search_for_child_that_should_not_exist(child)
 
     dashboard_page.navigate()
     log_in_page.log_out()
@@ -258,7 +258,7 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
     # Triage step added for MMR
     sessions_search_page.click_session_for_programme_group(schools[0], Programme.MMR)
     sessions_overview_page.click_triage_tab()
-    sessions_triage_page.search_child(child)
+    sessions_triage_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.MMR)
     sessions_patient_page.triage_mmr_patient(ConsentOption.MMR_EITHER)
     dashboard_page.navigate()
@@ -269,7 +269,7 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(child, Programme.MMR, mmr_batch_name)
     sessions_patient_page.set_up_vaccination(vaccination_record)

--- a/tests/test_nurse_consent.py
+++ b/tests/test_nurse_consent.py
@@ -74,7 +74,7 @@ def test_gillick_competence(
 
     sessions_search_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_assess_gillick_competence()
 
@@ -112,7 +112,7 @@ def test_gillick_competence_notes(
 
     sessions_search_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_assess_gillick_competence()
 
@@ -164,7 +164,7 @@ def test_invalid_consent(
     sessions_search_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_overview_page.click_consent_tab()
     sessions_consent_page.select_no_response()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
 
@@ -174,7 +174,7 @@ def test_invalid_consent(
 
     sessions_consent_page.select_no_response()
 
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
     nurse_consent_wizard_page.select_parent(child.parents[1])
@@ -182,7 +182,7 @@ def test_invalid_consent(
     nurse_consent_wizard_page.record_parent_refuse_consent()
 
     sessions_consent_page.select_consent_refused()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.invalidate_parent_refusal(child.parents[1])
     sessions_patient_page.click_session_activity_and_notes()
@@ -231,7 +231,7 @@ def test_parent_provides_consent_twice(
     sessions_overview_page.click_consent_tab()
     sessions_consent_page.select_no_response()
 
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
     nurse_consent_wizard_page.select_parent(child.parents[0])
@@ -241,7 +241,7 @@ def test_parent_provides_consent_twice(
     )
     sessions_consent_page.select_consent_given_filters_for_programme(Programme.HPV)
 
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
     nurse_consent_wizard_page.select_parent(child.parents[0])
@@ -250,7 +250,7 @@ def test_parent_provides_consent_twice(
 
     sessions_consent_page.select_consent_refused()
 
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_vaccination_wizard_page.expect_consent_refused_text(child.parents[0])
     sessions_patient_page.click_session_activity_and_notes()
@@ -299,7 +299,7 @@ def test_conflicting_consent_with_gillick_consent(
     sessions_search_page.click_session_for_programme_group(school, Programme.HPV)
     sessions_overview_page.click_consent_tab()
     sessions_consent_page.select_no_response()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
 
@@ -308,7 +308,7 @@ def test_conflicting_consent_with_gillick_consent(
     nurse_consent_wizard_page.record_parent_positive_consent()
 
     sessions_consent_page.select_consent_given_filters_for_programme(Programme.HPV)
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
 
@@ -318,7 +318,7 @@ def test_conflicting_consent_with_gillick_consent(
 
     sessions_consent_page.select_conflicting_consent()
 
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.expect_consent_status(Programme.HPV, "Conflicting consent")
     sessions_patient_page.expect_conflicting_consent_text()
@@ -331,7 +331,7 @@ def test_conflicting_consent_with_gillick_consent(
     nurse_consent_wizard_page.expect_text_in_alert(f"Consent recorded for {child!s}")
 
     sessions_consent_page.select_consent_given_filters_for_programme(Programme.HPV)
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.expect_consent_status(Programme.HPV, "Consent given")
     sessions_patient_page.click_session_activity_and_notes()
@@ -367,7 +367,7 @@ def test_accessibility(
     sessions_overview_page.click_consent_tab()
     sessions_consent_page.select_no_response()
 
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
     accessibility_helper.check_accessibility()
@@ -401,7 +401,7 @@ def test_accessibility(
     sessions_register_page.click_record_vaccinations_tab()
     accessibility_helper.check_accessibility()
 
-    sessions_record_vaccinations_page.click_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
     accessibility_helper.check_accessibility()
 
     sessions_patient_page.confirm_pre_screening_checks(Programme.HPV)

--- a/tests/test_psd.py
+++ b/tests/test_psd.py
@@ -119,7 +119,7 @@ def test_delivering_vaccination_after_psd(
     sessions_edit_page.click_save_changes()
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.search_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.FLU)
     sessions_patient_page.click_record_a_new_consent_response()
     nurse_consent_wizard_page.select_parent(child.parents[0])
@@ -144,7 +144,7 @@ def test_delivering_vaccination_after_psd(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(
         child, Programme.FLU, fluenz_batch_name, ConsentOption.NASAL_SPRAY_OR_INJECTION

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -100,7 +100,7 @@ def test_pre_screening_questions_prefilled_for_multiple_vaccinations(
             sessions_overview_page.click_register_tab()
             sessions_register_page.register_child_as_attending(str(child))
         sessions_register_page.click_consent_tab()
-        sessions_consent_page.search_child(child)
+        sessions_consent_page.search_and_click_child(child)
         programmes = (
             [Programme.MENACWY, Programme.TD_IPV]
             if programme_group == "doubles"
@@ -128,7 +128,7 @@ def test_pre_screening_questions_prefilled_for_multiple_vaccinations(
                 target_length=MAVIS_NOTE_LENGTH_LIMIT + 1,
                 generate_spaced_words=True,
             )
-            sessions_consent_page.search_child(child)
+            sessions_consent_page.search_and_click_child(child)
             sessions_patient_page.set_up_vaccination(vaccination_record, notes=notes)
             sessions_vaccination_wizard_page.record_vaccination(
                 vaccination_record, notes=notes

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -192,7 +192,7 @@ def test_consent_filters(
     """
     child = children[Programme.HPV][0]
     sessions_overview_page.review_child_with_no_response()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_record_a_new_consent_response()
 
     nurse_consent_wizard_page.select_parent(child.parents[0])
@@ -232,7 +232,7 @@ def test_session_activity_notes_order(
     note_2 = "Note 2"
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.search_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_session_activity_and_notes()
     sessions_patient_session_activity_page.add_note(note_1)
     sessions_patient_session_activity_page.add_note(note_2)
@@ -242,7 +242,7 @@ def test_session_activity_notes_order(
     sessions_overview_page.click_consent_tab()
     sessions_consent_page.search_for(str(child))
     sessions_consent_page.check_note_appears_in_search(child, note_2)
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_session_activity_and_notes()
     sessions_patient_session_activity_page.check_notes_appear_in_order([note_2, note_1])
 
@@ -272,7 +272,7 @@ def test_triage_consent_given_and_triage_outcome(
     school = schools[Programme.HPV][0]
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
 
@@ -288,7 +288,7 @@ def test_triage_consent_given_and_triage_outcome(
     sessions_search_page.click_session_for_programme_group(school, Programme.HPV)
 
     sessions_overview_page.click_register_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_update_triage_outcome()
     sessions_patient_page.select_yes_safe_to_vaccinate()
@@ -318,7 +318,7 @@ def test_consent_refused_and_activity_log(
     child = children[Programme.HPV][0]
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.HPV)
     sessions_patient_page.click_record_a_new_consent_response()
 
@@ -328,7 +328,7 @@ def test_consent_refused_and_activity_log(
     nurse_consent_wizard_page.expect_text_in_alert(str(child))
 
     sessions_consent_page.select_consent_refused()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_session_activity_and_notes()
     sessions_patient_session_activity_page.check_session_activity_entry(
         f"Consent refused by {child.parents[0].name_and_relationship}",
@@ -396,7 +396,7 @@ def test_verify_excel_export_and_clinic_invitation(
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
     vaccination_record = VaccinationRecord(child, Programme.HPV, batch_name)
     sessions_patient_page.set_up_vaccination(vaccination_record)
     sessions_vaccination_wizard_page.record_vaccination(
@@ -463,7 +463,7 @@ def test_editing_session_programmes(
     sessions_edit_page.click_save_changes()
     sessions_edit_page.expect_session_to_have_programmes([Programme.FLU, Programme.HPV])
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.FLU)
 
 
@@ -522,7 +522,7 @@ def test_accessibility(
     sessions_triage_page.click_register_tab()
     accessibility_helper.check_accessibility()
 
-    sessions_register_page.click_child(child)
+    sessions_register_page.search_and_click_child(child)
     accessibility_helper.check_accessibility()
 
     sessions_patient_page.click_session_activity_and_notes()

--- a/tests/test_tallying.py
+++ b/tests/test_tallying.py
@@ -99,7 +99,7 @@ def test_tallying(  # noqa: PLR0915
     assert tally_totals[TallyCategory.NO_RESPONSE] > 0
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.FLU)
     sessions_patient_page.click_record_a_new_consent_response()
     nurse_consent_wizard_page.select_parent(child.parents[0])
@@ -113,7 +113,7 @@ def test_tallying(  # noqa: PLR0915
     sessions_overview_page.check_all_totals(tally_totals)
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_response_from_parent(child.parents[0])
     sessions_patient_page.click_withdraw_consent()
     nurse_consent_wizard_page.click_consent_refusal_reason(
@@ -129,7 +129,7 @@ def test_tallying(  # noqa: PLR0915
     sessions_overview_page.check_all_totals(tally_totals)
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.invalidate_parent_refusal(child.parents[0])
     sessions_patient_page.go_back_to_session_for_school(school)
 
@@ -138,7 +138,7 @@ def test_tallying(  # noqa: PLR0915
     sessions_overview_page.check_all_totals(tally_totals)
 
     sessions_overview_page.click_consent_tab()
-    sessions_consent_page.click_child(child)
+    sessions_consent_page.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(Programme.FLU)
     sessions_patient_page.click_record_a_new_consent_response()
     nurse_consent_wizard_page.select_parent(child.parents[1])
@@ -156,7 +156,7 @@ def test_tallying(  # noqa: PLR0915
     sessions_overview_page.click_register_tab()
     sessions_register_page.register_child_as_attending(str(child))
     sessions_register_page.click_record_vaccinations_tab()
-    sessions_record_vaccinations_page.search_child(child)
+    sessions_record_vaccinations_page.search_and_click_child(child)
 
     vaccination_record = VaccinationRecord(
         child, Programme.FLU, batch_name, ConsentOption.NASAL_SPRAY


### PR DESCRIPTION
Replaces `click_child` with `search_and_click_child` which is far more robust. It should prevent some flaky errors we see in non-chromium browsers too.