### PR TITLE
Check for import in completed imports tab

### DIFF
--- a/mavis/test/pages/imports/import_records_wizard_page.py
+++ b/mavis/test/pages/imports/import_records_wizard_page.py
@@ -203,7 +203,7 @@ class ImportRecordsWizardPage:
             self.page.get_by_role("cell", name=file_path.name).get_by_role("link").first
         )
 
-        self.page.reload()
+        self.page.wait_for_load_state()
 
         if not import_link.is_visible():
             self.completed_imports_tab.click()


### PR DESCRIPTION
Sometimes imports go straight to the "completed imports" tab without first appearing in the "incomplete uploads" tab. The tests didn't account for this and so we were seeing some flakiness.

(I thought we already handled this so this was quite surprising for me to find! I think it will erase a significant amount of flakiness/reruns)