### PR TITLE
Re-enable imms/reporting tests for overnight runs

### DIFF
--- a/.github/workflows/end-to-end-tests-all-devices.yaml
+++ b/.github/workflows/end-to-end-tests-all-devices.yaml
@@ -44,6 +44,8 @@ jobs:
         with:
           device: ${{ matrix.device }}
           base_url: ${{ vars.BASE_URL }}
+          imms_api_tests: 'true'
+          reporting_tests: 'true'
           playwright_cache_hit: ${{ steps.playwright-cache.outputs.cache-hit }}
         env:
           BASIC_AUTH_TOKEN: ${{ secrets.HTTP_AUTH_TOKEN_FOR_TESTS }}


### PR DESCRIPTION
It seems that when making these tests optional (so they can be disabled for PRs etc) we forgot to update the overnight run to run these imms api and reporting tests. 

We usually trigger full runs during the day so this has not resulted in us missing any failing tests.