### PR TITLE
Make VACCINE_GIVEN check less strict

### DIFF
--- a/mavis/test/data/import_format_details/vaccs.txt
+++ b/mavis/test/data/import_format_details/vaccs.txt
@@ -10,7 +10,6 @@ PERSON_POSTCODE	Required, must be formatted as a valid postcode, for example SW1
 DATE_OF_VACCINATION	Required, must use either YYYYMMDD or DD/MM/YYYY format.
 TIME_OF_VACCINATION	Optional, must use HH:MM:SS format.
 VACCINATED	Required, must be Y or N. Can be omitted if VACCINE_GIVEN is provided.
-VACCINE_GIVEN	Optional, must be one of: Cervarix, Gardasil, Gardasil9, Sequirus Cell-based Trivalent, AstraZeneca Fluenz, Viatris, Sanofi Vaxigrip, MenQuadfi, Menveo, Nimenrix, Priorix, VaxPro, Revaxis, ProQuad or Priorix-Tetra.
 BATCH_NUMBER	Required if BATCH_EXPIRY_DATE is provided.
 BATCH_EXPIRY_DATE	Required if BATCH_NUMBER is provided, must use either YYYYMMDD or DD/MM/YYYY format.
 PROGRAMME	Required, must be Flu, HPV, ACWYX4, MenACWY, MMR, MMRV, 3-in-1 or Td/IPV.

--- a/mavis/test/pages/imports/import_records_wizard_page.py
+++ b/mavis/test/pages/imports/import_records_wizard_page.py
@@ -276,3 +276,27 @@ class ImportRecordsWizardPage:
             if line not in main_content:
                 missing_line_msg = f"Inconsistent import format details: {line}"
                 raise AssertionError(missing_line_msg)
+
+        if import_format_details_mapping is ImportFormatDetails.VACCS:
+            for vaccine in self.EXPECTED_VACCINES:
+                if vaccine not in main_content:
+                    missing_line_msg = f"VACCINE_GIVEN: missing {vaccine}"
+                    raise AssertionError(missing_line_msg)
+
+    EXPECTED_VACCINES: list[str] = [  # noqa: RUF012
+        "Cervarix",
+        "Gardasil",
+        "Gardasil9",
+        "Sequirus Cell-based Trivalent",
+        "AstraZeneca Fluenz",
+        "Viatris",
+        "Sanofi Vaxigrip",
+        "MenQuadfi",
+        "Menveo",
+        "Nimenrix",
+        "Priorix",
+        "VaxPro",
+        "Revaxis",
+        "ProQuad",
+        "Priorix-Tetra",
+    ]


### PR DESCRIPTION
The VACCINE_GIVEN field is populated programmatically and therefore the order in which the vaccines appear could change depending on the state of the database. To prevent frequently having to update this test we'll just check that each vaccine we expect to appear, appears.