### PR TITLE
Rename "functional tests" to "end-to-end tests" everywhere

### DIFF
--- a/.github/actions/run-end-to-end-tests/action.yml
+++ b/.github/actions/run-end-to-end-tests/action.yml
@@ -1,4 +1,4 @@
-name: 'Run Tests'
+name: 'Run End-to-End tests'
 description: 'Execute tests'
 inputs:
   tests:

--- a/.github/workflows/accessibility.yaml
+++ b/.github/workflows/accessibility.yaml
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: write
     
-    name: Functional tests
+    name: End-to-End tests
     runs-on: ubuntu-latest
 
     env:
@@ -113,7 +113,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Run tests
-        uses: ./.github/actions/run-functional-tests
+        uses: ./.github/actions/run-end-to-end-tests
         with:
           tests: ${{ steps.set-variables.outputs.tests }}
           accessibility_tests: 'true'

--- a/.github/workflows/end-to-end-tests-all-devices.yaml
+++ b/.github/workflows/end-to-end-tests-all-devices.yaml
@@ -1,4 +1,4 @@
-name: Functional tests (all devices on QA)
+name: End-to-End tests (all devices on QA)
 
 on:
   schedule:
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
 
-    name: Functional tests
+    name: End-to-End tests
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Run tests
-        uses: ./.github/actions/run-functional-tests
+        uses: ./.github/actions/run-end-to-end-tests
         with:
           device: ${{ matrix.device }}
           base_url: ${{ vars.BASE_URL }}

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -1,4 +1,4 @@
-name: Functional tests
+name: End-to-End tests
 
 on:
   workflow_call:
@@ -151,7 +151,7 @@ jobs:
     permissions:
       contents: write
     
-    name: Functional tests
+    name: End-to-End tests
     runs-on: ubuntu-latest
 
     env:
@@ -215,7 +215,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Run tests
-        uses: ./.github/actions/run-functional-tests
+        uses: ./.github/actions/run-end-to-end-tests
         with:
           tests: ${{ steps.set-variables.outputs.tests }}
           imms_api_tests: ${{ steps.set-variables.outputs.cross_service_tests }}

--- a/.github/workflows/pull_request_validation.yaml
+++ b/.github/workflows/pull_request_validation.yaml
@@ -32,7 +32,7 @@ jobs:
   run-tests-against-staging:
     needs: identify-target-environment
     if: needs.identify-target-environment.outputs.environment != 'container'
-    uses: ./.github/workflows/functional_selected_device.yaml
+    uses: ./.github/workflows/end-to-end-tests.yaml
     permissions:
       contents: write
     with:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Testing for Manage vaccinations in schools
 
-This repository contains automated functional, performance and security tests for the [Manage vaccinations in schools][mavis] application.
+This repository contains automated end-to-end, performance and security tests for the [Manage vaccinations in schools][mavis] application.
 
 [mavis]: https://github.com/nhsuk/manage-vaccinations-in-schools/
 
-[![Functional tests](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/functional_selected_device.yaml/badge.svg?branch=main)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/functional_selected_device.yaml?branch=main)
+[![End-to-End tests](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/end-to-end-tests.yaml/badge.svg?branch=main)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/end-to-end-tests.yaml?branch=main)
 
 [![Performance (end to end) tests](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/performance-e2e.yaml/badge.svg)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/performance-e2e.yaml)
 
 [![Run full OWASP ZAP scan against QA](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/owasp_zap.yaml/badge.svg)](https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/actions/workflows/owasp_zap.yaml)
 
-## Functional tests
+## End-to-End tests
 
-The functional tests are written using [Playwright] with [Pytest].
+The end-to-end tests are written using [Playwright] with [Pytest].
 
 [Playwright]: https://playwright.dev/python/
 [Pytest]: https://docs.pytest.org/en/stable/


### PR DESCRIPTION
As more people may begin to start using this repository, I think we'll have less confusion if we use a single name for this test suite:
(rather than the current mix of "functional tests", "regression tests", "automated tests" etc.)

I believe the easiest and most descriptive label is "End-to-End" tests, since this is fairly standard and this repository contains full e2e journeys.

There will need to be a corresponding PR in the mavis repo, which I will open after