### PR TITLE
Force a one second wait before clicking prescreening checkbox

### DIFF
--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -220,7 +220,7 @@ class SessionsPatientPage:
             expect(locator).to_be_visible()
 
         # need to wait for checkbox to load properly
-        self.page.wait_for_load_state("networkidle")
+        time.sleep(1)
 
         expect(self.pre_screening_checkbox).to_be_editable()
         self.pre_screening_checkbox.check()


### PR DESCRIPTION
The recent PR #859 attempted to fix this, but it still seems that this checkbox is still somehow refreshing/resetting after being checked. Will now force a longer wait