### PR TITLE
Add call to location deletion endpoint

### DIFF
--- a/mavis/test/fixtures/data_models.py
+++ b/mavis/test/fixtures/data_models.py
@@ -43,6 +43,12 @@ def reset_before_each_module(base_url, team) -> None:
     response = requests.delete(url, params={"keep_itself": "true"}, timeout=30)
     _check_response_status(response)
 
+    url = urllib.parse.urljoin(
+        base_url, f"api/testing/teams/{team.workgroup}/locations"
+    )
+    response = requests.delete(url, params={"keep_base_locations": "true"}, timeout=30)
+    _check_response_status(response)
+
 
 @pytest.fixture(scope="session")
 def year_groups() -> dict[str, int]:


### PR DESCRIPTION
Delete all sites created by tests after each test module, preventing sites created in `tests/test_team.py` from interfering with other tests

corresponds to mavis PR: [add-location-deletion-endpoint](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/5946)