### PR TITLE
Revert "add --maxfail 5 to test runs"

### DIFF
--- a/.github/actions/run-functional-tests/action.yml
+++ b/.github/actions/run-functional-tests/action.yml
@@ -85,7 +85,7 @@ runs:
       shell: bash
 
     - name: Run tests
-      run: uv run pytest --maxfail 5 -n ${{ inputs.test_workers }} ${{ steps.reruns.outputs.reruns }} -m "${{ steps.marker.outputs.marker }}" --device "${{ inputs.device }}" ${{ inputs.tests }}
+      run: uv run pytest -n ${{ inputs.test_workers }} ${{ steps.reruns.outputs.reruns }} -m "${{ steps.marker.outputs.marker }}" --device "${{ inputs.device }}" ${{ inputs.tests }}
       shell: bash
       env:
         BASE_URL: ${{ inputs.base_url }}


### PR DESCRIPTION
This reverts commit 51259925307fbdfdf53e2ea59f94f6ad3cc452a6.

There are some flaws with this approach, so we'll revert it for now