### PR TITLE
Refactor self-consent tests

### DIFF
--- a/mavis/test/pages/sessions/nurse_consent_wizard_page.py
+++ b/mavis/test/pages/sessions/nurse_consent_wizard_page.py
@@ -207,7 +207,7 @@ class NurseConsentWizardPage:
     def click_yes_for_injected_vaccine(self) -> None:
         self.online_flu_agree_injection_radio.check()
 
-    def record_parent_positive_consent(
+    def record_parent_given_consent(
         self,
         programme: Programme = Programme.HPV,
         consent_option: ConsentOption = ConsentOption.INJECTION,
@@ -235,7 +235,7 @@ class NurseConsentWizardPage:
         self.click_continue()
         self.click_confirm()
 
-    def record_child_positive_consent(
+    def record_child_given_consent(
         self,
         programme: Programme = Programme.HPV,
         consent_option: ConsentOption = ConsentOption.INJECTION,

--- a/mavis/test/pages/sessions/sessions_overview_page.py
+++ b/mavis/test/pages/sessions/sessions_overview_page.py
@@ -215,23 +215,29 @@ class SessionsOverviewPage:
         *,
         competent: bool,
     ) -> None:
-        _data_frame = self.get_offline_recording_dataframe()
-        competence_status = (
-            "Gillick competent" if competent else "Not Gillick competent"
-        )
-        row = _data_frame[
-            (_data_frame["PERSON_FORENAME"] == child.first_name)
-            & (_data_frame["PERSON_SURNAME"] == child.last_name)
-            & (_data_frame["GILLICK_STATUS"] == competence_status)
+        data_frame = self.get_offline_recording_dataframe()
+
+        child_rows = data_frame[
+            (data_frame["PERSON_FORENAME"] == child.first_name)
+            & (data_frame["PERSON_SURNAME"] == child.last_name)
         ]
-        if row.empty:
+
+        if child_rows.empty:
+            msg = f"No row found for child {child}."
+            raise ValueError(msg)
+
+        expected_status = "Gillick competent" if competent else "Not Gillick competent"
+        rows = child_rows[child_rows["GILLICK_STATUS"] == expected_status]
+
+        if rows.empty:
             msg = (
-                f"No corresponding Gillick competence found for {child!s} "
-                "in offline recording excel."
+                f"Child {child} found but Gillick competence status of "
+                f"'{expected_status}' was not. Current status: "
+                f"{child_rows.iloc[0]['GILLICK_STATUS']}"
             )
             raise ValueError(msg)
 
-        row = row.iloc[0]
+        row = rows.iloc[0]
 
         assert row["GILLICK_ASSESSMENT_DATE"].split(" ")[
             0

--- a/mavis/test/pages/sessions/sessions_search_page.py
+++ b/mavis/test/pages/sessions/sessions_search_page.py
@@ -21,25 +21,36 @@ class SessionsSearchPage:
     def click_add_a_new_session(self) -> None:
         self.add_a_new_session_link.click()
 
+    def _check_programmes(self, checked_programmes: list[Programme]) -> None:
+        for programme in Programme:
+            if programme in checked_programmes:
+                self.page.get_by_role("checkbox", name=str(programme)).check()
+            else:
+                self.page.get_by_role("checkbox", name=str(programme)).uncheck()
+
+    def _search_for_location(self, location: Location) -> None:
+        self.search.search_for(str(location))
+
+    def _click_location(self, location: Location) -> None:
+        self.page.get_by_role("link", name=str(location)).first.click()
+
     @step("Click on {2} session at {1}")
     def click_session_for_programme_group(
         self, location: Location, programme_group: str
     ) -> None:
         if programme_group != Programme.MMR_MMRV:
-            for programme in Programme:
-                if programme.group == programme_group:
-                    self.page.get_by_role("checkbox", name=str(programme)).check()
-                else:
-                    self.page.get_by_role("checkbox", name=str(programme)).uncheck()
+            programmes = [
+                programme
+                for programme in Programme
+                if programme.group == programme_group
+            ]
+            self._check_programmes(programmes)
 
-        self.search.search_for(str(location))
-
-        self.page.get_by_role("link", name=str(location)).first.click()
-
-        ten_seconds_ms = 10000
+        self._search_for_location(location)
+        self._click_location(location)
 
         expect(self.page.locator("h1", has_text=str(location))).to_be_visible(
-            timeout=ten_seconds_ms,
+            timeout=10_000,
         )
 
     @step("Check if session exists")

--- a/mavis/test/pages/sessions/sessions_search_page.py
+++ b/mavis/test/pages/sessions/sessions_search_page.py
@@ -35,6 +35,18 @@ class SessionsSearchPage:
         self.page.get_by_role("link", name=str(location)).first.click()
 
     @step("Click on {2} session at {1}")
+    def click_session_for_programmes(
+        self, location: Location, programmes: list[Programme]
+    ) -> None:
+        self._check_programmes(programmes)
+        self._search_for_location(location)
+        self._click_location(location)
+
+        expect(self.page.locator("h1", has_text=str(location))).to_be_visible(
+            timeout=10_000,
+        )
+
+    @step("Click on {2} session at {1}")
     def click_session_for_programme_group(
         self, location: Location, programme_group: str
     ) -> None:

--- a/mavis/test/pages/utils.py
+++ b/mavis/test/pages/utils.py
@@ -71,7 +71,7 @@ def record_nurse_consent_and_vaccination(
     if mmrv_eligibility:
         NurseConsentWizardPage(page).select_mmrv_eligibility_for_child()
 
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         programme=programme,
         consent_option=consent_option,
         mmrv_eligibility=mmrv_eligibility,

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -417,7 +417,7 @@ def test_withdraw_consent_link_on_summary_card(
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.PHONE)
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         yes_to_health_questions=False, programme=Programme.FLU
     )
 
@@ -572,7 +572,7 @@ def test_follow_up_link_on_summary_card(
     # Complete by clicking continue (notes are optional)
     NurseConsentWizardPage(page).select_parent_consent_refusal_stands_no()
     NurseConsentWizardPage(page).click_continue()
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         yes_to_health_questions=False, programme=Programme.FLU
     )
     expect_alert_text(page, "Consent recorded for")

--- a/tests/test_follow_up_requests.py
+++ b/tests/test_follow_up_requests.py
@@ -369,7 +369,7 @@ def test_follow_up_journey_decision_changed_record_consent(
     ConsentRefusalFollowUpPage(page).select_decision_stands(stands=False)
     ConsentRefusalFollowUpPage(page).click_continue()
 
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         programme=Programme.MMR_MMRV,
         consent_option=ConsentOption.MMR_EITHER,
         yes_to_health_questions=False,
@@ -443,7 +443,7 @@ def test_gillick_self_consent_overrides_follow_up_requested(
 
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_gillick_competent_child()
-    NurseConsentWizardPage(page).record_child_positive_consent(
+    NurseConsentWizardPage(page).record_child_given_consent(
         programme=Programme.MMR_MMRV,
         consent_option=ConsentOption.MMR_EITHER,
         yes_to_health_questions=False,

--- a/tests/test_parent_consent.py
+++ b/tests/test_parent_consent.py
@@ -136,7 +136,7 @@ def test_parent_provides_consent_twice(
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.PAPER)
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         yes_to_health_questions=True
     )
     SessionsChildrenPage(page).search.select_due_vaccination()

--- a/tests/test_parent_consent.py
+++ b/tests/test_parent_consent.py
@@ -1,8 +1,6 @@
 import pytest
 
-from mavis.test.annotations import issue
 from mavis.test.constants import (
-    MAVIS_NOTE_LENGTH_LIMIT,
     ConsentMethod,
     ConsentRefusalReason,
     DeliverySite,
@@ -13,7 +11,6 @@ from mavis.test.data import ClassFileMapping
 from mavis.test.helpers.accessibility_helper import AccessibilityHelper
 from mavis.test.pages import (
     DashboardPage,
-    GillickCompetencePage,
     ImportRecordsWizardPage,
     NurseConsentWizardPage,
     RecordVaccinationWizardPage,
@@ -28,11 +25,10 @@ from mavis.test.pages import (
     VaccinesPage,
 )
 from mavis.test.pages.utils import schedule_school_session_if_needed
-from mavis.test.utils import expect_alert_text
 
 
 @pytest.fixture
-def setup_session_with_file_upload(
+def set_up_session_with_file_upload(
     log_in_as_nurse,
     schools,
     page,
@@ -42,132 +38,34 @@ def setup_session_with_file_upload(
     school = schools[Programme.HPV][0]
     year_group = year_groups[Programme.HPV]
 
-    def _setup(class_list_file):
-        DashboardPage(page).click_schools()
-        SchoolsSearchPage(page).click_school(school)
-        SchoolChildrenPage(page).click_import_class_lists()
-        ImportRecordsWizardPage(page, point_of_care_file_generator).import_class_list(
-            class_list_file, year_group
-        )
-        schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
-        yield
-
-    return _setup
-
-
-@pytest.fixture
-def setup_fixed_child(setup_session_with_file_upload):
-    yield from setup_session_with_file_upload(ClassFileMapping.FIXED_CHILD)
-
-
-def test_gillick_competence(
-    setup_fixed_child,
-    page,
-    children,
-    schools,
-):
-    """
-    Test: Add and edit Gillick competence assessment for a child.
-    Steps:
-    1. Open the session for the school and programme.
-    2. Navigate to Gillick competence assessment for the child.
-    3. Add a Gillick competence assessment as competent.
-    4. Edit the assessment to mark as not competent.
-    Verification:
-    - Gillick competence status is updated and reflected for the child.
-    """
-    child = children[Programme.HPV][0]
-    school = schools[Programme.HPV][0]
-
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_assess_gillick_competence()
-
-    GillickCompetencePage(page).add_gillick_competence(is_competent=True)
-
-    SessionsChildrenPage(page).header.click_mavis()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
-    SessionsOverviewPage(page).verify_offline_sheet_gillick_competence(
-        child, competent=True
+    DashboardPage(page).click_schools()
+    SchoolsSearchPage(page).click_school(school)
+    SchoolChildrenPage(page).click_import_class_lists()
+    ImportRecordsWizardPage(page, point_of_care_file_generator).import_class_list(
+        ClassFileMapping.FIXED_CHILD, year_group
     )
-
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_edit_gillick_competence()
-    GillickCompetencePage(page).edit_gillick_competence(is_competent=False)
-
-    SessionsChildrenPage(page).header.click_mavis()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
-    SessionsOverviewPage(page).verify_offline_sheet_gillick_competence(
-        child, competent=False
-    )
-
-
-@issue("MAV-955")
-def test_gillick_competence_notes(
-    setup_fixed_child,
-    page,
-    children,
-):
-    """
-    Test: Validate Gillick competence assessment notes length and update.
-    Steps:
-    1. Open the session for the school and programme.
-    2. Navigate to Gillick competence assessment for the child.
-    3. Attempt to complete assessment with notes over 1000 characters (should error).
-    4. Complete assessment with valid notes.
-    5. Edit assessment and again try to update with notes over 1000
-       characters (should error).
-    Verification:
-    - Error is shown for notes over 1000 characters.
-    - Assessment can be completed and updated with valid notes.
-    """
-    child = children[Programme.HPV][0]
-
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_assess_gillick_competence()
-
-    GillickCompetencePage(page).answer_gillick_competence_questions(is_competent=True)
-    GillickCompetencePage(page).fill_assessment_notes_with_string_of_length(
-        MAVIS_NOTE_LENGTH_LIMIT + 1
-    )
-    GillickCompetencePage(page).click_complete_assessment()
-    GillickCompetencePage(page).check_notes_length_error_appears()
-
-    GillickCompetencePage(page).fill_assessment_notes("Gillick competent")
-    GillickCompetencePage(page).click_complete_assessment()
-
-    SessionsPatientPage(page).click_edit_gillick_competence()
-    GillickCompetencePage(page).answer_gillick_competence_questions(is_competent=True)
-    GillickCompetencePage(page).fill_assessment_notes_with_string_of_length(
-        MAVIS_NOTE_LENGTH_LIMIT + 1
-    )
-    GillickCompetencePage(page).click_update_assessment()
-    GillickCompetencePage(page).check_notes_length_error_appears()
+    schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
 
 
 def test_invalid_consent(
-    setup_fixed_child,
+    set_up_session_with_file_upload,
     page,
     children,
 ):
     """
     Test: Record invalid and refused consents and verify activity log entries.
+
     Steps:
     1. Open the session and consent tab for the child.
     2. Record a 'no response' verbal consent for parent 1.
     3. Record a refusal verbal consent for parent 2.
     4. Invalidate the refusal from parent 2.
     5. Check the session activity log for correct entries.
-    Verification:
+
+    Expectations:
     - Activity log contains entries for invalidated consent, refusal, and no response.
     """
+
     child = children[Programme.HPV][0]
 
     SessionsOverviewPage(page).tabs.click_children_tab()
@@ -208,23 +106,26 @@ def test_invalid_consent(
 
 
 def test_parent_provides_consent_twice(
-    setup_fixed_child,
+    set_up_session_with_file_upload,
     page,
     children,
 ):
     """
-    Test: Record two consents from the same parent (positive then refusal)
-       and verify activity log.
+    Test: Record two consents from the same parent (positive then refusal) and verify
+      activity log.
+
     Steps:
     1. Open the session and consent tab for the child.
     2. Record a written positive consent for parent 1.
     3. Record a triage outcome as safe to vaccinate.
     4. Record a verbal refusal for the same parent.
     5. Check the consent refused text and session activity log.
-    Verification:
+
+    Expectations:
     - Consent refused text is shown for the parent.
     - Activity log contains entries for refusal, triage, and initial consent.
     """
+
     child = children[Programme.HPV][0]
 
     SessionsOverviewPage(page).tabs.click_children_tab()
@@ -265,77 +166,8 @@ def test_parent_provides_consent_twice(
     )
 
 
-def test_conflicting_consent_with_gillick_consent(
-    setup_fixed_child,
-    page,
-    children,
-):
-    """
-    Test: Record conflicting consents from parents, resolve with Gillick competence,
-       and verify status.
-    Steps:
-    1. Open the session and consent tab for the child.
-    2. Record a verbal positive consent for parent 1.
-    3. Record a verbal refusal for parent 2, resulting in conflicting consent.
-    4. Assess Gillick competence as competent.
-    5. Record child verbal consent.
-    6. Verify consent status and activity log.
-    Verification:
-    - Consent status updates to 'Conflicting consent', then 'Safe to vaccinate',
-      then 'Consent given'.
-    - Activity log contains entry for Gillick competent child consent.
-    """
-    child = children[Programme.HPV][0]
-
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.select_needs_consent()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_record_a_new_consent_response()
-
-    NurseConsentWizardPage(page).select_parent(child.parents[0])
-    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_positive_consent()
-
-    SessionsChildrenPage(page).search.select_due_vaccination()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_record_a_new_consent_response()
-
-    NurseConsentWizardPage(page).select_parent(child.parents[1])
-    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_refuse_consent()
-
-    SessionsChildrenPage(page).search.select_has_a_refusal()
-    SessionsChildrenPage(page).search.select_consent_refused()
-    SessionsChildrenPage(page).search.select_conflicting_consent()
-
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.HPV, "Conflicting consent"
-    )
-    SessionsPatientPage(page).expect_conflicting_consent_text()
-    SessionsPatientPage(page).click_assess_gillick_competence()
-    GillickCompetencePage(page).add_gillick_competence(is_competent=True)
-    SessionsPatientPage(page).click_record_a_new_consent_response()
-
-    NurseConsentWizardPage(page).select_gillick_competent_child()
-    NurseConsentWizardPage(page).record_child_positive_consent()
-    expect_alert_text(page, f"Consent recorded for {child!s}")
-
-    SessionsChildrenPage(page).search.select_due_vaccination()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent given")
-    SessionsPatientPage(page).click_session_activity_and_notes()
-    SessionsPatientSessionActivityPage(page).check_session_activity_entry(
-        f"Consent given by {child!s} (Child (Gillick competent))",
-    )
-
-
 def test_consent_refusal_do_not_want_vaccination_at_school(
-    setup_fixed_child,
+    set_up_session_with_file_upload,
     page,
     children,
 ):
@@ -376,7 +208,7 @@ def test_consent_refusal_do_not_want_vaccination_at_school(
 
 @pytest.mark.accessibility
 def test_accessibility(
-    setup_fixed_child,
+    set_up_session_with_file_upload,
     add_vaccine_batch,
     page,
     schools,

--- a/tests/test_psd.py
+++ b/tests/test_psd.py
@@ -125,7 +125,7 @@ def test_delivering_vaccination_after_psd(
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         programme=Programme.FLU,
         consent_option=ConsentOption.NASAL_SPRAY_OR_INJECTION,
         psd_option=True,

--- a/tests/test_self_consent.py
+++ b/tests/test_self_consent.py
@@ -1,0 +1,210 @@
+import pytest
+
+from mavis.test.annotations import issue
+from mavis.test.constants import MAVIS_NOTE_LENGTH_LIMIT, ConsentMethod, Programme
+from mavis.test.data import ClassFileMapping
+from mavis.test.pages import (
+    DashboardPage,
+    GillickCompetencePage,
+    ImportRecordsWizardPage,
+    NurseConsentWizardPage,
+    SchoolChildrenPage,
+    SchoolsSearchPage,
+    SessionsChildrenPage,
+    SessionsOverviewPage,
+    SessionsPatientPage,
+    SessionsPatientSessionActivityPage,
+    SessionsSearchPage,
+)
+from mavis.test.pages.utils import schedule_school_session_if_needed
+from mavis.test.utils import expect_alert_text
+
+
+@pytest.fixture
+def set_up_session_with_file_upload(
+    log_in_as_nurse,
+    schools,
+    page,
+    point_of_care_file_generator,
+    year_groups,
+):
+    school = schools[Programme.HPV][0]
+    year_group = year_groups[Programme.HPV]
+
+    DashboardPage(page).click_schools()
+    SchoolsSearchPage(page).click_school(school)
+    SchoolChildrenPage(page).click_import_class_lists()
+    ImportRecordsWizardPage(page, point_of_care_file_generator).import_class_list(
+        ClassFileMapping.FIXED_CHILD, year_group
+    )
+    schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
+
+
+def test_gillick_competence(
+    set_up_session_with_file_upload,
+    page,
+    children,
+    schools,
+):
+    """
+    Test: Add and edit Gillick competence assessment for a child.
+
+    Steps:
+    1. Open the session for the school and programme.
+    2. Navigate to Gillick competence assessment for the child.
+    3. Add a Gillick competence assessment as competent.
+    4. Edit the assessment to mark as not competent.
+
+    Expectations:
+    - Gillick competence status is updated and reflected for the child.
+    """
+
+    child = children[Programme.HPV][0]
+    school = schools[Programme.HPV][0]
+
+    SessionsOverviewPage(page).tabs.click_children_tab()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).click_assess_gillick_competence()
+
+    GillickCompetencePage(page).add_gillick_competence(is_competent=True)
+
+    SessionsChildrenPage(page).header.click_mavis()
+    DashboardPage(page).click_sessions()
+    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
+    SessionsOverviewPage(page).verify_offline_sheet_gillick_competence(
+        child, competent=True
+    )
+
+    SessionsOverviewPage(page).tabs.click_children_tab()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).click_edit_gillick_competence()
+    GillickCompetencePage(page).edit_gillick_competence(is_competent=False)
+
+    SessionsChildrenPage(page).header.click_mavis()
+    DashboardPage(page).click_sessions()
+    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
+    SessionsOverviewPage(page).verify_offline_sheet_gillick_competence(
+        child, competent=False
+    )
+
+
+@issue("MAV-955")
+def test_gillick_competence_notes(
+    set_up_session_with_file_upload,
+    page,
+    children,
+):
+    """
+    Test: Validate Gillick competence assessment notes length and update.
+
+    Steps:
+    1. Open the session for the school and programme.
+    2. Navigate to Gillick competence assessment for the child.
+    3. Attempt to complete assessment with notes over 1000 characters (should error).
+    4. Complete assessment with valid notes.
+    5. Edit assessment and again try to update with notes over 1000 characters (should
+       error).
+
+    Expectations:
+    - Error is shown for notes over 1000 characters.
+    - Assessment can be completed and updated with valid notes.
+    """
+
+    child = children[Programme.HPV][0]
+
+    SessionsOverviewPage(page).tabs.click_children_tab()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).click_assess_gillick_competence()
+
+    GillickCompetencePage(page).answer_gillick_competence_questions(is_competent=True)
+    GillickCompetencePage(page).fill_assessment_notes_with_string_of_length(
+        MAVIS_NOTE_LENGTH_LIMIT + 1
+    )
+    GillickCompetencePage(page).click_complete_assessment()
+    GillickCompetencePage(page).check_notes_length_error_appears()
+
+    GillickCompetencePage(page).fill_assessment_notes("Gillick competent")
+    GillickCompetencePage(page).click_complete_assessment()
+
+    SessionsPatientPage(page).click_edit_gillick_competence()
+    GillickCompetencePage(page).answer_gillick_competence_questions(is_competent=True)
+    GillickCompetencePage(page).fill_assessment_notes_with_string_of_length(
+        MAVIS_NOTE_LENGTH_LIMIT + 1
+    )
+    GillickCompetencePage(page).click_update_assessment()
+    GillickCompetencePage(page).check_notes_length_error_appears()
+
+
+def test_conflicting_consent_with_gillick_consent(
+    set_up_session_with_file_upload,
+    page,
+    children,
+):
+    """
+    Test: Record conflicting consents from parents, resolve with Gillick competence,
+       and verify status.
+
+    Steps:
+    1. Open the session and consent tab for the child.
+    2. Record a verbal positive consent for parent 1.
+    3. Record a verbal refusal for parent 2, resulting in conflicting consent.
+    4. Assess Gillick competence as competent.
+    5. Record child verbal consent.
+    6. Verify consent status and activity log.
+
+    Expectations:
+    - Consent status updates to 'Conflicting consent', then 'Safe to vaccinate',
+      then 'Consent given'.
+    - Activity log contains entry for Gillick competent child consent.
+    """
+
+    child = children[Programme.HPV][0]
+
+    SessionsOverviewPage(page).tabs.click_children_tab()
+    SessionsChildrenPage(page).search.select_needs_consent()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).click_record_a_new_consent_response()
+
+    NurseConsentWizardPage(page).select_parent(child.parents[0])
+    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
+    NurseConsentWizardPage(page).record_parent_positive_consent()
+
+    SessionsChildrenPage(page).search.select_due_vaccination()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).click_record_a_new_consent_response()
+
+    NurseConsentWizardPage(page).select_parent(child.parents[1])
+    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
+    NurseConsentWizardPage(page).record_parent_refuse_consent()
+
+    SessionsChildrenPage(page).search.select_has_a_refusal()
+    SessionsChildrenPage(page).search.select_consent_refused()
+    SessionsChildrenPage(page).search.select_conflicting_consent()
+
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).expect_consent_status(
+        Programme.HPV, "Conflicting consent"
+    )
+    SessionsPatientPage(page).expect_conflicting_consent_text()
+    SessionsPatientPage(page).click_assess_gillick_competence()
+    GillickCompetencePage(page).add_gillick_competence(is_competent=True)
+    SessionsPatientPage(page).click_record_a_new_consent_response()
+
+    NurseConsentWizardPage(page).select_gillick_competent_child()
+    NurseConsentWizardPage(page).record_child_positive_consent()
+    expect_alert_text(page, f"Consent recorded for {child!s}")
+
+    SessionsChildrenPage(page).search.select_due_vaccination()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent given")
+    SessionsPatientPage(page).click_session_activity_and_notes()
+    SessionsPatientSessionActivityPage(page).check_session_activity_entry(
+        f"Consent given by {child!s} (Child (Gillick competent))",
+    )

--- a/tests/test_self_consent.py
+++ b/tests/test_self_consent.py
@@ -171,7 +171,7 @@ def test_conflicting_consent_with_gillick_consent(
 
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_positive_consent()
+    NurseConsentWizardPage(page).record_parent_given_consent()
 
     SessionsChildrenPage(page).search.select_due_vaccination()
     SessionsChildrenPage(page).search.search_and_click_child(child)
@@ -197,7 +197,7 @@ def test_conflicting_consent_with_gillick_consent(
     SessionsPatientPage(page).click_record_a_new_consent_response()
 
     NurseConsentWizardPage(page).select_gillick_competent_child()
-    NurseConsentWizardPage(page).record_child_positive_consent()
+    NurseConsentWizardPage(page).record_child_given_consent()
     expect_alert_text(page, f"Consent recorded for {child!s}")
 
     SessionsChildrenPage(page).search.select_due_vaccination()

--- a/tests/test_self_consent.py
+++ b/tests/test_self_consent.py
@@ -1,7 +1,12 @@
 import pytest
 
 from mavis.test.annotations import issue
-from mavis.test.constants import MAVIS_NOTE_LENGTH_LIMIT, ConsentMethod, Programme
+from mavis.test.constants import (
+    MAVIS_NOTE_LENGTH_LIMIT,
+    ConsentMethod,
+    ConsentOption,
+    Programme,
+)
 from mavis.test.data import ClassFileMapping
 from mavis.test.pages import (
     DashboardPage,
@@ -21,12 +26,12 @@ from mavis.test.utils import expect_alert_text
 
 
 @pytest.fixture
-def set_up_session_with_file_upload(
-    log_in_as_nurse,
+def session_with_child_for_programme(
     schools,
-    page,
-    point_of_care_file_generator,
     year_groups,
+    point_of_care_file_generator,
+    page,
+    log_in_as_nurse,
 ):
     school = schools[Programme.HPV][0]
     year_group = year_groups[Programme.HPV]
@@ -39,13 +44,10 @@ def set_up_session_with_file_upload(
     )
     schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
 
+    return Programme.HPV, ConsentOption.INJECTION
 
-def test_gillick_competence(
-    set_up_session_with_file_upload,
-    page,
-    children,
-    schools,
-):
+
+def test_gillick(session_with_child_for_programme, children, schools, page):
     """
     Test: Add and edit Gillick competence assessment for a child.
 
@@ -59,43 +61,47 @@ def test_gillick_competence(
     - Gillick competence status is updated and reflected for the child.
     """
 
-    child = children[Programme.HPV][0]
-    school = schools[Programme.HPV][0]
+    programme, _ = session_with_child_for_programme
+    child = children[programme.group][0]
+    school = schools[programme.group][0]
 
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_assess_gillick_competence()
+    dashboard_page = DashboardPage(page)
+    gillick_competence_page = GillickCompetencePage(page)
+    sessions_children_page = SessionsChildrenPage(page)
+    sessions_overview_page = SessionsOverviewPage(page)
+    sessions_patient_page = SessionsPatientPage(page)
+    sessions_search_page = SessionsSearchPage(page)
 
-    GillickCompetencePage(page).add_gillick_competence(is_competent=True)
+    sessions_overview_page.tabs.click_children_tab()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.click_assess_gillick_competence()
 
-    SessionsChildrenPage(page).header.click_mavis()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
-    SessionsOverviewPage(page).verify_offline_sheet_gillick_competence(
+    gillick_competence_page.add_gillick_competence(is_competent=True)
+
+    sessions_children_page.header.click_mavis()
+    dashboard_page.click_sessions()
+    sessions_search_page.click_session_for_programme_group(school, programme)
+    sessions_overview_page.verify_offline_sheet_gillick_competence(
         child, competent=True
     )
 
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_edit_gillick_competence()
-    GillickCompetencePage(page).edit_gillick_competence(is_competent=False)
+    sessions_overview_page.tabs.click_children_tab()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.click_edit_gillick_competence()
+    gillick_competence_page.edit_gillick_competence(is_competent=False)
 
-    SessionsChildrenPage(page).header.click_mavis()
-    DashboardPage(page).click_sessions()
-    SessionsSearchPage(page).click_session_for_programme_group(school, Programme.HPV)
-    SessionsOverviewPage(page).verify_offline_sheet_gillick_competence(
+    sessions_children_page.header.click_mavis()
+    dashboard_page.click_sessions()
+    sessions_search_page.click_session_for_programme_group(school, programme)
+    sessions_overview_page.verify_offline_sheet_gillick_competence(
         child, competent=False
     )
 
 
 @issue("MAV-955")
-def test_gillick_competence_notes(
-    set_up_session_with_file_upload,
-    page,
-    children,
-):
+def test_gillick_with_notes(session_with_child_for_programme, children, page):
     """
     Test: Validate Gillick competence assessment notes length and update.
 
@@ -112,36 +118,40 @@ def test_gillick_competence_notes(
     - Assessment can be completed and updated with valid notes.
     """
 
-    child = children[Programme.HPV][0]
+    programme, _ = session_with_child_for_programme
+    child = children[programme.group][0]
 
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_assess_gillick_competence()
+    gillick_competence_page = GillickCompetencePage(page)
+    sessions_children_page = SessionsChildrenPage(page)
+    sessions_overview_page = SessionsOverviewPage(page)
+    sessions_patient_page = SessionsPatientPage(page)
 
-    GillickCompetencePage(page).answer_gillick_competence_questions(is_competent=True)
-    GillickCompetencePage(page).fill_assessment_notes_with_string_of_length(
+    sessions_overview_page.tabs.click_children_tab()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.click_assess_gillick_competence()
+
+    gillick_competence_page.answer_gillick_competence_questions(is_competent=True)
+    gillick_competence_page.fill_assessment_notes_with_string_of_length(
         MAVIS_NOTE_LENGTH_LIMIT + 1
     )
-    GillickCompetencePage(page).click_complete_assessment()
-    GillickCompetencePage(page).check_notes_length_error_appears()
+    gillick_competence_page.click_complete_assessment()
+    gillick_competence_page.check_notes_length_error_appears()
 
-    GillickCompetencePage(page).fill_assessment_notes("Gillick competent")
-    GillickCompetencePage(page).click_complete_assessment()
+    gillick_competence_page.fill_assessment_notes("Gillick competent")
+    gillick_competence_page.click_complete_assessment()
 
-    SessionsPatientPage(page).click_edit_gillick_competence()
-    GillickCompetencePage(page).answer_gillick_competence_questions(is_competent=True)
-    GillickCompetencePage(page).fill_assessment_notes_with_string_of_length(
+    sessions_patient_page.click_edit_gillick_competence()
+    gillick_competence_page.answer_gillick_competence_questions(is_competent=True)
+    gillick_competence_page.fill_assessment_notes_with_string_of_length(
         MAVIS_NOTE_LENGTH_LIMIT + 1
     )
-    GillickCompetencePage(page).click_update_assessment()
-    GillickCompetencePage(page).check_notes_length_error_appears()
+    gillick_competence_page.click_update_assessment()
+    gillick_competence_page.check_notes_length_error_appears()
 
 
-def test_conflicting_consent_with_gillick_consent(
-    set_up_session_with_file_upload,
-    page,
-    children,
+def test_gillick_override_conflicting_from_parent(
+    session_with_child_for_programme, children, page
 ):
     """
     Test: Record conflicting consents from parents, resolve with Gillick competence,
@@ -161,50 +171,56 @@ def test_conflicting_consent_with_gillick_consent(
     - Activity log contains entry for Gillick competent child consent.
     """
 
-    child = children[Programme.HPV][0]
+    programme, consent_option = session_with_child_for_programme
+    child = children[programme.group][0]
 
-    SessionsOverviewPage(page).tabs.click_children_tab()
-    SessionsChildrenPage(page).search.select_needs_consent()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_record_a_new_consent_response()
+    gillick_competence_page = GillickCompetencePage(page)
+    nurse_consent_wizard_page = NurseConsentWizardPage(page)
+    sessions_children_page = SessionsChildrenPage(page)
+    sessions_overview_page = SessionsOverviewPage(page)
+    sessions_patient_page = SessionsPatientPage(page)
+    sessions_patient_session_activity_page = SessionsPatientSessionActivityPage(page)
 
-    NurseConsentWizardPage(page).select_parent(child.parents[0])
-    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_given_consent()
+    sessions_overview_page.tabs.click_children_tab()
+    sessions_children_page.search.select_needs_consent()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.click_record_a_new_consent_response()
 
-    SessionsChildrenPage(page).search.select_due_vaccination()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).click_record_a_new_consent_response()
+    nurse_consent_wizard_page.select_parent(child.parents[0])
+    nurse_consent_wizard_page.select_consent_method(ConsentMethod.IN_PERSON)
+    nurse_consent_wizard_page.record_parent_given_consent(programme, consent_option)
 
-    NurseConsentWizardPage(page).select_parent(child.parents[1])
-    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_refuse_consent()
+    sessions_children_page.search.select_due_vaccination()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.click_record_a_new_consent_response()
 
-    SessionsChildrenPage(page).search.select_has_a_refusal()
-    SessionsChildrenPage(page).search.select_consent_refused()
-    SessionsChildrenPage(page).search.select_conflicting_consent()
+    nurse_consent_wizard_page.select_parent(child.parents[1])
+    nurse_consent_wizard_page.select_consent_method(ConsentMethod.IN_PERSON)
+    nurse_consent_wizard_page.record_parent_refuse_consent()
 
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.HPV, "Conflicting consent"
-    )
-    SessionsPatientPage(page).expect_conflicting_consent_text()
-    SessionsPatientPage(page).click_assess_gillick_competence()
-    GillickCompetencePage(page).add_gillick_competence(is_competent=True)
-    SessionsPatientPage(page).click_record_a_new_consent_response()
+    sessions_children_page.search.select_has_a_refusal()
+    sessions_children_page.search.select_consent_refused()
+    sessions_children_page.search.select_conflicting_consent()
 
-    NurseConsentWizardPage(page).select_gillick_competent_child()
-    NurseConsentWizardPage(page).record_child_given_consent()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.expect_consent_status(programme, "Conflicting consent")
+    sessions_patient_page.expect_conflicting_consent_text()
+    sessions_patient_page.click_assess_gillick_competence()
+    gillick_competence_page.add_gillick_competence(is_competent=True)
+    sessions_patient_page.click_record_a_new_consent_response()
+
+    nurse_consent_wizard_page.select_gillick_competent_child()
+    nurse_consent_wizard_page.record_child_given_consent(programme, consent_option)
     expect_alert_text(page, f"Consent recorded for {child!s}")
 
-    SessionsChildrenPage(page).search.select_due_vaccination()
-    SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent given")
-    SessionsPatientPage(page).click_session_activity_and_notes()
-    SessionsPatientSessionActivityPage(page).check_session_activity_entry(
+    sessions_children_page.search.select_due_vaccination()
+    sessions_children_page.search.search_and_click_child(child)
+    sessions_patient_page.click_programme_tab(programme)
+    sessions_patient_page.expect_consent_status(programme, "Consent given")
+    sessions_patient_page.click_session_activity_and_notes()
+    sessions_patient_session_activity_page.check_session_activity_entry(
         f"Consent given by {child!s} (Child (Gillick competent))",
     )

--- a/tests/test_self_consent.py
+++ b/tests/test_self_consent.py
@@ -27,26 +27,48 @@ from mavis.test.utils import expect_alert_text
 
 @pytest.fixture
 def session_with_child_for_programme(
+    request,
     schools,
     year_groups,
     point_of_care_file_generator,
     page,
     log_in_as_nurse,
 ):
-    school = schools[Programme.HPV][0]
-    year_group = year_groups[Programme.HPV]
+    programme, consent_option = request.param
+    school = schools[programme.group][0]
+    year_group = year_groups[programme.group]
 
     DashboardPage(page).click_schools()
     SchoolsSearchPage(page).click_school(school)
     SchoolChildrenPage(page).click_import_class_lists()
     ImportRecordsWizardPage(page, point_of_care_file_generator).import_class_list(
-        ClassFileMapping.FIXED_CHILD, year_group
+        ClassFileMapping.FIXED_CHILD, year_group, programme.group
     )
-    schedule_school_session_if_needed(page, school, [Programme.HPV], [year_group])
+    schedule_school_session_if_needed(page, school, [programme], [year_group])
 
-    return Programme.HPV, ConsentOption.INJECTION
+    return programme, consent_option
 
 
+programmes_and_consent_options = [
+    (Programme.FLU, ConsentOption.INJECTION),
+    (Programme.FLU, ConsentOption.NASAL_SPRAY_OR_INJECTION),
+    (Programme.HPV, ConsentOption.INJECTION),
+    (Programme.MENACWY, ConsentOption.INJECTION),
+    # TODO: Enable these once we have a way of working with children that are either
+    #  MMR or MMRV, and `expect_programme_status` is able to accept the MMR or MMRV
+    #  variant.
+    # (Programme.MMR, ConsentOption.MMR_EITHER), # noqa: ERA001
+    # (Programme.MMR, ConsentOption.MMR_WITHOUT_GELATINE), # noqa: ERA001
+    (Programme.TD_IPV, ConsentOption.INJECTION),
+]
+
+
+@pytest.mark.parametrize(
+    "session_with_child_for_programme",
+    programmes_and_consent_options,
+    indirect=True,
+    ids=lambda v: f"{v[0]}-{v[1]}",
+)
 def test_gillick(session_with_child_for_programme, children, schools, page):
     """
     Test: Add and edit Gillick competence assessment for a child.
@@ -76,12 +98,11 @@ def test_gillick(session_with_child_for_programme, children, schools, page):
     sessions_children_page.search.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(programme)
     sessions_patient_page.click_assess_gillick_competence()
-
     gillick_competence_page.add_gillick_competence(is_competent=True)
 
     sessions_children_page.header.click_mavis()
     dashboard_page.click_sessions()
-    sessions_search_page.click_session_for_programme_group(school, programme)
+    sessions_search_page.click_session_for_programmes(school, [programme])
     sessions_overview_page.verify_offline_sheet_gillick_competence(
         child, competent=True
     )
@@ -94,13 +115,19 @@ def test_gillick(session_with_child_for_programme, children, schools, page):
 
     sessions_children_page.header.click_mavis()
     dashboard_page.click_sessions()
-    sessions_search_page.click_session_for_programme_group(school, programme)
+    sessions_search_page.click_session_for_programmes(school, [programme])
     sessions_overview_page.verify_offline_sheet_gillick_competence(
         child, competent=False
     )
 
 
 @issue("MAV-955")
+@pytest.mark.parametrize(
+    "session_with_child_for_programme",
+    programmes_and_consent_options,
+    indirect=True,
+    ids=lambda v: f"{v[0]}-{v[1]}",
+)
 def test_gillick_with_notes(session_with_child_for_programme, children, page):
     """
     Test: Validate Gillick competence assessment notes length and update.
@@ -150,6 +177,12 @@ def test_gillick_with_notes(session_with_child_for_programme, children, page):
     gillick_competence_page.check_notes_length_error_appears()
 
 
+@pytest.mark.parametrize(
+    "session_with_child_for_programme",
+    programmes_and_consent_options,
+    indirect=True,
+    ids=lambda v: f"{v[0]}-{v[1]}",
+)
 def test_gillick_override_conflicting_from_parent(
     session_with_child_for_programme, children, page
 ):
@@ -219,7 +252,15 @@ def test_gillick_override_conflicting_from_parent(
     sessions_children_page.search.select_due_vaccination()
     sessions_children_page.search.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(programme)
-    sessions_patient_page.expect_consent_status(programme, "Consent given")
+
+    if consent_option == ConsentOption.NASAL_SPRAY_OR_INJECTION:
+        consent_status = "Consent given for nasal spray"
+    elif consent_option == ConsentOption.MMR_WITHOUT_GELATINE:
+        consent_status = "Consent given for gelatine-free injection"
+    else:
+        consent_status = "Consent given"
+    sessions_patient_page.expect_consent_status(programme, consent_status)
+
     sessions_patient_page.click_session_activity_and_notes()
     sessions_patient_session_activity_page.check_session_activity_entry(
         f"Consent given by {child!s} (Child (Gillick competent))",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -289,7 +289,7 @@ def test_triage_consent_given_and_triage_outcome(
 
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.PHONE)
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         yes_to_health_questions=True
     )
 
@@ -383,7 +383,7 @@ def test_add_child_to_community_clinic_session(
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
-    NurseConsentWizardPage(page).record_parent_positive_consent()
+    NurseConsentWizardPage(page).record_parent_given_consent()
     SessionsChildrenPage(page).tabs.click_record_vaccinations_tab()
     SessionsRecordVaccinationsPage(page).search.search_and_click_child(child)
     vaccination_record = VaccinationRecord(child, Programme.HPV, batch_name)

--- a/tests/test_tallying.py
+++ b/tests/test_tallying.py
@@ -92,7 +92,7 @@ def test_tallying(  # noqa: PLR0915
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[0])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.PHONE)
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         yes_to_health_questions=False, programme=Programme.FLU
     )
 
@@ -131,7 +131,7 @@ def test_tallying(  # noqa: PLR0915
     SessionsPatientPage(page).click_record_a_new_consent_response()
     NurseConsentWizardPage(page).select_parent(child.parents[1])
     NurseConsentWizardPage(page).select_consent_method(ConsentMethod.PHONE)
-    NurseConsentWizardPage(page).record_parent_positive_consent(
+    NurseConsentWizardPage(page).record_parent_given_consent(
         yes_to_health_questions=False,
         programme=Programme.FLU,
         consent_option=ConsentOption.NASAL_SPRAY,


### PR DESCRIPTION
This refactors the tests related to self-consent to make them easier to add to in the future and also to improve coverage.

[Jira Issue - MAV-5891](https://nhsd-jira.digital.nhs.uk/browse/MAV-5891)