### PR TITLE
Rename draft-schoolsite to draft-school

### DIFF
--- a/mavis/test/pages/team/team_schools_page.py
+++ b/mavis/test/pages/team/team_schools_page.py
@@ -34,8 +34,7 @@ class TeamSchoolsPage:
         )
         self.continue_button = self.page.get_by_role("button", name="Continue")
         self.confirm_site_button = self.page.get_by_role("button", name="Add site")
-        self.name_error_summary = self.page.locator("#draft-school-site-name-error")
-        self.confirm_school_name = self.page.locator("#confirm-school-site-name")
+        self.name_error_summary = self.page.locator("#draft-school-name-error")
         self.change_parent_school_link = self.page.get_by_role(
             "link", name="Change parent school"
         )


### PR DESCRIPTION
This was refactored in Mavis to allow for more geenric wizard flow, hence the selectors need to be renamed too.

To be merged in when 7.1.0 is on `next`