### PR TITLE
Set batch expiry date further in future

### DIFF
--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -47,7 +47,7 @@ def add_vaccine_batch(page):
         VaccinesPage(page).navigate()
         VaccinesPage(page).click_add_batch(vaccine)
         AddBatchPage(page).fill_name(batch_name)
-        AddBatchPage(page).date.fill_expiry_date(get_offset_date(1))
+        AddBatchPage(page).date.fill_expiry_date(get_offset_date(14))
         AddBatchPage(page).confirm()
         return batch_name
 


### PR DESCRIPTION
Some flakiness in tests is coming from vaccine batches not appearing when they should when recording vaccinations.

I'm not fully sure why this is happening. We currently create batches with an expiry date of tomorrow, which has worked so far, but just in case there is some weird time travel happening in the github runner, I'm going to try setting the expiry dates further in the future