### PR TITLE
Fill any missing required details with fixed values

### DIFF
--- a/mavis/test/pages/team/team_schools_page.py
+++ b/mavis/test/pages/team/team_schools_page.py
@@ -124,6 +124,17 @@ class TeamSchoolsPage:
     def confirm_site(self) -> None:
         self.confirm_site_button.click()
 
+    @step("Fill any missing required details")
+    def fill_missing_details(self) -> None:
+        if not self.address_line_1_textbox.input_value():
+            self.address_line_1_textbox.fill("New Address Line 1")
+
+        if not self.address_town_textbox.input_value():
+            self.address_town_textbox.fill("New Town")
+
+        if not self.address_postcode_textbox.input_value():
+            self.address_postcode_textbox.fill("SW1A 1AA")
+
     @step("Check new site success flash and site is listed in the table")
     def check_new_site_is_listed(
         self, new_site_name: str, new_site_urn: str, old_school_urn: str

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -139,6 +139,7 @@ def test_site_child_record_import(
     TeamSchoolsPage(page).click_add_new_school_site()
     TeamSchoolsPage(page).select_school(school)
     TeamSchoolsPage(page).fill_site_name(new_site_name)
+    TeamSchoolsPage(page).fill_missing_details()
     TeamSchoolsPage(page).click_continue()
     TeamSchoolsPage(page).confirm_site()
 
@@ -204,6 +205,7 @@ def test_site_class_list_import(
     TeamSchoolsPage(page).click_add_new_school_site()
     TeamSchoolsPage(page).select_school(school)
     TeamSchoolsPage(page).fill_site_name(new_site_name)
+    TeamSchoolsPage(page).fill_missing_details()
     TeamSchoolsPage(page).click_continue()
     TeamSchoolsPage(page).confirm_site()
 


### PR DESCRIPTION
Some schools in the GIAS data don't have postcodes or towns. Mavis prefills this data when creating a site for a school. Mavis also requires postcode/town data when creating a site for a school.

This causes tests to break as they assume the postcode and town fields are filled when creating a site, but they are very occasionally not. To solve this, for now we'll just fill any missing fields. 

(It could also be that Mavis should allow empty postcodes/towns for sites, but I assume this is not desired and the current failures are due to poor GIAS data.)