### PR TITLE
Flaky test test_patient_details_load_with_missing_vaccine_info fix

### DIFF
--- a/mavis/test/utils.py
+++ b/mavis/test/utils.py
@@ -238,6 +238,7 @@ def click_secondary_navigation_item(link: Locator) -> None:
     if link.get_by_role("strong").is_visible():
         return
     link.click()
+    link.page.wait_for_load_state()  # Wait for page to stabilize before accessing DOM
     link.get_by_role("strong").wait_for()
 
 


### PR DESCRIPTION
The test test_patient_details_load_with_missing_vaccine_info failed every night only on Firefox with:
playwright._impl._errors.Error: NS_BINDING_ABORTED; maybe frame was detached?

The test passes when run individually.

This fix hopes to patch the issue.