### PR TITLE
Separate working directories by worker

### DIFF
--- a/mavis/test/data/file_generator.py
+++ b/mavis/test/data/file_generator.py
@@ -1,4 +1,5 @@
 import csv
+import os
 from collections.abc import Callable
 from pathlib import Path
 
@@ -19,7 +20,6 @@ from mavis.test.utils import (
 
 class FileGenerator:
     template_path = Path(__file__).parent
-    working_path = Path("working")
 
     def __init__(  # noqa: PLR0913
         self,
@@ -38,6 +38,12 @@ class FileGenerator:
         self.year_groups = year_groups
 
         self.faker = Faker(locale="en_GB")
+
+        self.create_working_directory()
+
+    def create_working_directory(self) -> None:
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", "main")
+        self.working_path = Path("working") / f"working_{worker_id}"
 
         self.working_path.mkdir(parents=True, exist_ok=True)
 

--- a/utils/001_cleanup.py
+++ b/utils/001_cleanup.py
@@ -1,15 +1,15 @@
 import os
+import shutil
 
-#  This script is designed to be run manually to clear down the 'working', 'reports' and 'screenshots' directories.
-folders_to_clean = ["working", "allure-results"]  # "reports"
+#  This script is designed to be run manually to clear down directories.
+folders_to_clean = ["working", "allure-results"]
 
 
 def cleanup() -> None:
-    for _folder in folders_to_clean:
-        _all_files = os.listdir(_folder)
-        for _file in _all_files:
-            if _file != ".gitkeep":
-                os.remove(os.path.join(_folder, _file))
+    for entry in os.listdir("."):
+        for folder in folders_to_clean:
+            if entry.startswith(folder) and os.path.isdir(entry):
+                shutil.rmtree(entry)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ensures each test worker uses a separate working directory.

While unlikely, the current shared directory could lead to cases where one test could overwrite a file just before it is supposed to be used in another test, causing a test failure. This PR just eliminates this possibility