### PR TITLE
Make import processing more robust

### DIFF
--- a/mavis/test/pages/imports/import_records_wizard_page.py
+++ b/mavis/test/pages/imports/import_records_wizard_page.py
@@ -139,7 +139,11 @@ class ImportRecordsWizardPage:
     def wait_for_processed(self) -> None:
         self.page.wait_for_load_state()
 
-        tag = self.completed_tag.or_(self.invalid_tag).or_(self.review_and_approve_tag)
+        tag = (
+            self.completed_tag.or_(self.invalid_tag)
+            .or_(self.review_and_approve_tag)
+            .first
+        )
 
         reload_until_element_is_visible(self.page, tag, seconds=60)
 


### PR DESCRIPTION
Makes a tiny change which will allow tests to retry after failing after the import stage in tests. (mostly helps with tests on mobile devices)