### PR TITLE
Allow step annotation to be used for util functions

### DIFF
--- a/mavis/test/utils.py
+++ b/mavis/test/utils.py
@@ -176,7 +176,7 @@ def normalize_postcode(postcode: str) -> str:
 DEFAULT_TIMEOUT_SECONDS = 30
 
 
-@step("Reload page until {1} is visible")
+@step("Reload page until {1} is visible", page_object=False)
 def reload_until_element_is_visible(
     page: Page, tag: Locator, seconds: int = DEFAULT_TIMEOUT_SECONDS
 ) -> None:
@@ -191,7 +191,7 @@ def reload_until_element_is_visible(
         expect(tag).to_be_visible()
 
 
-@step("Reload page until {1} is not visible")
+@step("Reload page until {1} is not visible", page_object=False)
 def reload_until_element_is_not_visible(
     page: Page, tag: Locator, seconds: int = DEFAULT_TIMEOUT_SECONDS
 ) -> None:


### PR DESCRIPTION
Adds a parameter that allows utility functions outside of page objects to also be annotated with `@step`