### PR TITLE
Rename release workflow

### DIFF
--- a/.github/workflows/end-to-end-tests-release.yaml
+++ b/.github/workflows/end-to-end-tests-release.yaml
@@ -1,4 +1,4 @@
-name: End-to-End tests
+name: End-to-End tests (Jira integration)
 
 on:
   workflow_call:


### PR DESCRIPTION
Renames the new release workflow so that it does not have the same name as our current "End-to-End tests" workflow