### PR TITLE
Updated header navigation

### DIFF
--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -178,10 +178,12 @@ def upload_offline_vaccination(
             child.year_group,
             programme.group,
         )
-        ImportsPage(page).header.click_sessions_header()
+        ImportsPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         SessionsSearchPage(page).click_session_for_programme_group(school, programme)
         session_id = SessionsOverviewPage(page).get_session_id_from_offline_excel()
-        SessionsOverviewPage(page).header.click_imports_header()
+        SessionsOverviewPage(page).header.click_mavis_header()
+        DashboardPage(page).click_imports()
         ImportsPage(page).click_upload_records()
         ImportRecordsWizardPage(
             page, test_data
@@ -191,7 +193,8 @@ def upload_offline_vaccination(
             session_id=session_id,
             programme_group=programme.group,
         )
-        ImportsPage(page).header.click_programmes_header()
+        ImportsPage(page).header.click_mavis_header()
+        DashboardPage(page).click_programmes()
         ProgrammesListPage(page).click_programme_for_current_year(programme)
         ProgrammeOverviewPage(page).tabs.click_children_tab()
         ProgrammeChildrenPage(page).search_for_child(child)

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -47,11 +47,17 @@ def setup_children_session(
             SessionsEditPage(page).schedule_a_valid_session(
                 offset_days=0, skip_weekends=False
             )
-        SessionsOverviewPage(page).click_import_class_lists()
-        ImportRecordsWizardPage(page, test_data).import_class_list(
-            class_list_file, year_group
+        SessionsOverviewPage(page).header.click_mavis_header()
+        DashboardPage(page).click_imports()
+        ImportsPage(page).click_upload_records()
+        ImportRecordsWizardPage(page, test_data).navigate_to_class_list_record_import(
+            str(school), year_group
         )
-        ImportsPage(page).header.click_children_header()
+        ImportRecordsWizardPage(page, test_data).import_class_list(
+            class_list_file, year_group=None
+        )
+        ImportRecordsWizardPage(page, test_data).header.click_mavis_header()
+        DashboardPage(page).click_children()
         yield
 
     return _setup
@@ -91,10 +97,11 @@ def setup_mav_853(
     ImportRecordsWizardPage(page, test_data).import_class_list(
         ClassFileMapping.RANDOM_CHILD, year_group
     )
-    ImportsPage(page).header.click_sessions_header()
+
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
     session_id = SessionsOverviewPage(page).get_session_id_from_offline_excel()
-    SessionsOverviewPage(page).header.click_programmes_header()
+    DashboardPage(page).click_programmes()
     ProgrammesListPage(page).click_programme_for_current_year(Programme.HPV)
     ProgrammeOverviewPage(page).tabs.click_children_tab()
     ProgrammeChildrenPage(page).click_import_child_records()
@@ -102,14 +109,16 @@ def setup_mav_853(
         CohortsFileMapping.FIXED_CHILD
     )
 
-    ImportsPage(page).header.click_imports_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, test_data).navigate_to_vaccination_records_import()
     ImportRecordsWizardPage(page, test_data).upload_and_verify_output(
         file_mapping=VaccsFileMapping.NOT_GIVEN,
         session_id=session_id,
     )
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
 
 
 @issue("MAV-853")

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -141,7 +141,8 @@ def test_match_unmatched_consent_response_and_verify_activity_log(
     ImportRecordsWizardPage(page, test_data).import_class_list(
         CohortsFileMapping.FIXED_CHILD
     )
-    ImportsPage(page).header.click_consent_responses_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_unmatched_consent_responses()
 
     UnmatchedConsentResponsesPage(page).click_parent_on_consent_record_for_child(child)
 
@@ -151,7 +152,8 @@ def test_match_unmatched_consent_response_and_verify_activity_log(
     expect(UnmatchedConsentResponsesPage(page).matched_alert).to_be_visible()
     UnmatchedConsentResponsesPage(page).check_response_for_child_not_visible(child)
 
-    UnmatchedConsentResponsesPage(page).header.click_children_header()
+    UnmatchedConsentResponsesPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_with_all_filters_for_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).tabs.click_activity_log()
@@ -186,7 +188,8 @@ def test_create_child_record_from_consent_with_nhs_number(
     expect(UnmatchedConsentResponsesPage(page).created_alert).to_be_visible()
     UnmatchedConsentResponsesPage(page).check_response_for_child_not_visible(child)
 
-    UnmatchedConsentResponsesPage(page).header.click_children_header()
+    UnmatchedConsentResponsesPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_with_all_filters_for_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).tabs.click_activity_log()
@@ -221,7 +224,8 @@ def test_create_child_record_from_consent_without_nhs_number(
     expect(UnmatchedConsentResponsesPage(page).created_alert).to_be_visible()
     UnmatchedConsentResponsesPage(page).check_response_for_child_not_visible(child)
 
-    UnmatchedConsentResponsesPage(page).header.click_children_header()
+    UnmatchedConsentResponsesPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_with_all_filters_for_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).tabs.click_activity_log()
@@ -253,8 +257,8 @@ def test_accessibility(
     ImportRecordsWizardPage(page, test_data).import_class_list(
         CohortsFileMapping.FIXED_CHILD
     )
-
-    ImportsPage(page).header.click_consent_responses_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_unmatched_consent_responses()
     AccessibilityHelper(page).check_accessibility()
 
     UnmatchedConsentResponsesPage(page).click_parent_on_consent_record_for_child(child)
@@ -311,7 +315,8 @@ def test_match_consent_with_vaccination_record_no_service_error(
     child_with_vaccination = children[Programme.HPV][1]
 
     # Navigate back to unmatched consent responses
-    ImportsPage(page).header.click_consent_responses_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_unmatched_consent_responses()
 
     # Step 4: Navigate to unmatched consent responses and attempt to search for
     # the patient who has vaccination record (this tests the edge case)

--- a/tests/test_e2e_flu.py
+++ b/tests/test_e2e_flu.py
@@ -1,11 +1,7 @@
 import pytest
 
 from mavis.test.annotations import issue
-from mavis.test.constants import (
-    ConsentOption,
-    Programme,
-    Vaccine,
-)
+from mavis.test.constants import ConsentOption, Programme, Vaccine
 from mavis.test.data_models import VaccinationRecord
 from mavis.test.pages import (
     ChildRecordPage,
@@ -124,7 +120,8 @@ def test_recording_flu_vaccination_e2e(
     SessionsVaccinationWizardPage(page).record_vaccination(vaccination_record)
 
     # MAV-1831
-    SessionsPatientPage(page).header.click_children_header()
+    SessionsPatientPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_for_a_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).click_vaccination_details(schools[0])

--- a/tests/test_e2e_mmr.py
+++ b/tests/test_e2e_mmr.py
@@ -1,10 +1,6 @@
 import pytest
 
-from mavis.test.constants import (
-    ConsentOption,
-    Programme,
-    Vaccine,
-)
+from mavis.test.constants import ConsentOption, Programme, Vaccine
 from mavis.test.data_models import VaccinationRecord
 from mavis.test.pages import (
     DashboardPage,
@@ -184,7 +180,8 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     SessionsVaccinationWizardPage(page).record_vaccination(vaccination_record)
 
     # Attempt to record second dose on the same day
-    SessionsPatientPage(page).header.click_sessions_header()
+    SessionsPatientPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[0], Programme.MMR
     )
@@ -263,7 +260,8 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
     SessionsChildrenPage(page).search.search_and_click_child(child)
     SessionsPatientPage(page).click_programme_tab(Programme.MMR)
     SessionsPatientPage(page).triage_mmr_patient(ConsentOption.MMR_EITHER)
-    SessionsPatientPage(page).header.click_sessions_header()
+    SessionsPatientPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
 
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[0], Programme.MMR

--- a/tests/test_import_child_lists.py
+++ b/tests/test_import_child_lists.py
@@ -142,7 +142,8 @@ def test_child_list_file_upload_whitespace_normalization(
     input_file, _ = ImportRecordsWizardPage(page, test_data).upload_and_verify_output(
         ChildFileMapping.WHITESPACE,
     )
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).verify_list_has_been_uploaded(
         input_file, is_vaccinations=False
     )

--- a/tests/test_import_class_lists.py
+++ b/tests/test_import_class_lists.py
@@ -31,8 +31,8 @@ def setup_class_list_import(
         SessionsEditPage(page).schedule_a_valid_session(
             offset_days=7, skip_weekends=False
         )
-
-    SessionsOverviewPage(page).header.click_imports_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, test_data).navigate_to_class_list_record_import(
         str(school), year_group
@@ -183,7 +183,8 @@ def test_class_list_file_upload_whitespace_normalization(
     input_file, _ = ImportRecordsWizardPage(page, test_data).upload_and_verify_output(
         ClassFileMapping.WHITESPACE,
     )
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).verify_list_has_been_uploaded(
         input_file, is_vaccinations=False
     )

--- a/tests/test_import_historical_vaccinations.py
+++ b/tests/test_import_historical_vaccinations.py
@@ -106,7 +106,9 @@ def test_historical_vaccination_file_upload_creates_child(
     ImportRecordsWizardPage(page, test_data).upload_and_verify_output(
         VaccsFileMapping.HIST_HPV
     )
-    ImportsPage(page).header.click_children_header()
+
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
 
     ChildrenSearchPage(page).click_advanced_filters()
     ChildrenSearchPage(page).check_children_aged_out_of_programmes()

--- a/tests/test_import_offline_vaccinations.py
+++ b/tests/test_import_offline_vaccinations.py
@@ -41,10 +41,12 @@ def setup_vaccs(
     ImportRecordsWizardPage(page, test_data).import_class_list(
         ClassFileMapping.RANDOM_CHILD, year_group
     )
-    ImportsPage(page).header.click_sessions_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
     session_id = SessionsOverviewPage(page).get_session_id_from_offline_excel()
-    SessionsOverviewPage(page).header.click_imports_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, test_data).navigate_to_vaccination_records_import()
     return session_id
@@ -135,7 +137,8 @@ def test_vaccination_file_upload_duplicate_records(
         VaccsFileMapping.DUP_1,
         session_id=setup_vaccs,
     )
-    ImportsPage(page).header.click_imports_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, test_data).navigate_to_vaccination_records_import()
     ImportRecordsWizardPage(page, test_data).upload_and_verify_output(
@@ -222,7 +225,8 @@ def test_vaccination_file_upload_creates_child_no_setting(
     ImportRecordsWizardPage(page, test_data).upload_and_verify_output(
         VaccsFileMapping.NO_CARE_SETTING
     )
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
 
     ChildrenSearchPage(page).click_advanced_filters()
     ChildrenSearchPage(page).check_children_aged_out_of_programmes()
@@ -255,7 +259,8 @@ def test_vaccination_file_upload_whitespace_normalization(
         VaccsFileMapping.WHITESPACE,
         session_id=setup_vaccs,
     )
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).verify_list_has_been_uploaded(
         input_file, is_vaccinations=True
     )

--- a/tests/test_nurse_consent.py
+++ b/tests/test_nurse_consent.py
@@ -50,7 +50,8 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, test_data).import_class_list(
             class_list_file, year_group
         )
-        ImportsPage(page).header.click_sessions_header()
+        ImportsPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         yield
 
     return _setup

--- a/tests/test_online_consent_school_moves.py
+++ b/tests/test_online_consent_school_moves.py
@@ -108,7 +108,8 @@ def test_online_consent_school_moves_with_existing_patient(
     SchoolMovesPage(page).click_child(child)
     ReviewSchoolMovePage(page).confirm()
 
-    SchoolMovesPage(page).header.click_sessions_header()
+    SchoolMovesPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[1], Programme.FLU
     )
@@ -174,7 +175,8 @@ def test_online_consent_school_moves_with_new_patient(
     ConsentResponsePage(page).click_create_new_record()
     CreateNewRecordConsentResponsePage(page).create_new_record()
 
-    UnmatchedConsentResponsesPage(page).header.click_sessions_header()
+    UnmatchedConsentResponsesPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[1], Programme.FLU
     )

--- a/tests/test_programmes.py
+++ b/tests/test_programmes.py
@@ -137,13 +137,15 @@ def test_archive_and_unarchive_child_via_cohort_upload(
         CohortsFileMapping.FIXED_CHILD
     )
 
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_with_all_filters_for_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).click_archive_child_record()
     ChildArchivePage(page).archive_child_record()
 
-    ChildRecordPage(page).header.click_programmes_header()
+    ChildRecordPage(page).header.click_mavis_header()
+    DashboardPage(page).click_programmes()
     ProgrammesListPage(page).click_programme_for_current_year(Programme.HPV)
     ProgrammeOverviewPage(page).tabs.click_children_tab()
     ProgrammeChildrenPage(page).click_import_child_records()
@@ -152,7 +154,8 @@ def test_archive_and_unarchive_child_via_cohort_upload(
         CohortsFileMapping.FIXED_CHILD
     )
 
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_with_all_filters_for_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).check_child_is_unarchived()
@@ -223,7 +226,8 @@ def test_verify_careplus_report_for_doubles(
     ProgrammeOverviewPage(page).verify_report_format(
         report_format=ReportFormat.CAREPLUS,
     )
-    ProgrammeOverviewPage(page).header.click_programmes_header()
+    ProgrammeOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_programmes()
     ProgrammesListPage(page).click_programme_for_current_year(Programme.TD_IPV)
     ProgrammeOverviewPage(page).verify_report_format(
         report_format=ReportFormat.CAREPLUS,
@@ -267,7 +271,8 @@ def test_verify_csv_report_for_doubles(
     ProgrammeOverviewPage(page).verify_report_format(
         report_format=ReportFormat.CSV,
     )
-    ProgrammeOverviewPage(page).header.click_programmes_header()
+    ProgrammeOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_programmes()
     ProgrammesListPage(page).click_programme_for_current_year(Programme.TD_IPV)
     ProgrammeOverviewPage(page).verify_report_format(
         report_format=ReportFormat.CSV,
@@ -392,7 +397,8 @@ def test_accessibility(
     ProgrammeOverviewPage(page).click_continue()
     AccessibilityHelper(page).check_accessibility()
 
-    ProgrammeOverviewPage(page).header.click_programmes_header()
+    ProgrammeOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_programmes()
     ProgrammesListPage(page).click_programme_for_current_year(Programme.FLU)
 
     ProgrammeOverviewPage(page).tabs.click_sessions_tab()

--- a/tests/test_psd.py
+++ b/tests/test_psd.py
@@ -1,11 +1,6 @@
 import pytest
 
-from mavis.test.constants import (
-    ConsentMethod,
-    ConsentOption,
-    Programme,
-    Vaccine,
-)
+from mavis.test.constants import ConsentMethod, ConsentOption, Programme, Vaccine
 from mavis.test.data import ClassFileMapping
 from mavis.test.data_models import VaccinationRecord
 from mavis.test.helpers.accessibility_helper import AccessibilityHelper
@@ -46,7 +41,8 @@ def setup_session_with_file_upload(
         school = schools[Programme.FLU][0]
         year_group = year_groups[Programme.FLU]
         batch_name = add_vaccine_batch(Vaccine.FLUENZ)
-        VaccinesPage(page).header.click_sessions_header()
+        VaccinesPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         SessionsSearchPage(page).click_session_for_programme_group(
             school, Programme.FLU.group
         )
@@ -61,7 +57,8 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, test_data).import_class_list(
             class_file_mapping, year_group, Programme.FLU.group
         )
-        ImportsPage(page).header.click_sessions_header()
+        ImportsPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         return batch_name
 
     return _factory

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,8 +1,6 @@
 import pytest
 
-from mavis.test.constants import (
-    Programme,
-)
+from mavis.test.constants import Programme
 from mavis.test.pages import (
     ChildRecordPage,
     ChildrenSearchPage,
@@ -73,7 +71,8 @@ def test_report_view(
         "Vaccinated", expected_vaccinated_percentage
     )
 
-    ReportsVaccinationsPage(page).header.click_children_header()
+    ReportsVaccinationsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_with_all_filters_for_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).click_vaccination_details(school)

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -67,7 +67,8 @@ def setup_confirm_and_ignore(
         SessionsEditPage(page).schedule_a_valid_session(
             offset_days=7, skip_weekends=False
         )
-    SessionsOverviewPage(page).header.click_sessions_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[1], Programme.HPV
     )
@@ -76,24 +77,28 @@ def setup_confirm_and_ignore(
         SessionsEditPage(page).schedule_a_valid_session(
             offset_days=7, skip_weekends=False
         )
-    SessionsOverviewPage(page).header.click_sessions_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[0], Programme.HPV
     )
     upload_class_list()
-    ImportsPage(page).header.click_children_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_for_a_child_name(str(children[0]))
     ChildrenSearchPage(page).click_record_for_child(children[0])
     ChildRecordPage(page).tabs.click_activity_log()
     ChildActivityLogPage(page).expect_activity_log_header(
         f"Added to the session at {schools[0]}"
     )
-    ChildActivityLogPage(page).header.click_sessions_header()
+    ChildActivityLogPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         schools[1], Programme.HPV
     )
     upload_class_list()
-    ImportsPage(page).header.click_school_moves_header()
+    ImportsPage(page).header.click_mavis_header()
+    DashboardPage(page).click_school_moves()
 
 
 def test_confirm_and_ignore(
@@ -191,6 +196,7 @@ def test_accessibility(
     DownloadSchoolMovesPage(page).click_continue()
     AccessibilityHelper(page).check_accessibility()
 
-    DownloadSchoolMovesPage(page).header.click_school_moves_header()
+    DownloadSchoolMovesPage(page).header.click_mavis_header()
+    DashboardPage(page).click_school_moves()
     SchoolMovesPage(page).click_child(child)
     AccessibilityHelper(page).check_accessibility()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2,11 +2,7 @@ import pytest
 from playwright.sync_api import expect
 
 from mavis.test.annotations import issue
-from mavis.test.constants import (
-    ConsentMethod,
-    Programme,
-    Vaccine,
-)
+from mavis.test.constants import ConsentMethod, Programme, Vaccine
 from mavis.test.data import ClassFileMapping
 from mavis.test.data_models import Clinic, VaccinationRecord
 from mavis.test.helpers.accessibility_helper import AccessibilityHelper
@@ -61,7 +57,8 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, test_data).import_class_list(
             class_list_file, year_group
         )
-        ImportsPage(page).header.click_sessions_header()
+        ImportsPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         SessionsSearchPage(page).click_session_for_programme_group(
             school, Programme.HPV
         )
@@ -243,7 +240,8 @@ def test_session_activity_notes_order(
     SessionsPatientPage(page).click_session_activity_and_notes()
     SessionsPatientSessionActivityPage(page).add_note(note_1)
     SessionsPatientSessionActivityPage(page).add_note(note_2)
-    SessionsPatientSessionActivityPage(page).header.click_sessions_header()
+    SessionsPatientSessionActivityPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).search.search_for(str(child))
@@ -285,7 +283,8 @@ def test_triage_consent_given_and_triage_outcome(
         yes_to_health_questions=True
     )
 
-    SessionsPatientPage(page).header.click_sessions_header()
+    SessionsPatientPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
 
     SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
 
@@ -359,7 +358,8 @@ def test_verify_excel_export_and_clinic_invitation(
     batch_name = add_vaccine_batch(Vaccine.GARDASIL_9)
     generic_clinic = Clinic(name="Community clinic")
 
-    SessionsOverviewPage(page).header.click_sessions_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
         generic_clinic, Programme.HPV.group
     )
@@ -369,7 +369,8 @@ def test_verify_excel_export_and_clinic_invitation(
             offset_days=0, skip_weekends=False
         )
 
-    SessionsOverviewPage(page).header.click_children_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_children()
     ChildrenSearchPage(page).search_for_a_child_name(str(child))
     ChildrenSearchPage(page).click_record_for_child(child)
     ChildRecordPage(page).click_invite_to_community_clinic()
@@ -396,7 +397,8 @@ def test_verify_excel_export_and_clinic_invitation(
     SessionsVaccinationWizardPage(page).click_continue_button()
     SessionsVaccinationWizardPage(page).click_confirm_button()
     expect_alert_text(page, "Vaccination outcome recorded for HPV")
-    SessionsPatientPage(page).header.click_sessions_header()
+    SessionsPatientPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
     assert SessionsOverviewPage(page).get_session_id_from_offline_excel()
 
@@ -472,7 +474,8 @@ def test_accessibility(
     school = schools[Programme.HPV][0]
     child = children[Programme.HPV][0]
 
-    SessionsOverviewPage(page).header.click_sessions_header()
+    SessionsOverviewPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
     AccessibilityHelper(page).check_accessibility()
 
     SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)

--- a/tests/test_tallying.py
+++ b/tests/test_tallying.py
@@ -53,7 +53,8 @@ def setup_session_with_file_upload(
             vaccine: add_vaccine_batch(vaccine)
             for vaccine in [Vaccine.SEQUIRUS, Vaccine.FLUENZ]
         }
-        VaccinesPage(page).header.click_sessions_header()
+        VaccinesPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         SessionsSearchPage(page).click_session_for_programme_group(
             school, Programme.FLU.group
         )
@@ -66,7 +67,8 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, test_data).import_class_list(
             class_list_file, year_group, Programme.FLU.group
         )
-        ImportsPage(page).header.click_sessions_header()
+        ImportsPage(page).header.click_mavis_header()
+        DashboardPage(page).click_sessions()
         SessionsSearchPage(page).click_session_for_programme_group(
             school, Programme.FLU
         )


### PR DESCRIPTION
As the mobile screens are not very wide, the header menu can only show two options (before it shows 'More >') which fails the tests as they now use the header navigation.  Changed such tests to navigate to dashboard and then to any other module.