### PR TITLE
Change import selection to use filename instead of date/time

### DIFF
--- a/tests/test_school_moves.py
+++ b/tests/test_school_moves.py
@@ -19,7 +19,6 @@ from mavis.test.pages import (
     SessionsOverviewPage,
 )
 from mavis.test.pages.utils import schedule_school_session_if_needed
-from mavis.test.utils import get_current_datetime
 
 pytestmark = pytest.mark.school_moves
 
@@ -46,14 +45,11 @@ def setup_confirm_and_ignore(
         ImportRecordsWizardPage(page, file_generator).select_year_groups(year_group)
         ImportRecordsWizardPage(page, file_generator).set_input_file(input_file_path)
         ImportRecordsWizardPage(page, file_generator).click_continue()
-        upload_time = get_current_datetime()
-        ImportRecordsWizardPage(page, file_generator).click_uploaded_file_datetime(
-            upload_time
-        )
+        ImportRecordsWizardPage(page, file_generator).click_import_link(input_file_path)
         ImportRecordsWizardPage(page, file_generator).wait_for_processed()
         if ImportRecordsWizardPage(page, file_generator).is_preview_page_link_visible():
             ImportRecordsWizardPage(page, file_generator).approve_preview_if_shown(
-                upload_time
+                input_file_path
             )
         ImportRecordsWizardPage(page, file_generator).verify_upload_output(
             file_path=output_file_path


### PR DESCRIPTION
We were using the date/time to determine which import to click at the imports screen, which could very occasionally lead to issues where the wrong file is selected. It makes more sense to use the filename which should be unique to each file.