### PR TITLE
Update PR validation workflow

### DIFF
--- a/.github/workflows/pull_request_validation.yaml
+++ b/.github/workflows/pull_request_validation.yaml
@@ -49,7 +49,7 @@ jobs:
       id-token: write
       contents: write
     with:
-      github_ref: ${{ needs.identify-target-environment.outputs.mavis_branch }}
+      git_reference_for_application_image: ${{ needs.identify-target-environment.outputs.mavis_branch }}
     secrets:
       HTTP_AUTH_TOKEN_FOR_TESTS: ${{ secrets.HTTP_AUTH_TOKEN_FOR_TESTS }}
       MAVIS_TESTING_REPO_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses the new name for the reference parameter.

We may also want to set the `git_reference_for_database_image` parameter if running tests against a branch that has a PR in the Mavis repo with a base branch that is not `next`. It's probably possible to determine this automatically? For now I'll just make this small change to get the workflow working again