### PR TITLE
Rename school search `type` to `gias_school`

### DIFF
--- a/mavis/test/data_models.py
+++ b/mavis/test/data_models.py
@@ -71,7 +71,7 @@ class School(Location):
         def _get_schools_with_year_group(year_group: int) -> list[School]:
             url = urllib.parse.urljoin(base_url, "api/testing/locations")
             params = {
-                "type": "school",
+                "type": "gias_school",
                 "status": "open",
                 "is_attached_to_team": "false",
                 "gias_year_groups[]": [str(year_group)],


### PR DESCRIPTION
Previously this location type was known as `school` but has been renamed to `gias_school` to make it clearer what this type represents.

https://github.com/NHSDigital/manage-vaccinations-in-schools/pull/6414

[Jira Issue - MAV-5556](https://nhsd-jira.digital.nhs.uk/browse/MAV-5556)