### PR TITLE
Add mmr nurse consent e2e test

### DIFF
--- a/mavis/test/constants.py
+++ b/mavis/test/constants.py
@@ -38,13 +38,9 @@ class HealthQuestion(StrEnum):
         "Does your child have a disease or treatment that severely affects their"
         " immune system?"
     )
-    BLEEDING_DISORDER = (
-        "Does your child have a bleeding disorder or another medical condition they"
-        " receive treatment for?"
-    )
+    BLEEDING_DISORDER = "Does your child have a bleeding disorder?"
 
     # hpv
-    BLEEDING_DISORDER_HPV = "Does your child have a bleeding disorder?"
     BLOOD_THINNING_MEDICINE = (
         "Does your child take blood-thinning medicine (anticoagulants)?"
     )
@@ -53,6 +49,10 @@ class HealthQuestion(StrEnum):
     )
 
     # doubles
+    BLEEDING_DISORDER_DOUBLES = (
+        "Does your child have a bleeding disorder or another medical condition they"
+        " receive treatment for?"
+    )
     MEDICAL_CONDITIONS = (
         "Does your child have any medical conditions for which they receive treatment?"
     )
@@ -122,7 +122,7 @@ class HealthQuestion(StrEnum):
         " yellow fever vaccine?"
     )
     MMR_OTHER_MEDICAL_CONDITIONS = (
-        "Does the child have any other medical conditions we should know about?"
+        "Does your child have any other medical conditions we should know about?"
     )
     MMR_EITHER_GELATINE = (
         "Has your child ever had a severe allergic reaction (anaphylaxis) to gelatine?"
@@ -201,7 +201,7 @@ class Programme(StrEnum):
         mmr_questions = [q for q in mmr_questions if q is not None]
 
         common_doubles_questions = [
-            HealthQuestion.BLEEDING_DISORDER,
+            HealthQuestion.BLEEDING_DISORDER_DOUBLES,
             HealthQuestion.SEVERE_ALLERGIES,
             HealthQuestion.REACTION,
             HealthQuestion.EXTRA_SUPPORT,
@@ -217,7 +217,7 @@ class Programme(StrEnum):
             ],
             Programme.HPV: [
                 HealthQuestion.SEVERE_ALLERGIES,
-                HealthQuestion.BLEEDING_DISORDER_HPV,
+                HealthQuestion.BLEEDING_DISORDER,
                 HealthQuestion.BLOOD_THINNING_MEDICINE,
                 HealthQuestion.IMMUNE_SYSTEM,
                 HealthQuestion.MEDICAL_CONDITIONS_HPV,

--- a/mavis/test/pages/sessions/nurse_consent_wizard_page.py
+++ b/mavis/test/pages/sessions/nurse_consent_wizard_page.py
@@ -74,6 +74,25 @@ class NurseConsentWizardPage:
         self.withdraw_consent_notes_textbox = self.page.get_by_role(
             "textbox", name="Notes"
         )
+        self.gelatine_free_radio = self.page.get_by_role(
+            "radio",
+            name="that does not contain gelatine",
+        )
+        self.either_vaccine_radio = self.page.get_by_role(
+            "radio",
+            name="Their child can have either type of vaccine",
+        )
+        self.mmrv_question_text = self.page.get_by_text(
+            "is eligible for the new MMRV vaccine"
+        )
+
+    @step("Select either vaccine option")
+    def select_either_vaccine_option(self) -> None:
+        self.either_vaccine_radio.check()
+
+    @step("Select gelatine free vaccine option")
+    def select_gelatine_free_vaccine_option(self) -> None:
+        self.gelatine_free_radio.check()
 
     @step("Click Continue")
     def click_continue(self) -> None:
@@ -229,6 +248,13 @@ class NurseConsentWizardPage:
         self.click_consent_method(method)
         self.click_continue()
 
+    def select_mmrv_eligibility_for_child(self) -> None:
+        # MMRV test is todo
+        self.page.wait_for_load_state()
+        if self.mmrv_question_text.is_visible():
+            self.select_no()
+            self.click_continue()
+
     def _process_consent_confirmation(
         self,
         programme: Programme = Programme.HPV,
@@ -238,18 +264,7 @@ class NurseConsentWizardPage:
         psd_option: bool | None = None,
         yes_to_health_questions: bool = False,
     ) -> None:
-        if programme is Programme.FLU:
-            if consent_option is ConsentOption.INJECTION:
-                self.click_yes_for_injected_vaccine()
-            else:
-                self.click_yes_for_nasal_spray()
-                if consent_option is ConsentOption.NASAL_SPRAY_OR_INJECTION:
-                    self.select_yes()
-                else:
-                    self.select_no()
-        else:
-            self.click_yes_they_agree()
-        self.click_continue()
+        self.agree_to_vaccination(programme, consent_option)
 
         if child_consent:
             self.select_yes()
@@ -271,6 +286,29 @@ class NurseConsentWizardPage:
             self.click_continue()
 
         self.click_confirm()
+
+    def agree_to_vaccination(
+        self, programme: Programme, consent_option: ConsentOption
+    ) -> None:
+        if programme is Programme.FLU:
+            if consent_option is ConsentOption.INJECTION:
+                self.click_yes_for_injected_vaccine()
+            else:
+                self.click_yes_for_nasal_spray()
+                if consent_option is ConsentOption.NASAL_SPRAY_OR_INJECTION:
+                    self.select_yes()
+                else:
+                    self.select_no()
+        else:
+            self.click_yes_they_agree()
+
+        if programme is Programme.MMR:
+            if consent_option is ConsentOption.MMR_WITHOUT_GELATINE:
+                self.select_gelatine_free_vaccine_option()
+            else:
+                self.select_either_vaccine_option()
+
+        self.click_continue()
 
     def update_triage_outcome_positive(self) -> None:
         self.click_safe_to_vaccinate()

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -187,10 +187,13 @@ class SessionsPatientPage:
         self,
         consent_option: ConsentOption = ConsentOption.INJECTION,
     ) -> None:
-        if consent_option is ConsentOption.INJECTION:
-            self.ready_for_injection_radio.check()
-        else:
+        if consent_option in (
+            ConsentOption.NASAL_SPRAY,
+            ConsentOption.NASAL_SPRAY_OR_INJECTION,
+        ):
             self.ready_for_nasal_spray_radio.check()
+        else:
+            self.ready_for_injection_radio.check()
 
     @step("Select vaccination site {1}")
     def select_delivery_site(self, site: DeliverySite) -> None:
@@ -286,7 +289,10 @@ class SessionsPatientPage:
         self.select_identity_confirmed_by_child(vaccination_record.child)
 
         self.select_ready_for_vaccination(vaccination_record.consent_option)
-        if vaccination_record.consent_option is ConsentOption.INJECTION:
+        if vaccination_record.consent_option not in (
+            ConsentOption.NASAL_SPRAY_OR_INJECTION,
+            ConsentOption.NASAL_SPRAY,
+        ):
             self.select_delivery_site(vaccination_record.delivery_site)
 
         self.click_continue_button()

--- a/mavis/test/pages/utils.py
+++ b/mavis/test/pages/utils.py
@@ -78,6 +78,7 @@ def record_nurse_consent_and_vaccination(
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
+    NurseConsentWizardPage(page).select_mmrv_eligibility_for_child()
     NurseConsentWizardPage(page).record_parent_positive_consent(
         programme=programme,
         consent_option=consent_option,

--- a/tests/test_e2e_nurse_consent_mmr.py
+++ b/tests/test_e2e_nurse_consent_mmr.py
@@ -1,0 +1,79 @@
+import pytest
+
+from mavis.test.annotations import issue
+from mavis.test.constants import (
+    ConsentOption,
+    Programme,
+    Vaccine,
+)
+from mavis.test.data_models import VaccinationRecord
+from mavis.test.pages.utils import (
+    prepare_child_for_vaccination,
+    record_nurse_consent_and_vaccination,
+)
+
+
+@pytest.fixture
+def setup_session_for_mmr(setup_session_and_batches_with_fixed_child):
+    return setup_session_and_batches_with_fixed_child(Programme.MMR)
+
+
+@issue("MAV-955")
+@pytest.mark.rav
+@pytest.mark.bug
+@pytest.mark.parametrize(
+    "consent_option",
+    [
+        ConsentOption.MMR_WITHOUT_GELATINE,
+        ConsentOption.MMR_EITHER,
+    ],
+    ids=lambda v: f"consent_option: {v}",
+)
+def test_e2e_nurse_consent_mmr(
+    setup_session_for_mmr,
+    schools,
+    page,
+    children,
+    consent_option,
+):
+    """
+    Test: Verify a vaccination can be recorded after providing nurse consent for MMR
+    Steps:
+    1. Setup: Schedule sessions for doubles at a school and
+       import a fixed child class list.
+    2. Navigate to the session and register the child as attending.
+    3. Record verbal consent for the child.
+    4. Record both vaccinations for the child with a long notes field.
+    Verification:
+    - Vaccinations can be recorded
+    - Providing long notes gives an error
+    """
+    batch_names = setup_session_for_mmr
+    programme_group = Programme.MMR
+    vaccine = (
+        Vaccine.PRIORIX
+        if consent_option is ConsentOption.MMR_WITHOUT_GELATINE
+        else Vaccine.MMR_VAXPRO
+    )
+
+    child = children[programme_group][0]
+    school = schools[programme_group][0]
+
+    mmr_vaccination_record = VaccinationRecord(
+        child,
+        Programme.MMR,
+        batch_names[vaccine],
+        consent_option,
+    )
+
+    prepare_child_for_vaccination(
+        page,
+        school,
+        programme_group,
+        child,
+    )
+
+    record_nurse_consent_and_vaccination(
+        page,
+        mmr_vaccination_record,
+    )


### PR DESCRIPTION
Following #893, adds a test that records nurse consent for MMR and records a vaccination. 

This does not record nurse consent for MMRV -> this will come in a follow up PR.
