### PR TITLE
Make tallying test more robust

### DIFF
--- a/mavis/test/pages/add_session_wizard_page.py
+++ b/mavis/test/pages/add_session_wizard_page.py
@@ -127,5 +127,6 @@ class AddSessionWizardPage:
 
     @step("Keep session dates if necessary")
     def keep_session_dates_if_necessary(self) -> None:
+        self.page.wait_for_load_state()
         if self.keep_session_dates_button.is_visible():
             self.click_keep_session_dates()

--- a/mavis/test/pages/sessions/sessions_overview_page.py
+++ b/mavis/test/pages/sessions/sessions_overview_page.py
@@ -55,8 +55,10 @@ class SessionsOverviewPage:
             "button", name="Send manual consent reminders"
         )
 
-    def get_total_for_category(self, category: str) -> int:
-        category_locator = self.page.locator(
+    def get_total_for_category(self, programme: Programme, category: str) -> int:
+        programme_section = self.page.locator(f'section:has(h3:text("{programme}"))')
+
+        category_locator = programme_section.locator(
             ".nhsuk-card__heading.nhsuk-heading-xs", has_text=category
         )
         total_locator = category_locator.locator("xpath=following-sibling::*[1]")
@@ -64,14 +66,14 @@ class SessionsOverviewPage:
 
     def get_all_totals(self, programme: Programme) -> dict[str, int]:
         return {
-            category: self.get_total_for_category(category)
+            category: self.get_total_for_category(programme, category)
             for category in programme.tally_categories
         }
 
-    def check_all_totals(self, totals: dict[str, int]) -> None:
+    def check_all_totals(self, programme: Programme, totals: dict[str, int]) -> None:
         self.tabs.click_overview_tab()
         for category, expected_total in totals.items():
-            actual_total = self.get_total_for_category(category)
+            actual_total = self.get_total_for_category(programme, category)
             assert actual_total == expected_total, (
                 f"Expected {expected_total} for {category}, but got {actual_total}"
             )

--- a/tests/test_tallying.py
+++ b/tests/test_tallying.py
@@ -101,7 +101,7 @@ def test_tallying(  # noqa: PLR0915
 
     tally_totals[TallyCategory.NEEDS_CONSENT] -= 1
     tally_totals[TallyCategory.DUE_INJECTION] += 1
-    SessionsOverviewPage(page).check_all_totals(tally_totals)
+    SessionsOverviewPage(page).check_all_totals(Programme.FLU, tally_totals)
 
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).search.search_and_click_child(child)
@@ -117,7 +117,7 @@ def test_tallying(  # noqa: PLR0915
 
     tally_totals[TallyCategory.DUE_INJECTION] -= 1
     tally_totals[TallyCategory.HAS_A_REFUSAL] += 1
-    SessionsOverviewPage(page).check_all_totals(tally_totals)
+    SessionsOverviewPage(page).check_all_totals(Programme.FLU, tally_totals)
 
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).search.search_and_click_child(child)
@@ -126,7 +126,7 @@ def test_tallying(  # noqa: PLR0915
 
     tally_totals[TallyCategory.HAS_A_REFUSAL] -= 1
     tally_totals[TallyCategory.NEEDS_CONSENT] += 1
-    SessionsOverviewPage(page).check_all_totals(tally_totals)
+    SessionsOverviewPage(page).check_all_totals(Programme.FLU, tally_totals)
 
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).search.search_and_click_child(child)
@@ -142,7 +142,7 @@ def test_tallying(  # noqa: PLR0915
 
     tally_totals[TallyCategory.NEEDS_CONSENT] -= 1
     tally_totals[TallyCategory.DUE_NASAL_SPRAY] += 1
-    SessionsOverviewPage(page).check_all_totals(tally_totals)
+    SessionsOverviewPage(page).check_all_totals(Programme.FLU, tally_totals)
 
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).register_child_as_attending(child)
@@ -158,7 +158,7 @@ def test_tallying(  # noqa: PLR0915
 
     tally_totals[TallyCategory.DUE_NASAL_SPRAY] -= 1
     tally_totals[TallyCategory.VACCINATED] += 1
-    SessionsOverviewPage(page).check_all_totals(tally_totals)
+    SessionsOverviewPage(page).check_all_totals(Programme.FLU, tally_totals)
 
 
 @issue("MAV-2689")


### PR DESCRIPTION
Ensures tallies are checked for the correct programme, in case a session is used with more than one programme.

