### PR TITLE
Adapt checkbox click

### DIFF
--- a/mavis/test/pages/add_session_wizard_page.py
+++ b/mavis/test/pages/add_session_wizard_page.py
@@ -58,7 +58,9 @@ class AddSessionWizardPage:
 
     @step("Fill school name")
     def fill_school_name(self, school: School) -> None:
+        self.page.wait_for_load_state()
         self.page.reload()  # to allow combobox to be interactable
+
         self.select_a_school_combobox.fill(str(school))
         self.page.get_by_role("option", name=str(school)).click()
 

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -218,7 +218,10 @@ class SessionsPatientPage:
         for check in programme.pre_screening_checks(consent_option):
             locator = self.pre_screening_listitem.get_by_text(check)
             expect(locator).to_be_visible()
-        self.page.wait_for_load_state()
+
+        # need to wait for checkbox to load properly
+        self.page.wait_for_load_state("networkidle")
+
         expect(self.pre_screening_checkbox).to_be_editable()
         self.pre_screening_checkbox.check()
 

--- a/mavis/test/pages/sessions/sessions_vaccination_wizard_page.py
+++ b/mavis/test/pages/sessions/sessions_vaccination_wizard_page.py
@@ -50,6 +50,8 @@ class SessionsVaccinationWizardPage:
     def choose_batch(self, batch_name: str) -> None:
         batch_radio = self.page.get_by_role("radio", name=batch_name)
 
+        self.page.wait_for_load_state()
+
         reload_until_element_is_visible(
             self.page,
             batch_radio,


### PR DESCRIPTION
This PR adds a wait before checking the checkbox confirming that all pre screening checks are complete.

Checking this checkbox too quickly causes the check to appear and then disappear, which occasionally breaks tests. I'm not fully sure why this is, perhaps the tests were interacting with the checkbox before it was fully loaded? (though our current approach was expecting that the checkbox was visible/interactable before checking it which feels like it should have worked in this case 🤔)

It also adds a few waits to reduce some flakiness which has been observed locally.