### PR TITLE
Use new session scheduling wizard 

### DIFF
--- a/mavis/test/pages/__init__.py
+++ b/mavis/test/pages/__init__.py
@@ -1,3 +1,4 @@
+from .add_session_wizard_page import AddSessionWizardPage
 from .children import (
     ChildActivityLogPage,
     ChildArchivePage,
@@ -48,6 +49,7 @@ from .vaccines import AddBatchPage, ArchiveBatchPage, EditBatchPage, VaccinesPag
 
 __all__ = [
     "AddBatchPage",
+    "AddSessionWizardPage",
     "ArchiveBatchPage",
     "ArchiveConsentResponsePage",
     "BadRequestPage",

--- a/mavis/test/pages/add_session_wizard_page.py
+++ b/mavis/test/pages/add_session_wizard_page.py
@@ -1,0 +1,131 @@
+from playwright.sync_api import Page
+
+from mavis.test.annotations import step
+from mavis.test.constants import Programme
+from mavis.test.data_models import School
+from mavis.test.pages.header_component import HeaderComponent
+from mavis.test.utils import (
+    get_day_month_year_from_compact_date,
+    get_offset_date_compact_format,
+)
+
+
+class AddSessionWizardPage:
+    def __init__(
+        self,
+        page: Page,
+    ) -> None:
+        self.page = page
+        self.header = HeaderComponent(page)
+
+        self.continue_button = self.page.get_by_role("button", name="Continue")
+        self.day_textbox = self.page.get_by_role("textbox", name="Day")
+        self.month_textbox = self.page.get_by_role("textbox", name="Month")
+        self.year_textbox = self.page.get_by_role("textbox", name="Year")
+        self.add_another_date_button = self.page.get_by_role(
+            "button",
+            name="Add another date",
+        )
+        self.school_session_radio = self.page.get_by_role(
+            "radio",
+            name="School session",
+        )
+        self.community_clinic_radio = self.page.get_by_role(
+            "radio",
+            name="Community clinic",
+        )
+        self.select_a_school_combobox = self.page.get_by_role(
+            "combobox",
+            name="Select a school",
+        )
+        self.keep_session_dates_button = self.page.get_by_role(
+            "button", name="Keep session dates"
+        )
+
+    @step("Select School session")
+    def select_school_session(self) -> None:
+        self.school_session_radio.check()
+        self.click_continue()
+
+    @step("Select Community clinic")
+    def select_community_clinic(self) -> None:
+        self.community_clinic_radio.check()
+        self.click_continue()
+
+    def select_school(self, school: School) -> None:
+        self.fill_school_name(school)
+        self.click_continue()
+
+    @step("Fill school name")
+    def fill_school_name(self, school: School) -> None:
+        self.page.reload()  # to allow combobox to be interactable
+        self.select_a_school_combobox.fill(str(school))
+        self.page.get_by_role("option", name=str(school)).click()
+
+    @step("Click Continue")
+    def click_continue(self) -> None:
+        self.continue_button.click()
+
+    @step("Select year groups {1}")
+    def select_year_groups(self, year_groups: list[int]) -> None:
+        for year_group in year_groups:
+            self.page.locator(f'input[type="checkbox"][value="{year_group}"]').check()
+
+        self.click_continue()
+
+    @step("Choose programmes {1}")
+    def choose_programmes(self, programmes: list[Programme]) -> None:
+        for programme in programmes:
+            self.page.get_by_role("checkbox", name=programme).check()
+        self.click_continue()
+
+    @step("Click on Add another date")
+    def click_add_another_date(self) -> None:
+        self.add_another_date_button.click()
+
+    @step("Fill date fields with {1}")
+    def fill_date_fields(self, date: str) -> None:
+        day, month, year = get_day_month_year_from_compact_date(date)
+
+        self.day_textbox.last.fill(str(day))
+        self.month_textbox.last.fill(str(month))
+        self.year_textbox.last.fill(str(year))
+
+        self.click_continue()
+
+    @step("Click Keep session dates")
+    def click_keep_session_dates(self) -> None:
+        self.keep_session_dates_button.click()
+
+    def schedule_school_session(
+        self,
+        school: School,
+        programmes: list[Programme],
+        year_groups: list[int],
+        date_offset: int,
+    ) -> None:
+        self.select_school_session()
+        self.select_school(school)
+        self.choose_programmes(programmes)
+        self.select_year_groups(year_groups)
+        self.fill_date_fields(get_offset_date_compact_format(date_offset))
+
+        self.keep_session_dates_if_necessary()
+
+        self.click_continue()
+
+    def schedule_clinic_session(
+        self,
+        programmes: list[Programme],
+        date_offset: int,
+    ) -> None:
+        self.select_community_clinic()
+        self.choose_programmes(programmes)
+        self.fill_date_fields(get_offset_date_compact_format(date_offset))
+
+        self.click_continue()
+
+    @step("Keep session dates if necessary")
+    def keep_session_dates_if_necessary(self) -> None:
+        if self.keep_session_dates_button.is_visible():
+            self.click_keep_session_dates()

--- a/mavis/test/pages/imports/import_records_wizard_page.py
+++ b/mavis/test/pages/imports/import_records_wizard_page.py
@@ -43,9 +43,9 @@ class ImportRecordsWizardPage:
         self.continue_button = self.page.get_by_role("button", name="Continue")
         self.file_input = self.page.locator('input[type="file"]')
         self.location_combobox = self.page.get_by_role("combobox")
-        self.imported_records_tab = self.page.get_by_role(
+        self.completed_imports_tab = self.page.get_by_role(
             "link",
-            name="Imported records",
+            name="Completed imports",
         )
 
         # Pattern to match dynamic text (s is optional for records)
@@ -217,7 +217,7 @@ class ImportRecordsWizardPage:
         if first_link.or_(second_link).first.is_visible():
             first_link.or_(second_link).first.click()
         else:
-            self.imported_records_tab.click()
+            self.completed_imports_tab.click()
             first_link.or_(second_link).first.click()
 
     @step("Verify upload output for {file_path}")

--- a/mavis/test/pages/schools/schools_sessions_page.py
+++ b/mavis/test/pages/schools/schools_sessions_page.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import Page
 
+from mavis.test.annotations import step
 from mavis.test.pages.header_component import HeaderComponent
 from mavis.test.pages.schools.schools_tabs import SchoolsTabs
 
@@ -9,3 +10,8 @@ class SchoolsSessionsPage:
         self.page = page
         self.header = HeaderComponent(page)
         self.tabs = SchoolsTabs(page)
+        self.add_a_new_session_link = page.get_by_role("link", name="Add a new session")
+
+    @step("Click Add a new session")
+    def click_add_a_new_session(self) -> None:
+        self.add_a_new_session_link.click()

--- a/mavis/test/pages/sessions/sessions_edit_page.py
+++ b/mavis/test/pages/sessions/sessions_edit_page.py
@@ -245,3 +245,7 @@ class SessionsEditPage:
                 " using a patient specific direction (PSD)?"
             ),
         ).get_by_label(answer).check()
+
+    def continue_if_warning_appears(self) -> None:
+        if self.page.get_by_role("button", name="Continue").is_visible():
+            self.click_continue_button()

--- a/mavis/test/pages/sessions/sessions_search_page.py
+++ b/mavis/test/pages/sessions/sessions_search_page.py
@@ -7,6 +7,7 @@ from mavis.test.constants import (
 from mavis.test.data_models import Location
 from mavis.test.pages.header_component import HeaderComponent
 from mavis.test.pages.search_components import BaseSearchComponent
+from mavis.test.utils import get_formatted_date_without_year, get_offset_date
 
 
 class SessionsSearchPage:
@@ -14,6 +15,11 @@ class SessionsSearchPage:
         self.page = page
         self.search = BaseSearchComponent(page)
         self.header = HeaderComponent(page)
+        self.add_a_new_session_link = page.get_by_role("link", name="Add a new session")
+
+    @step("Click Add a new session")
+    def click_add_a_new_session(self) -> None:
+        self.add_a_new_session_link.click()
 
     @step("Click on {2} session at {1}")
     def click_session_for_programme_group(
@@ -35,3 +41,29 @@ class SessionsSearchPage:
         expect(self.page.locator("h1", has_text=str(location))).to_be_visible(
             timeout=ten_seconds_ms,
         )
+
+    @step("Check if session exists")
+    def click_session_if_exists(
+        self,
+        location: Location,
+        programmes: list[Programme],
+        year_groups: list[int],
+        date_offset: int,
+    ) -> bool:
+        self.search.search_for(str(location))
+        self.page.wait_for_load_state()
+        session_locators = self.page.locator(
+            "div.nhsuk-card--clickable.app-card.app-card--compact"
+        )
+        session_date = get_formatted_date_without_year(get_offset_date(date_offset))
+
+        for i in range(session_locators.count()):
+            card_text = session_locators.nth(i).inner_text()
+            if (
+                all(str(programme) in card_text for programme in programmes)
+                and session_date in card_text
+                and all(str(year_group) in card_text for year_group in year_groups)
+            ):
+                session_locators.nth(i).get_by_role("link").click()
+                return True
+        return False

--- a/mavis/test/pages/utils.py
+++ b/mavis/test/pages/utils.py
@@ -1,0 +1,37 @@
+from playwright.sync_api import Page
+
+from mavis.test.constants import Programme
+from mavis.test.data_models import Clinic, School
+from mavis.test.pages import AddSessionWizardPage, DashboardPage, SessionsSearchPage
+
+
+def schedule_school_session_if_needed(
+    page: Page,
+    school: School,
+    programmes: list[Programme],
+    year_groups: list[int],
+    date_offset: int = 0,
+) -> None:
+    DashboardPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
+    if not SessionsSearchPage(page).click_session_if_exists(
+        school, programmes, year_groups, date_offset
+    ):
+        SessionsSearchPage(page).click_add_a_new_session()
+        AddSessionWizardPage(page).schedule_school_session(
+            school, programmes, year_groups, date_offset
+        )
+
+
+def schedule_community_clinic_session_if_needed(
+    page: Page,
+    programmes: list[Programme],
+    date_offset: int = 0,
+) -> None:
+    DashboardPage(page).header.click_mavis_header()
+    DashboardPage(page).click_sessions()
+    if not SessionsSearchPage(page).click_session_if_exists(
+        Clinic("community clinic"), programmes, [], date_offset
+    ):
+        SessionsSearchPage(page).click_add_a_new_session()
+        AddSessionWizardPage(page).schedule_clinic_session(programmes, date_offset)

--- a/mavis/test/utils.py
+++ b/mavis/test/utils.py
@@ -9,8 +9,6 @@ from playwright.sync_api import Locator, Page, expect
 
 faker = Faker()
 
-DEFAULT_TIMEOUT_SECONDS = 30
-
 
 def format_datetime_for_upload_link(now: datetime) -> str:
     am_or_pm = now.strftime(format="%p").lower()
@@ -40,6 +38,15 @@ def get_formatted_date_for_session_dates(date: date) -> str:
     except ValueError:
         # Windows (Dev VDI)
         return date.strftime(format="%#d %B %Y")
+
+
+def get_formatted_date_without_year(date: date) -> str:
+    try:
+        # Linux (Github Action)
+        return date.strftime(format="%-d %B")
+    except ValueError:
+        # Windows (Dev VDI)
+        return date.strftime(format="%#d %B")
 
 
 def get_day_month_year_from_compact_date(compact_date: str) -> tuple[int, int, int]:
@@ -162,6 +169,9 @@ def normalize_postcode(postcode: str) -> str:
     district = district.replace("O", "0").replace("I", "1")
 
     return f"{area}{district} {sector}{unit}"
+
+
+DEFAULT_TIMEOUT_SECONDS = 30
 
 
 def reload_until_element_is_visible(

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -18,12 +18,11 @@ from mavis.test.pages import (
     ProgrammesListPage,
     SchoolsChildrenPage,
     SchoolsSearchPage,
-    SessionsEditPage,
     SessionsOverviewPage,
-    SessionsSearchPage,
     VaccinationRecordPage,
 )
-from mavis.test.utils import expect_alert_text, get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
+from mavis.test.utils import expect_alert_text
 
 pytestmark = pytest.mark.children
 
@@ -46,16 +45,7 @@ def setup_children_session(
         ImportRecordsWizardPage(page, file_generator).import_class_list(
             class_list_file, year_group
         )
-        ImportsPage(page).header.click_mavis_header()
-        DashboardPage(page).click_sessions()
-        SessionsSearchPage(page).click_session_for_programme_group(
-            school, Programme.HPV.group
-        )
-        if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(0)):
-            SessionsOverviewPage(page).schedule_or_edit_session()
-            SessionsEditPage(page).schedule_a_valid_session(
-                offset_days=0, skip_weekends=False
-            )
+        schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
         SessionsOverviewPage(page).header.click_mavis_header()
         DashboardPage(page).click_children()
         yield
@@ -90,16 +80,7 @@ def setup_mav_853(
     ImportRecordsWizardPage(page, file_generator).import_class_list(
         ClassFileMapping.RANDOM_CHILD, year_group
     )
-    ImportsPage(page).header.click_mavis_header()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(
-        school, Programme.HPV.group
-    )
-    if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(0)):
-        SessionsOverviewPage(page).schedule_or_edit_session()
-        SessionsEditPage(page).schedule_a_valid_session(
-            offset_days=0, skip_weekends=False
-        )
+    schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
     session_id = SessionsOverviewPage(page).get_session_id_from_offline_excel()
 
     SessionsOverviewPage(page).header.click_mavis_header()

--- a/tests/test_import_class_lists.py
+++ b/tests/test_import_class_lists.py
@@ -7,11 +7,9 @@ from mavis.test.pages import (
     DashboardPage,
     ImportRecordsWizardPage,
     ImportsPage,
-    SessionsEditPage,
     SessionsOverviewPage,
-    SessionsSearchPage,
 )
-from mavis.test.utils import get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
 
 
 @pytest.fixture
@@ -24,13 +22,8 @@ def setup_class_list_import(
 ):
     school = schools[Programme.HPV][0]
     year_group = year_groups[Programme.HPV]
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
-    if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(7)):
-        SessionsOverviewPage(page).schedule_or_edit_session()
-        SessionsEditPage(page).schedule_a_valid_session(
-            offset_days=7, skip_weekends=False
-        )
+
+    schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
     SessionsOverviewPage(page).header.click_mavis_header()
     DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()

--- a/tests/test_import_offline_vaccinations.py
+++ b/tests/test_import_offline_vaccinations.py
@@ -11,12 +11,10 @@ from mavis.test.pages import (
     ImportsPage,
     SchoolsChildrenPage,
     SchoolsSearchPage,
-    SessionsEditPage,
     SessionsOverviewPage,
-    SessionsSearchPage,
     VaccinationRecordPage,
 )
-from mavis.test.utils import get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
 
 
 @pytest.fixture
@@ -36,16 +34,7 @@ def setup_vaccs(
     ImportRecordsWizardPage(page, file_generator).import_class_list(
         ClassFileMapping.RANDOM_CHILD, year_group
     )
-    ImportsPage(page).header.click_mavis_header()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(
-        school, Programme.HPV.group
-    )
-    if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(0)):
-        SessionsOverviewPage(page).schedule_or_edit_session()
-        SessionsEditPage(page).schedule_a_valid_session(
-            offset_days=0, skip_weekends=False
-        )
+    schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
     session_id = SessionsOverviewPage(page).get_session_id_from_offline_excel()
     SessionsOverviewPage(page).header.click_mavis_header()
     DashboardPage(page).click_imports()

--- a/tests/test_nurse_consent.py
+++ b/tests/test_nurse_consent.py
@@ -14,12 +14,10 @@ from mavis.test.pages import (
     DashboardPage,
     GillickCompetencePage,
     ImportRecordsWizardPage,
-    ImportsPage,
     NurseConsentWizardPage,
     SchoolsChildrenPage,
     SchoolsSearchPage,
     SessionsChildrenPage,
-    SessionsEditPage,
     SessionsOverviewPage,
     SessionsPatientPage,
     SessionsPatientSessionActivityPage,
@@ -28,7 +26,8 @@ from mavis.test.pages import (
     SessionsVaccinationWizardPage,
     VaccinesPage,
 )
-from mavis.test.utils import expect_alert_text, get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
+from mavis.test.utils import expect_alert_text
 
 pytestmark = pytest.mark.consent
 
@@ -51,16 +50,7 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, file_generator).import_class_list(
             class_list_file, year_group
         )
-        ImportsPage(page).header.click_mavis_header()
-        DashboardPage(page).click_sessions()
-        SessionsSearchPage(page).click_session_for_programme_group(
-            school, Programme.HPV.group
-        )
-        if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(0)):
-            SessionsOverviewPage(page).schedule_or_edit_session()
-            SessionsEditPage(page).schedule_a_valid_session(
-                offset_days=0, skip_weekends=False
-            )
+        schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
         yield
 
     return _setup

--- a/tests/test_online_consent_school_moves.py
+++ b/tests/test_online_consent_school_moves.py
@@ -16,10 +16,10 @@ from mavis.test.pages import (
     SchoolsSearchPage,
     SessionsChildrenPage,
     SessionsOverviewPage,
-    SessionsSearchPage,
     StartPage,
     UnmatchedConsentResponsesPage,
 )
+from mavis.test.pages.utils import schedule_school_session_if_needed
 
 pytestmark = pytest.mark.consent
 
@@ -110,10 +110,8 @@ def test_online_consent_school_moves_with_existing_patient(
     SchoolMovesPage(page).click_child(child)
     ReviewSchoolMovePage(page).confirm()
 
-    SchoolMovesPage(page).header.click_mavis_header()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(
-        schools[1], Programme.FLU
+    schedule_school_session_if_needed(
+        page, schools[1], [Programme.FLU], [child.year_group], date_offset=7
     )
 
     SessionsOverviewPage(page).tabs.click_children_tab()
@@ -177,10 +175,8 @@ def test_online_consent_school_moves_with_new_patient(
     ConsentResponsePage(page).click_create_new_record()
     CreateNewRecordConsentResponsePage(page).create_new_record()
 
-    UnmatchedConsentResponsesPage(page).header.click_mavis_header()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(
-        schools[1], Programme.FLU
+    schedule_school_session_if_needed(
+        page, schools[1], [Programme.FLU], [child.year_group], date_offset=7
     )
 
     SessionsOverviewPage(page).tabs.click_children_tab()

--- a/tests/test_psd.py
+++ b/tests/test_psd.py
@@ -7,7 +7,6 @@ from mavis.test.helpers.accessibility_helper import AccessibilityHelper
 from mavis.test.pages import (
     DashboardPage,
     ImportRecordsWizardPage,
-    ImportsPage,
     LogInPage,
     NurseConsentWizardPage,
     OnlineConsentWizardPage,
@@ -24,7 +23,7 @@ from mavis.test.pages import (
     StartPage,
     VaccinesPage,
 )
-from mavis.test.utils import get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
 
 
 @pytest.fixture
@@ -50,18 +49,11 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, file_generator).import_class_list(
             class_file_mapping, year_group, Programme.FLU.group
         )
-        ImportsPage(page).header.click_mavis_header()
-        DashboardPage(page).click_sessions()
-        SessionsSearchPage(page).click_session_for_programme_group(
-            school, Programme.FLU.group
+
+        offset_days = 0 if schedule_session_for_today else 7
+        schedule_school_session_if_needed(
+            page, school, [Programme.FLU], [year_group], offset_days
         )
-        if schedule_session_for_today and not SessionsOverviewPage(
-            page
-        ).is_date_scheduled(get_offset_date(0)):
-            SessionsOverviewPage(page).schedule_or_edit_session()
-            SessionsEditPage(page).schedule_a_valid_session(
-                offset_days=0, skip_weekends=False
-            )
         return batch_name
 
     return _factory
@@ -243,11 +235,6 @@ def test_accessibility(
     - No accessibility issues are found.
     """
 
-    if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(7)):
-        SessionsOverviewPage(page).schedule_or_edit_session()
-        SessionsEditPage(page).schedule_a_valid_session(
-            offset_days=7, skip_weekends=False
-        )
     SessionsOverviewPage(page).click_edit_session()
     SessionsEditPage(page).click_change_psd()
     AccessibilityHelper(page).check_accessibility()

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -17,16 +17,15 @@ from mavis.test.pages import (
     SchoolsChildrenPage,
     SchoolsSearchPage,
     SessionsChildrenPage,
-    SessionsEditPage,
     SessionsOverviewPage,
     SessionsPatientPage,
     SessionsSearchPage,
     SessionsVaccinationWizardPage,
     VaccinesPage,
 )
+from mavis.test.pages.utils import schedule_school_session_if_needed
 from mavis.test.utils import (
     generate_random_string,
-    get_offset_date,
 )
 
 
@@ -59,16 +58,10 @@ def setup_all_programmes(
     )
 
     for programme_group in [Programme.HPV, "doubles", Programme.FLU]:
-        DashboardPage(page).header.click_mavis_header()
-        DashboardPage(page).click_sessions()
-        SessionsSearchPage(page).click_session_for_programme_group(
-            school, programme_group
-        )
-        if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(0)):
-            SessionsOverviewPage(page).schedule_or_edit_session()
-            SessionsEditPage(page).schedule_a_valid_session(
-                offset_days=0, skip_weekends=False
-            )
+        programmes = [
+            programme for programme in Programme if programme.group == programme_group
+        ]
+        schedule_school_session_if_needed(page, school, programmes, [child.year_group])
     return batch_names
 
 

--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -16,11 +16,10 @@ from mavis.test.pages import (
     SchoolMovesPage,
     SchoolsChildrenPage,
     SchoolsSearchPage,
-    SessionsEditPage,
     SessionsOverviewPage,
-    SessionsSearchPage,
 )
-from mavis.test.utils import get_current_datetime, get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
+from mavis.test.utils import get_current_datetime
 
 pytestmark = pytest.mark.school_moves
 
@@ -60,25 +59,8 @@ def setup_confirm_and_ignore(
             file_path=output_file_path
         )
 
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.HPV
-    )
-    if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(7)):
-        SessionsOverviewPage(page).schedule_or_edit_session()
-        SessionsEditPage(page).schedule_a_valid_session(
-            offset_days=7, skip_weekends=False
-        )
-    SessionsOverviewPage(page).header.click_mavis_header()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(
-        schools[1], Programme.HPV
-    )
-    if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(7)):
-        SessionsOverviewPage(page).schedule_or_edit_session()
-        SessionsEditPage(page).schedule_a_valid_session(
-            offset_days=7, skip_weekends=False
-        )
+    for school in schools:
+        schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
     SessionsOverviewPage(page).header.click_mavis_header()
     DashboardPage(page).click_schools()
     SchoolsSearchPage(page).click_school(schools[0])

--- a/tests/test_tallying.py
+++ b/tests/test_tallying.py
@@ -14,20 +14,17 @@ from mavis.test.data_models import VaccinationRecord
 from mavis.test.pages import (
     DashboardPage,
     ImportRecordsWizardPage,
-    ImportsPage,
     NurseConsentWizardPage,
     SchoolsChildrenPage,
     SchoolsSearchPage,
     SessionsChildrenPage,
-    SessionsEditPage,
     SessionsOverviewPage,
     SessionsPatientPage,
     SessionsRecordVaccinationsPage,
-    SessionsSearchPage,
     SessionsVaccinationWizardPage,
     VaccinesPage,
 )
-from mavis.test.utils import get_offset_date
+from mavis.test.pages.utils import schedule_school_session_if_needed
 
 pytestmark = pytest.mark.tallying
 
@@ -61,16 +58,7 @@ def setup_session_with_file_upload(
         ImportRecordsWizardPage(page, file_generator).import_class_list(
             class_list_file, year_group, Programme.FLU.group
         )
-        ImportsPage(page).header.click_mavis_header()
-        DashboardPage(page).click_sessions()
-        SessionsSearchPage(page).click_session_for_programme_group(
-            school, Programme.FLU.group
-        )
-        if not SessionsOverviewPage(page).is_date_scheduled(get_offset_date(0)):
-            SessionsOverviewPage(page).schedule_or_edit_session()
-            SessionsEditPage(page).schedule_a_valid_session(
-                offset_days=0, skip_weekends=False
-            )
+        schedule_school_session_if_needed(page, school, [Programme.FLU], [year_group])
         yield batch_names
 
     return _setup


### PR DESCRIPTION
This PR ensures the tests use the new wizard for scheduling sessions. 

The logic for scheduling these sessions was also extracted into a new method which is used by a lot of tests.

The tests are passing, though there are some issues with flakiness. I have collected some errors and will try to address them in future PRs.
