### PR TITLE
Small improvements

### DIFF
--- a/mavis/test/pages/add_session_wizard_page.py
+++ b/mavis/test/pages/add_session_wizard_page.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from mavis.test.annotations import step
 from mavis.test.constants import Programme
@@ -41,15 +41,26 @@ class AddSessionWizardPage:
         self.keep_session_dates_button = self.page.get_by_role(
             "button", name="Keep session dates"
         )
+        self.session_type_heading = self.page.get_by_role(
+            "heading", name="What type of session is this?"
+        )
 
     @step("Select School session")
     def select_school_session(self) -> None:
+        expect(self.session_type_heading).to_be_visible()
+
         self.school_session_radio.check()
+        self.page.wait_for_load_state()
+
         self.click_continue()
 
     @step("Select Community clinic")
     def select_community_clinic(self) -> None:
+        expect(self.session_type_heading).to_be_visible()
+
         self.community_clinic_radio.check()
+        self.page.wait_for_load_state()
+
         self.click_continue()
 
     def select_school(self, school: School) -> None:

--- a/mavis/test/pages/imports/import_records_wizard_page.py
+++ b/mavis/test/pages/imports/import_records_wizard_page.py
@@ -25,7 +25,6 @@ class ImportRecordsWizardPage:
         self.file_generator = file_generator
         self.header = HeaderComponent(page)
 
-        self.alert_success = self.page.get_by_text("Import processing started")
         self.completed_tag = self.page.get_by_role("strong").get_by_text("Completed")
         self.invalid_tag = self.page.get_by_role("strong").get_by_text("Invalid")
         self.child_records_radio_button = self.page.get_by_role(
@@ -88,10 +87,6 @@ class ImportRecordsWizardPage:
     @step("Fill location combobox with {1}")
     def fill_location(self, location: str) -> None:
         self.location_combobox.fill(location)
-
-    def is_processing_in_background(self) -> bool:
-        self.page.wait_for_load_state()
-        return self.alert_success.is_visible()
 
     def get_preview_page_link(self):  # noqa: ANN201
         """Get the preview page link using multiple selector strategies."""
@@ -185,11 +180,12 @@ class ImportRecordsWizardPage:
         self.set_input_file(_input_file_path)
         upload_time = get_current_datetime()
         self.click_continue(_coverage=_scenario_list)
-
-        if self.is_processing_in_background():
-            self.click_uploaded_file_datetime(upload_time)
-
         self.page.wait_for_load_state()
+
+        if self.completed_imports_tab.is_visible():
+            self.click_uploaded_file_datetime(upload_time)
+            self.page.wait_for_load_state()
+
         status_text = (
             self.review_and_approve_tag.or_(self.completed_tag)
             .or_(self.invalid_tag)

--- a/mavis/test/pages/online_consent_wizard_page.py
+++ b/mavis/test/pages/online_consent_wizard_page.py
@@ -294,12 +294,14 @@ class OnlineConsentWizardPage:
         )
 
     def answer_yes(self, details: str | None = None) -> None:
+        self.page.wait_for_load_state()
         self.select_yes()
         if details:
             self.give_details(details)
         self.click_continue()
 
     def answer_no(self) -> None:
+        self.page.wait_for_load_state()
         self.select_no()
         self.click_continue()
 

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -102,6 +102,9 @@ class SessionsPatientPage:
         self.notes_length_error = (
             page.locator("div").filter(has_text="There is a problemEnter").nth(3)
         )
+        self.triage_notes_textbox = self.page.get_by_role(
+            "textbox", name="Triage notes"
+        )
 
     def _select_tab(self, name: str) -> None:
         link = self.page.get_by_label("Secondary menu").get_by_role("link", name=name)
@@ -263,6 +266,7 @@ class SessionsPatientPage:
     @step("Triage MMR patient")
     def triage_mmr_patient(self, consent_option: ConsentOption) -> None:
         reload_until_element_is_visible(self.page, self.triage_safe_mmr_either_radio)
+        self.triage_notes_textbox.fill("Triage notes for MMR")
         if consent_option is ConsentOption.MMR_EITHER:
             self.triage_safe_mmr_either_radio.check()
         else:


### PR DESCRIPTION
Small improvements for robustness in tests. Adds extra waits for page to load and slightly improves MMR triage test.

A lot of reruns are needed for the "Desktop Safari" test run to succeed, and this should fix some of the causes. There are still some other problems with the Safari run but I don't see a way around them without forcing a longer wait (and therefore negatively affecting other device runs)