### PR TITLE
Add careplus staff fields when onboarding

### DIFF
--- a/mavis/test/data_models.py
+++ b/mavis/test/data_models.py
@@ -137,6 +137,8 @@ class Team:
     name: str
     workgroup: str
     careplus_venue_code: str
+    careplus_staff_code: str
+    careplus_staff_type: str
     email: str
     phone: str
 
@@ -150,6 +152,8 @@ class Team:
             "email": self.email,
             "phone": self.phone,
             "careplus_venue_code": self.careplus_venue_code,
+            "careplus_staff_code": self.careplus_staff_code,
+            "careplus_staff_type": self.careplus_staff_type,
             "privacy_notice_url": "https://example.com/privacy",
             "privacy_policy_url": "https://example.com/privacy",
             "type": "poc_only",
@@ -160,7 +164,9 @@ class Team:
         return cls(
             name=subteam.name,
             workgroup=organisation.ods_code,
-            careplus_venue_code=organisation.ods_code,
+            careplus_venue_code=organisation.ods_code + "A",
+            careplus_staff_code=organisation.ods_code + "B",
+            careplus_staff_type=organisation.ods_code + "C",
             email=subteam.email,
             phone=subteam.phone,
         )


### PR DESCRIPTION
Fills these fields when creating organisations to use in tests. This allows the tests to verify that careplus reports can be downloaded