### PR TITLE
Make pre-screening checks more robust

### DIFF
--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -282,6 +282,7 @@ class SessionsPatientPage:
         self.select_ready_for_vaccination(vaccination_record.consent_option)
         if vaccination_record.consent_option is ConsentOption.INJECTION:
             self.select_delivery_site(vaccination_record.delivery_site)
+
         self.click_continue_button()
 
         if len(notes) > MAVIS_NOTE_LENGTH_LIMIT:

--- a/mavis/test/pages/sessions/sessions_vaccination_wizard_page.py
+++ b/mavis/test/pages/sessions/sessions_vaccination_wizard_page.py
@@ -28,6 +28,9 @@ class SessionsVaccinationWizardPage:
             page.locator("div").filter(has_text="There is a problemEnter").nth(3)
         )
         self.continue_button = self.page.get_by_role("button", name="Continue")
+        self.select_batch_heading = self.page.get_by_role(
+            "heading", name="Which batch did you use?"
+        )
 
     @step("Click on Confirm")
     def click_confirm_button(self) -> None:
@@ -51,6 +54,10 @@ class SessionsVaccinationWizardPage:
         batch_radio = self.page.get_by_role("radio", name=batch_name)
 
         self.page.wait_for_load_state()
+
+        expect(
+            self.page.get_by_role("heading", name="Which batch did you use?")
+        ).to_be_visible()
 
         reload_until_element_is_visible(
             self.page,


### PR DESCRIPTION
Follows #859 #864, by adding two additional verifications and increasing the wait time before proceeding with the checks. Should either fix this flaky test or make it easier to debug.

