### PR TITLE
Increase vaccination record edit coverage

### DIFF
--- a/mavis/test/pages/vaccination_record/edit_vaccination_record_page.py
+++ b/mavis/test/pages/vaccination_record/edit_vaccination_record_page.py
@@ -5,6 +5,7 @@ from playwright.sync_api import Page, expect
 from mavis.test.annotations import step
 from mavis.test.constants import DeliverySite
 from mavis.test.pages.header_component import HeaderComponent
+from mavis.test.utils import get_current_datetime, random_datetime_earlier_today
 
 
 class EditVaccinationRecordPage:
@@ -26,6 +27,9 @@ class EditVaccinationRecordPage:
             name="They refused it",
         )
         self.continue_button = page.get_by_role("button", name="Continue")
+        self.vaccinated_radio = page.get_by_role("radio", name="Vaccinated")
+        self.add_batch_link = page.get_by_role("link", name="Add batch")
+        self.add_method_link = page.get_by_role("link", name="Add method")
 
     @step("Click on Edit vaccination record")
     def click_edit_vaccination_record(self) -> None:
@@ -63,6 +67,32 @@ class EditVaccinationRecordPage:
     @step("Click on Continue")
     def click_continue(self) -> None:
         self.continue_button.click()
+        self.page.wait_for_load_state()
+
+    @step("Click on Vaccinated")
+    def click_vaccinated(self) -> None:
+        self.vaccinated_radio.check()
+
+    @step("Add batch {1}")
+    def add_batch(self, batch_name: str) -> None:
+        self.add_batch_link.click()
+        self.page.get_by_role("radio", name=batch_name).check()
+        self.click_continue()
+
+    @step("Add method and site")
+    def add_method_and_site(self, delivery_site: DeliverySite) -> None:
+        self.add_method_link.click()
+        self.page.get_by_role("radio", name="Intramuscular (IM) injection").check()
+        self.page.get_by_role("radio", name=str(delivery_site)).check()
+        self.click_continue()
+
+    @step("Update time of delivery")
+    def update_time_of_delivery(self) -> None:
+        self.click_change_time()
+        self.change_time_of_delivery(
+            random_datetime_earlier_today(get_current_datetime())
+        )
+        self.click_continue()
 
     def expect_text_to_not_be_visible(self, text: str) -> None:
         expect(self.page.get_by_text(text)).not_to_be_visible()

--- a/tests/test_vaccination_records.py
+++ b/tests/test_vaccination_records.py
@@ -1,37 +1,65 @@
 import pytest
 
-from mavis.test.constants import Programme
+from mavis.test.constants import DeliverySite, Programme, Vaccine
 from mavis.test.pages import (
     EditVaccinationRecordPage,
     VaccinationRecordPage,
 )
+from mavis.test.pages.sessions.sessions_patient_page import SessionsPatientPage
 from mavis.test.utils import expect_alert_text
 
 
 @pytest.fixture
-def upload_offline_vaccination_hpv(upload_offline_vaccination):
+def setup_gardasil_batch(page, add_vaccine_batch):
+    return add_vaccine_batch(Vaccine.GARDASIL_9)
+
+
+@pytest.fixture
+def upload_offline_vaccination_hpv(upload_offline_vaccination, add_vaccine_batch):
     yield from upload_offline_vaccination(Programme.HPV)
 
 
 @pytest.mark.rav
 @pytest.mark.bug
-def test_edit_vaccination_dose_to_not_given(
+def test_edit_vaccination_dose_to_not_given_and_bac(
     log_in_as_nurse,
+    setup_gardasil_batch,
     upload_offline_vaccination_hpv,
+    schools,
     page,
 ):
     """
-    Test: Edit a vaccination dose to 'not given' and verify outcome.
+    Test: Edit a vaccination dose to 'not given' and verify outcome. Then
+    change it back to 'given' with batch and site, and verify outcome.
     Steps:
     1. Navigate to the child in the programme.
     2. Edit the vaccination record and change outcome to 'they refused it'.
     3. Save changes.
+    4. Verify alert confirms vaccination outcome recorded as refused.
+    5. Edit the vaccination record again and change outcome back to 'vaccinated'.
+    6. Add batch and site information.
+    7. Update time of delivery.
+    8. Save changes.
     Verification:
     - Alert confirms vaccination outcome recorded as refused.
     """
+    school = schools[Programme.HPV][0]
+    batch_name = setup_gardasil_batch
+
     VaccinationRecordPage(page).click_edit_vaccination_record()
     EditVaccinationRecordPage(page).click_change_outcome()
     EditVaccinationRecordPage(page).click_they_refused_it()
     EditVaccinationRecordPage(page).click_continue()
+    EditVaccinationRecordPage(page).click_save_changes()
+    expect_alert_text(page, "Vaccination outcome recorded for HPV")
+
+    SessionsPatientPage(page).click_vaccination_details(school)
+    VaccinationRecordPage(page).click_edit_vaccination_record()
+    EditVaccinationRecordPage(page).click_change_outcome()
+    EditVaccinationRecordPage(page).click_vaccinated()
+    EditVaccinationRecordPage(page).click_continue()
+    EditVaccinationRecordPage(page).add_batch(batch_name)
+    EditVaccinationRecordPage(page).add_method_and_site(DeliverySite.LEFT_ARM_UPPER)
+    EditVaccinationRecordPage(page).update_time_of_delivery()
     EditVaccinationRecordPage(page).click_save_changes()
     expect_alert_text(page, "Vaccination outcome recorded for HPV")


### PR DESCRIPTION
After editing a vaccination record to not given, edit it back to given and edit more fields