### PR TITLE
Add MMRV end-to-end test

### DIFF
--- a/mavis/test/constants.py
+++ b/mavis/test/constants.py
@@ -1,5 +1,6 @@
 import os
 import urllib.parse
+from datetime import date
 from enum import StrEnum
 
 from faker import Faker
@@ -7,6 +8,8 @@ from faker import Faker
 faker = Faker("en_GB")
 
 MAVIS_NOTE_LENGTH_LIMIT = 1000
+
+MMRV_ELIGIBILITY_CUTOFF_DOB = date(2020, 1, 1)
 
 
 class ConsentOption(StrEnum):
@@ -109,6 +112,10 @@ class HealthQuestion(StrEnum):
         "Has your child received a blood or plasma transfusion,"
         " or immunoglobulin in the last 3 months?"
     )
+    MMRV_ALLERGIC_REACTION = (
+        "Has your child had a severe allergic reaction (anaphylaxis) to a previous dose"
+        " of MMRV or any other vaccine?"
+    )
     MMR_ALLERGIC_REACTION = (
         "Has your child had a severe allergic reaction (anaphylaxis) to a previous dose"
         " of MMR or any other vaccine?"
@@ -158,6 +165,7 @@ class Programme(StrEnum):
         consent_option: ConsentOption = ConsentOption.INJECTION,
         *,
         nurse_consent: bool = False,
+        mmrv_eligibility: bool = False,
     ) -> list[HealthQuestion]:
         includes_nasal = consent_option is not ConsentOption.INJECTION
         includes_injection = consent_option is not ConsentOption.NASAL_SPRAY
@@ -190,7 +198,9 @@ class Programme(StrEnum):
             HealthQuestion.BLEEDING_DISORDER,
             HealthQuestion.MMR_ANTICOAGULANTS,
             HealthQuestion.MMR_TRANSFUSION,
-            HealthQuestion.MMR_ALLERGIC_REACTION,
+            HealthQuestion.MMRV_ALLERGIC_REACTION
+            if mmrv_eligibility
+            else HealthQuestion.MMR_ALLERGIC_REACTION,
             HealthQuestion.MMR_ALLERGIC_REACTION_NEOMYCIN,
             HealthQuestion.IMMUNE_SYSTEM,
             HealthQuestion.MMR_TB_TEST,
@@ -306,6 +316,10 @@ class Vaccine(StrEnum):
     MMR_VAXPRO = "MMR VaxPro"
     PRIORIX = "Priorix"
 
+    # MMRV
+    PROQUAD = "ProQuad"
+    PRIORIX_TETRA = "Priorix-Tetra"
+
     # Td/IPV
     REVAXIS = "Revaxis"
 
@@ -330,6 +344,8 @@ class Vaccine(StrEnum):
             Vaccine.REVAXIS: Programme.TD_IPV,
             Vaccine.MMR_VAXPRO: Programme.MMR,
             Vaccine.PRIORIX: Programme.MMR,
+            Vaccine.PROQUAD: Programme.MMR,
+            Vaccine.PRIORIX_TETRA: Programme.MMR,
         }
         return programme_mapping[self]
 
@@ -363,6 +379,8 @@ class Vaccine(StrEnum):
             Vaccine.REVAXIS: Vaccine.REVAXIS,
             Vaccine.MMR_VAXPRO: Vaccine.MMR_VAXPRO,
             Vaccine.PRIORIX: Vaccine.PRIORIX,
+            Vaccine.PROQUAD: Vaccine.PROQUAD,
+            Vaccine.PRIORIX_TETRA: Vaccine.PRIORIX_TETRA,
         }
         return offline_sheet_map[self]
 

--- a/mavis/test/pages/sessions/nurse_consent_wizard_page.py
+++ b/mavis/test/pages/sessions/nurse_consent_wizard_page.py
@@ -111,9 +111,11 @@ class NurseConsentWizardPage:
         programme: Programme,
         consent_option: ConsentOption = ConsentOption.INJECTION,
         answer: str = "No",
+        *,
+        mmrv_eligibility: bool = False,
     ) -> None:
         for locator_text in programme.health_questions(
-            consent_option, nurse_consent=True
+            consent_option, nurse_consent=True, mmrv_eligibility=mmrv_eligibility
         ):
             self.select_answer_for_health_question(locator_text, answer)
 
@@ -198,12 +200,14 @@ class NurseConsentWizardPage:
         *,
         psd_option: bool | None = None,
         yes_to_health_questions: bool = False,
+        mmrv_eligibility: bool = False,
     ) -> None:
         self._process_consent_confirmation(
             programme=programme,
             consent_option=consent_option,
             psd_option=psd_option,
             yes_to_health_questions=yes_to_health_questions,
+            mmrv_eligibility=mmrv_eligibility,
         )
 
     def record_parent_no_response(self) -> None:
@@ -224,6 +228,7 @@ class NurseConsentWizardPage:
         *,
         psd_option: bool | None = None,
         yes_to_health_questions: bool = False,
+        mmrv_eligibility: bool = False,
     ) -> None:
         self._process_consent_confirmation(
             programme=programme,
@@ -231,6 +236,7 @@ class NurseConsentWizardPage:
             psd_option=psd_option,
             yes_to_health_questions=yes_to_health_questions,
             child_consent=True,
+            mmrv_eligibility=mmrv_eligibility,
         )
 
     def _handle_refusal_of_consent(self, reason: ConsentRefusalReason) -> None:
@@ -249,13 +255,10 @@ class NurseConsentWizardPage:
         self.click_continue()
 
     def select_mmrv_eligibility_for_child(self) -> None:
-        # MMRV test is todo
-        self.page.wait_for_load_state()
-        if self.mmrv_question_text.is_visible():
-            self.select_no()
-            self.click_continue()
+        self.select_yes()
+        self.click_continue()
 
-    def _process_consent_confirmation(
+    def _process_consent_confirmation(  # noqa: PLR0913
         self,
         programme: Programme = Programme.HPV,
         consent_option: ConsentOption = ConsentOption.INJECTION,
@@ -263,6 +266,7 @@ class NurseConsentWizardPage:
         child_consent: bool = False,
         psd_option: bool | None = None,
         yes_to_health_questions: bool = False,
+        mmrv_eligibility: bool = False,
     ) -> None:
         self.agree_to_vaccination(programme, consent_option)
 
@@ -272,7 +276,7 @@ class NurseConsentWizardPage:
 
         answer = "Yes" if yes_to_health_questions else "No"
         self.answer_all_health_questions(
-            programme=programme, consent_option=consent_option, answer=answer
+            programme, consent_option, answer, mmrv_eligibility=mmrv_eligibility
         )
 
         self.click_continue()

--- a/mavis/test/pages/utils.py
+++ b/mavis/test/pages/utils.py
@@ -69,6 +69,8 @@ def prepare_child_for_vaccination(
 def record_nurse_consent_and_vaccination(
     page: Page,
     vaccination_record: VaccinationRecord,
+    *,
+    mmrv_eligibility: bool = False,
 ) -> None:
     child = vaccination_record.child
     programme = vaccination_record.programme
@@ -78,10 +80,14 @@ def record_nurse_consent_and_vaccination(
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).select_mmrv_eligibility_for_child()
+
+    if mmrv_eligibility:
+        NurseConsentWizardPage(page).select_mmrv_eligibility_for_child()
+
     NurseConsentWizardPage(page).record_parent_positive_consent(
         programme=programme,
         consent_option=consent_option,
+        mmrv_eligibility=mmrv_eligibility,
     )
     notes = generate_random_string(
         target_length=MAVIS_NOTE_LENGTH_LIMIT + 1,

--- a/tests/test_e2e_nurse_consent_mmr.py
+++ b/tests/test_e2e_nurse_consent_mmr.py
@@ -2,6 +2,7 @@ import pytest
 
 from mavis.test.annotations import issue
 from mavis.test.constants import (
+    MMRV_ELIGIBILITY_CUTOFF_DOB,
     ConsentOption,
     Programme,
     Vaccine,
@@ -50,11 +51,23 @@ def test_e2e_nurse_consent_mmr(
     """
     batch_names = setup_session_for_mmr
     programme_group = Programme.MMR
-    vaccine = (
-        Vaccine.PRIORIX
-        if consent_option is ConsentOption.MMR_WITHOUT_GELATINE
-        else Vaccine.MMR_VAXPRO
-    )
+
+    child = children[programme_group][0]
+    school = schools[programme_group][0]
+
+    mmrv_eligibility = child.date_of_birth > MMRV_ELIGIBILITY_CUTOFF_DOB
+    if mmrv_eligibility:
+        vaccine = (
+            Vaccine.PRIORIX_TETRA
+            if consent_option is ConsentOption.MMR_WITHOUT_GELATINE
+            else Vaccine.PROQUAD
+        )
+    else:
+        vaccine = (
+            Vaccine.PRIORIX
+            if consent_option is ConsentOption.MMR_WITHOUT_GELATINE
+            else Vaccine.MMR_VAXPRO
+        )
 
     child = children[programme_group][0]
     school = schools[programme_group][0]
@@ -76,4 +89,5 @@ def test_e2e_nurse_consent_mmr(
     record_nurse_consent_and_vaccination(
         page,
         mmr_vaccination_record,
+        mmrv_eligibility=mmrv_eligibility,
     )


### PR DESCRIPTION
Changes the MMR end-to-end test so that if a patient is eligible for MMRV, they instead receive consent for MMRV and are vaccinated with an MMRV vaccine. This will happen around 25% of the time that this test is run.
