### PR TITLE
Remove logins and logouts from most helper fixtures

### DIFF
--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -67,7 +67,6 @@ def schedule_session_and_get_consent_url(
             page, school, list(programmes), [year_group], date_offset=7
         )
         url = SessionsOverviewPage(page).get_online_consent_url(*programmes)
-        LogInPage(page).log_out()
         yield url
 
     return wrapper
@@ -86,7 +85,6 @@ def schedule_mmr_session_and_get_consent_url(
             page, school, list(programmes), [year_group], date_offset=7
         )
         url = SessionsOverviewPage(page).get_online_consent_url(*programmes)
-        LogInPage(page).log_out()
         yield url
 
     return wrapper
@@ -101,24 +99,18 @@ def log_in_as_medical_secretary(
 ):
     LogInPage(page).navigate()
     LogInPage(page).log_in_and_choose_team_if_necessary(medical_secretary, team)
-    yield
-    LogInPage(page).log_out()
 
 
 @pytest.fixture
 def log_in_as_nurse(set_feature_flags, nurse, team, page):
     LogInPage(page).navigate()
     LogInPage(page).log_in_and_choose_team_if_necessary(nurse, team)
-    yield
-    LogInPage(page).log_out()
 
 
 @pytest.fixture
 def log_in_as_prescriber(set_feature_flags, prescriber, team, page):
     LogInPage(page).navigate()
     LogInPage(page).log_in_and_choose_team_if_necessary(prescriber, team)
-    yield
-    LogInPage(page).log_out()
 
 
 @pytest.fixture
@@ -186,15 +178,12 @@ def setup_session_and_batches_with_fixed_child(
     children,
     page,
     file_generator,
-    nurse,
-    team,
 ):
     def _setup(programme_group):
         school = schools[programme_group][0]
         child = children[programme_group][0]
 
-        LogInPage(page).navigate()
-        LogInPage(page).log_in_and_choose_team_if_necessary(nurse, team)
+        DashboardPage(page).navigate()
         batch_names = {
             vaccine: add_vaccine_batch(vaccine, re.sub(r"\W+", "", vaccine) + "123")
             for vaccine in Vaccine

--- a/mavis/test/pages/log_in_page.py
+++ b/mavis/test/pages/log_in_page.py
@@ -83,24 +83,11 @@ class LogInPage:
 
     @step("Log out")
     def log_out(self) -> None:
-        if self.log_out_button.is_visible():
-            # Write logout to audit log
-            if self.current_user:
-                self._write_audit_log(
-                    "LOGOUT", self.current_user, self.current_org_code
-                )
-                self.current_user = None  # Clear current user
-
-            self.log_out_button.click()
-            expect(self.start_page_link).to_be_visible()
+        self.log_out_button.click()
+        expect(self.start_page_link).to_be_visible()
 
     @step("Log out")
     def log_out_via_reporting_component(self) -> None:
-        # Write logout to audit log
-        if self.current_user:
-            self._write_audit_log("LOGOUT", self.current_user, self.current_org_code)
-            self.current_user = None  # Clear current user
-
         self.log_out_link.click()
 
     @step("Log in as {1} and choose team {2}")

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -79,14 +79,8 @@ def give_online_consent_pds_child(
     OnlineConsentWizardPage(page).click_confirm()
 
 
-@pytest.fixture
-def go_to_unmatched_consent_responses(log_in_as_nurse, page):
-    DashboardPage(page).click_unmatched_consent_responses()
-
-
 def test_archive_unmatched_consent_response_removes_from_list(
     give_online_consent,
-    go_to_unmatched_consent_responses,
     page,
     children,
 ):
@@ -100,6 +94,10 @@ def test_archive_unmatched_consent_response_removes_from_list(
     - The consent response for the child is no longer visible in the unmatched list.
     """
     child = children[Programme.HPV][0]
+
+    DashboardPage(page).navigate()
+    DashboardPage(page).click_unmatched_consent_responses()
+
     UnmatchedConsentResponsesPage(page).click_parent_on_consent_record_for_child(child)
 
     ConsentResponsePage(page).click_archive()
@@ -111,7 +109,6 @@ def test_archive_unmatched_consent_response_removes_from_list(
 
 def test_match_unmatched_consent_response_and_verify_activity_log(
     give_online_consent,
-    log_in_as_nurse,
     children,
     page,
     file_generator,
@@ -131,6 +128,7 @@ def test_match_unmatched_consent_response_and_verify_activity_log(
     """
     child = children[Programme.HPV][0]
 
+    DashboardPage(page).navigate()
     DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, file_generator).navigate_to_child_record_import()
@@ -158,7 +156,6 @@ def test_match_unmatched_consent_response_and_verify_activity_log(
 
 def test_create_child_record_from_consent_with_nhs_number(
     give_online_consent_pds_child,
-    go_to_unmatched_consent_responses,
     pds_child,
     page,
 ):
@@ -175,6 +172,9 @@ def test_create_child_record_from_consent_with_nhs_number(
     - Activity log for the child shows the creation event.
     """
     child = pds_child
+
+    DashboardPage(page).navigate()
+    DashboardPage(page).click_unmatched_consent_responses()
 
     UnmatchedConsentResponsesPage(page).click_parent_on_consent_record_for_child(child)
 
@@ -194,7 +194,6 @@ def test_create_child_record_from_consent_with_nhs_number(
 
 def test_create_child_record_from_consent_without_nhs_number(
     give_online_consent,
-    go_to_unmatched_consent_responses,
     children,
     page,
 ):
@@ -212,6 +211,10 @@ def test_create_child_record_from_consent_without_nhs_number(
     - Activity log for the child shows the creation event.
     """
     child = children[Programme.HPV][0]
+
+    DashboardPage(page).navigate()
+    DashboardPage(page).click_unmatched_consent_responses()
+
     UnmatchedConsentResponsesPage(page).click_parent_on_consent_record_for_child(child)
 
     ConsentResponsePage(page).click_create_new_record()
@@ -231,7 +234,6 @@ def test_create_child_record_from_consent_without_nhs_number(
 @pytest.mark.accessibility
 def test_accessibility(
     give_online_consent,
-    log_in_as_nurse,
     children,
     page,
     file_generator,
@@ -246,6 +248,7 @@ def test_accessibility(
     """
     child = children[Programme.HPV][0]
 
+    DashboardPage(page).navigate()
     DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, file_generator).navigate_to_child_record_import()
@@ -272,7 +275,6 @@ def test_accessibility(
 @issue("MAV-2681")
 def test_match_consent_with_vaccination_record_no_service_error(
     give_online_consent,
-    log_in_as_nurse,
     upload_offline_vaccination,
     children,
     page,
@@ -302,6 +304,7 @@ def test_match_consent_with_vaccination_record_no_service_error(
     school = schools[Programme.HPV][0]
 
     # Step 2: Import a class list to create searchable child records for both children
+    DashboardPage(page).navigate()
     DashboardPage(page).click_imports()
     ImportsPage(page).click_upload_records()
     ImportRecordsWizardPage(page, file_generator).navigate_to_class_list_record_import(

--- a/tests/test_e2e_nurse_consent_doubles.py
+++ b/tests/test_e2e_nurse_consent_doubles.py
@@ -21,6 +21,7 @@ def setup_session_for_doubles(setup_session_and_batches_with_fixed_child):
 @pytest.mark.rav
 @pytest.mark.bug
 def test_e2e_nurse_consent_doubles(
+    log_in_as_nurse,
     setup_session_for_doubles,
     schools,
     page,

--- a/tests/test_e2e_nurse_consent_flu.py
+++ b/tests/test_e2e_nurse_consent_flu.py
@@ -31,6 +31,7 @@ def setup_session_for_flu(setup_session_and_batches_with_fixed_child):
     ids=lambda v: f"consent_option: {v}",
 )
 def test_e2e_nurse_consent_flu(
+    log_in_as_nurse,
     setup_session_for_flu,
     schools,
     page,

--- a/tests/test_e2e_nurse_consent_hpv.py
+++ b/tests/test_e2e_nurse_consent_hpv.py
@@ -21,6 +21,7 @@ def setup_session_for_hpv(setup_session_and_batches_with_fixed_child):
 @pytest.mark.rav
 @pytest.mark.bug
 def test_e2e_nurse_consent_hpv(
+    log_in_as_nurse,
     setup_session_for_hpv,
     schools,
     page,

--- a/tests/test_e2e_nurse_consent_mmr.py
+++ b/tests/test_e2e_nurse_consent_mmr.py
@@ -31,6 +31,7 @@ def setup_session_for_mmr(setup_session_and_batches_with_fixed_child):
     ids=lambda v: f"consent_option: {v}",
 )
 def test_e2e_nurse_consent_mmr(
+    log_in_as_nurse,
     setup_session_for_mmr,
     schools,
     page,

--- a/tests/test_imms_sync.py
+++ b/tests/test_imms_sync.py
@@ -23,11 +23,6 @@ def imms_api_helper(authenticate_api):
 
 
 @pytest.fixture
-def sidekiq_helper():
-    return SidekiqHelper()
-
-
-@pytest.fixture
 def setup_session_for_flu(setup_session_and_batches_with_fixed_child):
     return setup_session_and_batches_with_fixed_child(Programme.FLU)
 
@@ -35,11 +30,11 @@ def setup_session_for_flu(setup_session_and_batches_with_fixed_child):
 @issue("MAV-2831")
 def test_create_imms_record_then_verify_on_children_page(
     imms_api_helper,
+    log_in_as_nurse,
+    setup_session_for_flu,
     page,
     children,
     schools,
-    setup_session_for_flu,
-    sidekiq_helper,
 ):
     """
     Test: Create a vaccination record via IMMS API, then log into MAVIS as a nurse.
@@ -73,7 +68,7 @@ def test_create_imms_record_then_verify_on_children_page(
         vaccination_time=vaccination_time,
     )
 
-    sidekiq_helper.run_recurring_job(sidekiq_job_name)
+    SidekiqHelper().run_recurring_job(sidekiq_job_name)
 
     # Verify the child created via IMMS API is visible in MAVIS children page
     DashboardPage(page).navigate()

--- a/tests/test_online_consent_flu.py
+++ b/tests/test_online_consent_flu.py
@@ -35,7 +35,6 @@ def start_consent_with_session_scheduled(url_with_session_scheduled, page):
 @pytest.fixture
 def setup_session_with_file_upload(
     url_with_session_scheduled,
-    log_in_as_nurse,
     schools,
     page,
     file_generator,
@@ -44,6 +43,7 @@ def setup_session_with_file_upload(
     school = schools[Programme.FLU][0]
     year_group = year_groups[Programme.FLU]
 
+    DashboardPage(page).navigate()
     DashboardPage(page).click_schools()
     SchoolsSearchPage(page).click_school(school)
     SchoolsChildrenPage(page).click_import_class_lists()

--- a/tests/test_online_consent_school_moves.py
+++ b/tests/test_online_consent_school_moves.py
@@ -8,7 +8,6 @@ from mavis.test.pages import (
     CreateNewRecordConsentResponsePage,
     DashboardPage,
     ImportRecordsWizardPage,
-    LogInPage,
     OnlineConsentWizardPage,
     ReviewSchoolMovePage,
     SchoolMovesPage,
@@ -41,7 +40,6 @@ def start_consent_with_session_scheduled(url_with_session_scheduled, page):
 @pytest.fixture
 def setup_session_with_file_upload(
     url_with_session_scheduled,
-    log_in_as_nurse,
     schools,
     page,
     file_generator,
@@ -49,6 +47,8 @@ def setup_session_with_file_upload(
 ):
     school = schools[Programme.FLU][0]
     year_group = year_groups[Programme.FLU]
+
+    DashboardPage(page).navigate()
 
     DashboardPage(page).click_schools()
     SchoolsSearchPage(page).click_school(school)
@@ -169,9 +169,6 @@ def test_online_consent_school_moves_with_new_patient(
         consent_option=ConsentOption.NASAL_SPRAY_OR_INJECTION,
     )
 
-    LogInPage(page).navigate()
-    LogInPage(page).log_in_and_choose_team_if_necessary(nurse, team)
-
     DashboardPage(page).navigate()
     DashboardPage(page).click_unmatched_consent_responses()
     UnmatchedConsentResponsesPage(page).click_parent_on_consent_record_for_child(child)
@@ -189,8 +186,6 @@ def test_online_consent_school_moves_with_new_patient(
     SessionsChildrenPage(page).verify_child_shows_correct_flu_consent_method(
         child, ConsentOption.NASAL_SPRAY_OR_INJECTION
     )
-
-    LogInPage(page).log_out()
 
 
 @pytest.mark.accessibility


### PR DESCRIPTION
We have a number of helper fixtures that set up sessions, get consent urls, upload offline vaccinations etc.

In some cases multiple of these are used at once. Previously, some of these would log in and some of these would not, which made using multiple helper fixtures confusing as you would need to ensure the user was logged in at each point.

This PR makes it so the only helper fixtures that log in are `log_in_as_nurse` or similar login helpers. Most logouts have been removed too, as they are not necessary in most cases.