### PR TITLE
Make child name handling consistent

### DIFF
--- a/mavis/test/data/__init__.py
+++ b/mavis/test/data/__init__.py
@@ -376,7 +376,7 @@ def create_child_list_from_file(
 
     last_name_list = _file_df[_cols[0]].apply(normalize_whitespace)
     first_name_list = _file_df[_cols[1]].apply(normalize_whitespace)
-    return (last_name_list + ", " + first_name_list).tolist()
+    return last_name_list.str.cat(first_name_list, sep=", ").tolist()
 
 
 def increment_date_of_birth_for_records(file_path: Path) -> None:

--- a/mavis/test/pages/school_moves.py
+++ b/mavis/test/pages/school_moves.py
@@ -10,10 +10,6 @@ from mavis.test.models import SCHOOL_MOVE_HEADERS, Child, School
 from mavis.test.utils import reload_until_element_is_visible
 
 
-def get_child_full_name(first_name: str, last_name: str) -> str:
-    return f"{last_name.upper()}, {first_name}"
-
-
 class SchoolMovesPage:
     def __init__(self, page: Page) -> None:
         self.page = page
@@ -26,9 +22,9 @@ class SchoolMovesPage:
             has_text="ignored",
         )
 
-    @step("Click on school move for {1} {2}")
-    def click_child(self, first_name: str, last_name: str) -> None:
-        row = self.get_row_for_child(first_name, last_name)
+    @step("Click on school move for {1}")
+    def click_child(self, child: Child) -> None:
+        row = self.get_row_for_child(child)
         reload_until_element_is_visible(self.page, row)
         row.get_by_role("link", name="Review").click()
 
@@ -36,9 +32,8 @@ class SchoolMovesPage:
     def click_download(self) -> None:
         self.download_button.click()
 
-    def get_row_for_child(self, first_name: str, last_name: str) -> Locator:
-        full_name = get_child_full_name(first_name, last_name)
-        return self.rows.filter(has=self.page.get_by_text(full_name))
+    def get_row_for_child(self, child: Child) -> Locator:
+        return self.rows.filter(has=self.page.get_by_text(str(child)))
 
 
 class DownloadSchoolMovesPage:

--- a/tests/test_online_consent_school_moves.py
+++ b/tests/test_online_consent_school_moves.py
@@ -98,7 +98,7 @@ def test_online_consent_school_moves_with_existing_patient(
     # Verify in session
     dashboard_page.navigate()
     dashboard_page.click_school_moves()
-    school_moves_page.click_child(*child.name)
+    school_moves_page.click_child(child)
     review_school_move_page.confirm()
 
     dashboard_page.navigate()

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -98,20 +98,20 @@ def test_confirm_and_ignore(
     schools = schools[Programme.HPV]
     child_1, child_2 = children[Programme.HPV][0], children[Programme.HPV][1]
 
-    row1 = school_moves_page.get_row_for_child(*child_1.name)
-    row2 = school_moves_page.get_row_for_child(*child_2.name)
+    row1 = school_moves_page.get_row_for_child(child_1)
+    row2 = school_moves_page.get_row_for_child(child_2)
 
     expect(row1).to_contain_text(f"Class list updated {schools[0]} to {schools[1]}")
     expect(row2).to_contain_text(f"Class list updated {schools[0]} to {schools[1]}")
 
-    school_moves_page.click_child(*child_1.name)
+    school_moves_page.click_child(child_1)
     review_school_move_page.confirm()
 
     expect(school_moves_page.confirmed_alert).to_contain_text(
         f"{child_1!s}’s school record updated",
     )
 
-    school_moves_page.click_child(*child_2.name)
+    school_moves_page.click_child(child_2)
     review_school_move_page.ignore()
 
     expect(school_moves_page.ignored_alert).to_contain_text(
@@ -179,5 +179,5 @@ def test_accessibility(
 
     dashboard_page.click_mavis()
     dashboard_page.click_school_moves()
-    school_moves_page.click_child(*child.name)
+    school_moves_page.click_child(child)
     accessibility_helper.check_accessibility()


### PR DESCRIPTION
Ensures test functions handle `Child` objects consistently