### PR TITLE
Add tests for "already vaccinated" for one dose vaccinations

### DIFF
--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -105,6 +105,9 @@ class SessionsPatientPage:
         self.triage_notes_textbox = self.page.get_by_role(
             "textbox", name="Triage notes"
         )
+        self.record_as_already_vaccinated_link = self.page.get_by_role(
+            "link", name="Record as already vaccinated"
+        )
 
     def _select_tab(self, name: str) -> None:
         link = self.page.get_by_label("Secondary menu").get_by_role("link", name=name)
@@ -149,6 +152,18 @@ class SessionsPatientPage:
     @step("Click on Mark as invalid")
     def click_mark_as_invalid_button(self) -> None:
         self.mark_as_invalid_button.click()
+
+    @step("Click on Record as already vaccinated")
+    def record_as_already_vaccinated(self) -> None:
+        self.record_as_already_vaccinated_link.click()
+
+    @step("Record {1} dose as already given")
+    def record_dose_as_already_given(self, dose_number: int) -> None:
+        dose_text = "1st" if dose_number == 1 else "2nd"
+        dose_link = self.page.get_by_role(
+            "link", name=f"Record {dose_text} dose as already given"
+        )
+        dose_link.click()
 
     def invalidate_parent_refusal(self, parent: Parent) -> None:
         invalidation_notes = "Invalidation notes."

--- a/mavis/test/pages/sessions/sessions_vaccination_wizard_page.py
+++ b/mavis/test/pages/sessions/sessions_vaccination_wizard_page.py
@@ -10,6 +10,7 @@ from mavis.test.pages.header_component import HeaderComponent
 from mavis.test.utils import (
     expect_alert_text,
     expect_details,
+    get_day_month_year_from_compact_date,
     reload_until_element_is_visible,
 )
 
@@ -31,6 +32,17 @@ class SessionsVaccinationWizardPage:
         self.select_batch_heading = self.page.get_by_role(
             "heading", name="Which batch did you use?"
         )
+        self.day_textbox = self.page.get_by_role("textbox", name="Day")
+        self.month_textbox = self.page.get_by_role("textbox", name="Month")
+        self.year_textbox = self.page.get_by_role("textbox", name="Year")
+        self.hour_textbox = self.page.get_by_role("textbox", name="Hour")
+        self.minute_textbox = self.page.get_by_role("textbox", name="Minute")
+        self.yes_radio = self.page.get_by_role("radio", name="Yes")
+        self.change_date_link = self.page.get_by_role("link", name="Change   date ")
+
+    @step("Click on Change date")
+    def click_change_date_link(self) -> None:
+        self.change_date_link.click()
 
     @step("Click on Confirm")
     def click_confirm_button(self) -> None:
@@ -56,10 +68,39 @@ class SessionsVaccinationWizardPage:
     def click_continue_button(self) -> None:
         self.continue_button.click()
 
+    @step("Fill date of vaccination with {1}")
+    def fill_date_of_vaccination(self, date: str) -> None:
+        day, month, year = get_day_month_year_from_compact_date(date)
+
+        self.day_textbox.fill(str(day))
+        self.month_textbox.fill(str(month))
+        self.year_textbox.fill(str(year))
+
+    @step("Confirm MMRV given")
+    def confirm_mmrv_given(self) -> None:
+        expect(
+            self.page.get_by_role("heading", name="vaccinated with the MMRV vaccine?")
+        ).to_be_visible()
+        self.click_yes()
+        self.click_continue_button()
+
+    @step("Click Yes")
+    def click_yes(self) -> None:
+        self.yes_radio.check()
+
+    @step("Fill time of vaccination with {1}:{2}")
+    def fill_time_of_vaccination(self, hour: str, minute: str) -> None:
+        self.hour_textbox.fill(str(hour))
+        self.minute_textbox.fill(str(minute))
+
     def expect_consent_refused_text(self, parent: Parent) -> None:
         expect(
             self.page.get_by_text(f"{parent.relationship} refused to give consent."),
         ).to_be_visible()
+
+    @step("Fill vaccination notes with {1}")
+    def fill_vaccination_notes(self, notes: str) -> None:
+        self.vaccination_notes.fill(notes)
 
     @step("Choose batch {1}")
     def choose_batch(self, batch_name: str) -> None:

--- a/mavis/test/pages/vaccination_record/vaccination_record_page.py
+++ b/mavis/test/pages/vaccination_record/vaccination_record_page.py
@@ -1,3 +1,5 @@
+import re
+
 from playwright.sync_api import Page, expect
 
 from mavis.test.annotations import step
@@ -21,8 +23,11 @@ class VaccinationRecordPage:
     def click_edit_vaccination_record(self) -> None:
         self.edit_vaccination_record_button.click()
 
+    @step("Expect vaccination details to contain {1} with value {2}")
     def expect_vaccination_details(self, key: str, value: str) -> None:
-        detail_key = self.page.locator(".nhsuk-summary-list__key", has_text=key)
+        detail_key = self.page.locator(
+            ".nhsuk-summary-list__key", has_text=re.compile(f"^{re.escape(key)}$")
+        )
         detail_value = detail_key.locator("xpath=following-sibling::*[1]")
 
         self.check_vaccination_details_heading_appears()

--- a/tests/test_already_given_vaccination.py
+++ b/tests/test_already_given_vaccination.py
@@ -1,0 +1,95 @@
+import pytest
+
+from mavis.test.constants import Programme
+from mavis.test.data import ClassFileMapping
+from mavis.test.pages import (
+    DashboardPage,
+    ImportRecordsWizardPage,
+    SchoolsChildrenPage,
+    SchoolsSearchPage,
+    SessionsChildrenPage,
+    SessionsOverviewPage,
+    SessionsPatientPage,
+    SessionsVaccinationWizardPage,
+)
+from mavis.test.pages.utils import (
+    schedule_school_session_if_needed,
+)
+from mavis.test.pages.vaccination_record.vaccination_record_page import (
+    VaccinationRecordPage,
+)
+from mavis.test.utils import (
+    get_formatted_date_for_session_dates,
+    get_offset_date,
+    get_offset_date_compact_format,
+)
+
+pytestmark = pytest.mark.sessions
+
+
+@pytest.fixture
+def setup_fixed_child_session(
+    log_in_as_nurse,
+    schools,
+    page,
+    point_of_care_file_generator,
+    year_groups,
+    request,
+):
+    programme = request.param
+    school = schools[programme.group][0]
+    year_group = year_groups[programme.group]
+
+    DashboardPage(page).click_schools()
+    SchoolsSearchPage(page).click_school(school)
+    SchoolsChildrenPage(page).click_import_class_lists()
+    ImportRecordsWizardPage(page, point_of_care_file_generator).import_class_list(
+        ClassFileMapping.FIXED_CHILD, year_group, programme.group
+    )
+    schedule_school_session_if_needed(
+        page, school, [programme], [year_group], date_offset=7
+    )
+    return programme
+
+
+@pytest.mark.parametrize(
+    "setup_fixed_child_session",
+    [Programme.FLU, Programme.HPV, Programme.MENACWY, Programme.TD_IPV],
+    indirect=True,
+)
+def test_one_dose_vaccinations_already_given(
+    setup_fixed_child_session,
+    children,
+    page,
+):
+    """
+    Test: Record a one-dose vaccination as already given and
+          verify the details are displayed correctly.
+    Steps:
+    1. Open a session with a fixed child for a
+       one-dose programme (FLU, HPV, MENACWY, or TD_IPV).
+    2. Record the child as already vaccinated.
+    3. Fill in vaccination details (date, time, and notes).
+    4. Confirm the vaccination record.
+    Verification:
+    - The vaccination record page displays the correct time, notes, and date.
+    """
+    programme = setup_fixed_child_session
+    child = children[programme.group][0]
+
+    SessionsOverviewPage(page).tabs.click_children_tab()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).record_as_already_vaccinated()
+    SessionsVaccinationWizardPage(page).fill_date_of_vaccination(
+        get_offset_date_compact_format(0)
+    )
+    SessionsVaccinationWizardPage(page).fill_time_of_vaccination("00", "01")
+    SessionsVaccinationWizardPage(page).click_continue_button()
+    SessionsVaccinationWizardPage(page).fill_vaccination_notes("Test notes")
+    SessionsVaccinationWizardPage(page).click_confirm_button()
+
+    VaccinationRecordPage(page).expect_vaccination_details("Time", "12:01am")
+    VaccinationRecordPage(page).expect_vaccination_details("Notes", "Test notes")
+    VaccinationRecordPage(page).expect_vaccination_details(
+        "Date", get_formatted_date_for_session_dates(get_offset_date(0))
+    )


### PR DESCRIPTION
Adds tests for the "already vaccinated" process for vaccinations that only require one dose. 

MMR tests to follow once some bugs are resolved