### PR TITLE
Rename `Programme.MMR` to `Programme.MMR_MMRV`

### DIFF
--- a/.github/actions/run-end-to-end-tests/action.yml
+++ b/.github/actions/run-end-to-end-tests/action.yml
@@ -19,7 +19,7 @@ inputs:
   base_url:
     required: true
   programmes_enabled:
-    default: 'FLU,HPV,MENACWY,MMR,TD_IPV'
+    default: FLU,HPV,MENACWY,MMR,TD_IPV
   screenshot_all_steps:
     required: true
   enable_reruns:

--- a/mavis/test/constants.py
+++ b/mavis/test/constants.py
@@ -152,7 +152,7 @@ class Programme(StrEnum):
     FLU = "flu"
     HPV = "HPV"
     MENACWY = "MenACWY"
-    MMR = "MMR(V)"
+    MMR_MMRV = "MMR(V)"
     TD_IPV = "Td/IPV"
 
     @property
@@ -235,7 +235,7 @@ class Programme(StrEnum):
                 HealthQuestion.EXTRA_SUPPORT,
             ],
             Programme.FLU: flu_questions,
-            Programme.MMR: mmr_questions,
+            Programme.MMR_MMRV: mmr_questions,
         }
         return programme_specific_questions[self]
 
@@ -265,8 +265,8 @@ class Programme(StrEnum):
         year_group_map = {
             self.FLU: list(range(12)),
             self.HPV: list(range(8, 12)),
-            self.MMR: list(range(12)),
             self.MENACWY: list(range(9, 12)),
+            self.MMR_MMRV: list(range(12)),
             self.TD_IPV: list(range(9, 12)),
         }
         return year_group_map[self]
@@ -290,12 +290,14 @@ class Programme(StrEnum):
 
     @property
     def offline_sheet_name(self) -> str:
+        # TODO: Some programmes have multiple supported named (e.g. 3-in-1 and Td/IPV),
+        #  we should add test coverage for this.
         offline_name_map = {
-            self.MENACWY: "ACWYX4",
-            self.TD_IPV: "3-in-1",
             self.FLU: "Flu",
             self.HPV: self.HPV,
-            self.MMR: self.MMR,
+            self.MENACWY: "ACWYX4",
+            self.MMR_MMRV: self.MMR_MMRV,
+            self.TD_IPV: "3-in-1",
         }
         return offline_name_map[self]
 
@@ -343,10 +345,10 @@ class Vaccine(StrEnum):
             Vaccine.MENVEO: Programme.MENACWY,
             Vaccine.NIMENRIX: Programme.MENACWY,
             Vaccine.REVAXIS: Programme.TD_IPV,
-            Vaccine.MMR_VAXPRO: Programme.MMR,
-            Vaccine.PRIORIX: Programme.MMR,
-            Vaccine.PROQUAD: Programme.MMR,
-            Vaccine.PRIORIX_TETRA: Programme.MMR,
+            Vaccine.MMR_VAXPRO: Programme.MMR_MMRV,
+            Vaccine.PRIORIX: Programme.MMR_MMRV,
+            Vaccine.PROQUAD: Programme.MMR_MMRV,
+            Vaccine.PRIORIX_TETRA: Programme.MMR_MMRV,
         }
         return programme_mapping[self]
 

--- a/mavis/test/fixtures/helpers.py
+++ b/mavis/test/fixtures/helpers.py
@@ -174,7 +174,7 @@ def upload_offline_vaccination(
                 else VaccsFileMapping.FLU_NASAL
             )
             vaccs_date = get_current_datetime()
-        elif programme is Programme.MMR:
+        elif programme is Programme.MMR_MMRV:
             vaccs_file = VaccsFileMapping.MMR_DOSE_ONE
             vaccs_date = get_current_datetime().replace(
                 year=get_current_datetime().year - 2

--- a/mavis/test/pages/add_session_wizard_page.py
+++ b/mavis/test/pages/add_session_wizard_page.py
@@ -152,7 +152,7 @@ class AddSessionWizardPage:
         # TODO: Add programmes, it's a bit trickier because it's a list
         # TODO: Add year_groups
         # TODO: Add date_offset, dates are just annoying
-        if Programme.MMR in programmes:
+        if Programme.MMR_MMRV in programmes:
             expect_details(
                 self.page,
                 "Type of MMR\\(V\\) consent request",
@@ -177,7 +177,7 @@ class AddSessionWizardPage:
     def select_consent_style_if_necessary(
         self, programmes: list[Programme], consent_style: str
     ) -> None:
-        if Programme.MMR in programmes:
+        if Programme.MMR_MMRV in programmes:
             self.page.wait_for_load_state()
             if consent_style == "Standard":
                 self.click_standard_consent_request_radio()

--- a/mavis/test/pages/online_consent_wizard_page.py
+++ b/mavis/test/pages/online_consent_wizard_page.py
@@ -384,7 +384,7 @@ class OnlineConsentWizardPage:
                     if consent_option is ConsentOption.INJECTION
                     else "nasal spray flu"
                 )
-            if programme is Programme.MMR:
+            if programme is Programme.MMR_MMRV:
                 if child.date_of_birth >= MMRV_ELIGIBILITY_CUTOFF_DOB:
                     return "MMRV"
                 return "MMR"

--- a/mavis/test/pages/record_vaccination_wizard_page.py
+++ b/mavis/test/pages/record_vaccination_wizard_page.py
@@ -185,7 +185,7 @@ class RecordVaccinationWizardPage:
 
             expected_outcome = (
                 "MMR"
-                if vaccination_record.programme is Programme.MMR
+                if vaccination_record.programme is Programme.MMR_MMRV
                 else str(vaccination_record.programme)
             )
 

--- a/mavis/test/pages/reports/vaccination_report_page.py
+++ b/mavis/test/pages/reports/vaccination_report_page.py
@@ -71,5 +71,7 @@ class VaccinationReportPage:
 
     def choose_programme(self, programme: Programme) -> None:
         # temp to ensure MMR works as expected
-        programme_radio_name = "MMR" if programme is Programme.MMR else str(programme)
+        programme_radio_name = (
+            "MMR" if programme is Programme.MMR_MMRV else str(programme)
+        )
         self.page.get_by_role("radio", name=programme_radio_name).check()

--- a/mavis/test/pages/sessions/nurse_consent_wizard_page.py
+++ b/mavis/test/pages/sessions/nurse_consent_wizard_page.py
@@ -306,7 +306,7 @@ class NurseConsentWizardPage:
         else:
             self.click_yes_they_agree()
 
-        if programme is Programme.MMR:
+        if programme is Programme.MMR_MMRV:
             if consent_option is ConsentOption.MMR_WITHOUT_GELATINE:
                 self.select_gelatine_free_vaccine_option()
             else:

--- a/mavis/test/pages/sessions/sessions_edit_page.py
+++ b/mavis/test/pages/sessions/sessions_edit_page.py
@@ -215,7 +215,7 @@ class SessionsEditPage:
             offset_days=offset_days, skip_weekends=skip_weekends
         )
         self.click_change_programmes()
-        self.add_programme(Programme.MMR)
+        self.add_programme(Programme.MMR_MMRV)
         self.click_continue_button()
         self.add_or_change_session_dates()
         if not self.session_date_already_scheduled(_future_date.strftime("%Y%m%d")):

--- a/mavis/test/pages/sessions/sessions_overview_page.py
+++ b/mavis/test/pages/sessions/sessions_overview_page.py
@@ -110,7 +110,7 @@ class SessionsOverviewPage:
         # Otherwise, we look for MMR link
         programme_names = []
         for programme in programmes:
-            if programme is Programme.MMR:
+            if programme is Programme.MMR_MMRV:
                 # Use MMRV if prefer_mmrv is True, otherwise MMR
                 programme_names.append("MMRV" if prefer_mmrv else "MMR")
             else:
@@ -304,9 +304,9 @@ class SessionsOverviewPage:
 
         # For MMR, the link text uses "MMR" not "MMR(V)"
         # When prefer_mmrv=True and programme is MMR, download MMRV form instead
-        if programme is Programme.MMR and prefer_mmrv:
+        if programme is Programme.MMR_MMRV and prefer_mmrv:
             programme_name = "MMRV"
-        elif programme is Programme.MMR:
+        elif programme is Programme.MMR_MMRV:
             programme_name = "MMR"
         else:
             programme_name = str(programme)

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -115,7 +115,7 @@ class SessionsPatientPage:
 
     @step("Click on {1} tab")
     def click_programme_tab(self, programme: Programme) -> None:
-        name = "MMR" if programme is Programme.MMR else str(programme)
+        name = "MMR" if programme is Programme.MMR_MMRV else str(programme)
         link = self.page.get_by_label("Secondary menu").get_by_role("link", name=name)
         click_secondary_navigation_item(link)
 

--- a/mavis/test/pages/sessions/sessions_search_page.py
+++ b/mavis/test/pages/sessions/sessions_search_page.py
@@ -25,7 +25,7 @@ class SessionsSearchPage:
     def click_session_for_programme_group(
         self, location: Location, programme_group: str
     ) -> None:
-        if programme_group != Programme.MMR:
+        if programme_group != Programme.MMR_MMRV:
             for programme in Programme:
                 if programme.group == programme_group:
                     self.page.get_by_role("checkbox", name=str(programme)).check()

--- a/tests/test_e2e_mmr.py
+++ b/tests/test_e2e_mmr.py
@@ -19,14 +19,14 @@ from mavis.test.utils import generate_random_dob_for_mmr_not_mmrv
 @pytest.fixture
 def url_with_mmr_session_scheduled(schedule_mmr_session_and_get_consent_url, schools):
     yield from schedule_mmr_session_and_get_consent_url(
-        schools[Programme.MMR.group][0],
-        Programme.MMR,
+        schools[Programme.MMR_MMRV.group][0],
+        Programme.MMR_MMRV,
     )
 
 
 @pytest.fixture
 def setup_session_for_mmr(setup_session_and_batches_with_fixed_child):
-    return setup_session_and_batches_with_fixed_child(Programme.MMR)
+    return setup_session_and_batches_with_fixed_child(Programme.MMR_MMRV)
 
 
 def test_recording_mmr_vaccination_e2e_with_triage(
@@ -49,12 +49,12 @@ def test_recording_mmr_vaccination_e2e_with_triage(
     - Final consent message is shown after online consent.
     - Vaccination is recorded for the child in the session.
     """
-    child = children[Programme.MMR][0]
+    child = children[Programme.MMR_MMRV][0]
     child.date_of_birth = generate_random_dob_for_mmr_not_mmrv()
-    schools = schools[Programme.MMR]
+    schools = schools[Programme.MMR_MMRV]
     mmr_batch_name = setup_session_for_mmr[Vaccine.PRIORIX]
     number_of_health_questions = len(
-        Programme.health_questions(Programme.MMR, ConsentOption.MMR_EITHER)
+        Programme.health_questions(Programme.MMR_MMRV, ConsentOption.MMR_EITHER)
     )
 
     OnlineConsentWizardPage(page).go_to_url(url_with_mmr_session_scheduled)
@@ -70,7 +70,7 @@ def test_recording_mmr_vaccination_e2e_with_triage(
     OnlineConsentWizardPage(page).click_confirm()
     OnlineConsentWizardPage(page).check_final_consent_message(
         child,
-        programmes=[Programme.MMR],
+        programmes=[Programme.MMR_MMRV],
         yes_to_health_questions=True,
     )
 
@@ -79,17 +79,17 @@ def test_recording_mmr_vaccination_e2e_with_triage(
 
     # Triage step added for MMR
     SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.MMR
+        schools[0], Programme.MMR_MMRV
     )
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.MMR)
+    SessionsPatientPage(page).click_programme_tab(Programme.MMR_MMRV)
     SessionsPatientPage(page).triage_mmr_patient(ConsentOption.MMR_EITHER)
     DashboardPage(page).navigate()
     DashboardPage(page).click_sessions()
 
     SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.MMR
+        schools[0], Programme.MMR_MMRV
     )
     SessionsOverviewPage(page).click_set_session_in_progress_for_today()
 
@@ -98,7 +98,7 @@ def test_recording_mmr_vaccination_e2e_with_triage(
     SessionsChildrenPage(page).tabs.click_record_vaccinations_tab()
     SessionsRecordVaccinationsPage(page).search.search_and_click_child(child)
 
-    vaccination_record = VaccinationRecord(child, Programme.MMR, mmr_batch_name)
+    vaccination_record = VaccinationRecord(child, Programme.MMR_MMRV, mmr_batch_name)
     SessionsPatientPage(page).set_up_vaccination(vaccination_record)
     RecordVaccinationWizardPage(page).record_vaccination(vaccination_record)
 
@@ -125,12 +125,14 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     - Vaccination is recorded for the child in the session on the first attempt.
     - Child cannot be found when attempting to record a second dose on the same day.
     """
-    child = children[Programme.MMR][0]
+    child = children[Programme.MMR_MMRV][0]
     child.date_of_birth = generate_random_dob_for_mmr_not_mmrv()
-    schools = schools[Programme.MMR]
+    schools = schools[Programme.MMR_MMRV]
     mmr_batch_name = setup_session_for_mmr[Vaccine.PRIORIX]
     number_of_health_questions = len(
-        Programme.health_questions(Programme.MMR, ConsentOption.MMR_WITHOUT_GELATINE)
+        Programme.health_questions(
+            Programme.MMR_MMRV, ConsentOption.MMR_WITHOUT_GELATINE
+        )
     )
 
     OnlineConsentWizardPage(page).go_to_url(url_with_mmr_session_scheduled)
@@ -148,7 +150,7 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     OnlineConsentWizardPage(page).click_confirm()
     OnlineConsentWizardPage(page).check_final_consent_message(
         child,
-        programmes=[Programme.MMR],
+        programmes=[Programme.MMR_MMRV],
         yes_to_health_questions=False,
     )
 
@@ -157,7 +159,7 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
 
     # Dose 1 flow
     SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.MMR
+        schools[0], Programme.MMR_MMRV
     )
     SessionsOverviewPage(page).click_set_session_in_progress_for_today()
     SessionsOverviewPage(page).tabs.click_children_tab()
@@ -165,7 +167,7 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     SessionsChildrenPage(page).tabs.click_record_vaccinations_tab()
     SessionsRecordVaccinationsPage(page).search.search_and_click_child(child)
 
-    vaccination_record = VaccinationRecord(child, Programme.MMR, mmr_batch_name)
+    vaccination_record = VaccinationRecord(child, Programme.MMR_MMRV, mmr_batch_name)
     SessionsPatientPage(page).set_up_vaccination(vaccination_record)
     RecordVaccinationWizardPage(page).record_vaccination(vaccination_record)
 
@@ -173,7 +175,7 @@ def test_verify_child_cannot_be_vaccinated_twice_for_mmr_on_same_day(
     SessionsPatientPage(page).header.click_mavis()
     DashboardPage(page).click_sessions()
     SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.MMR
+        schools[0], Programme.MMR_MMRV
     )
     SessionsOverviewPage(page).tabs.click_record_vaccinations_tab()
     SessionsRecordVaccinationsPage(page).search.search_for_child_that_should_not_exist(
@@ -204,16 +206,16 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
     - Final consent message is shown after online consent.
     - Vaccination is recorded for the child in the session.
     """
-    child = children[Programme.MMR][0]
+    child = children[Programme.MMR_MMRV][0]
     child.date_of_birth = generate_random_dob_for_mmr_not_mmrv()
-    schools = schools[Programme.MMR]
+    schools = schools[Programme.MMR_MMRV]
     mmr_batch_name = setup_session_for_mmr[Vaccine.PRIORIX]
     number_of_health_questions = len(
-        Programme.health_questions(Programme.MMR, ConsentOption.MMR_EITHER)
+        Programme.health_questions(Programme.MMR_MMRV, ConsentOption.MMR_EITHER)
     )
 
     # Import vaccination file with MMR dose 1
-    list(upload_offline_vaccination(Programme.MMR))
+    list(upload_offline_vaccination(Programme.MMR_MMRV))
 
     # Proceed with consent and vaccination process
     OnlineConsentWizardPage(page).go_to_url(url_with_mmr_session_scheduled)
@@ -229,7 +231,7 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
     OnlineConsentWizardPage(page).click_confirm()
     OnlineConsentWizardPage(page).check_final_consent_message(
         child,
-        programmes=[Programme.MMR],
+        programmes=[Programme.MMR_MMRV],
         yes_to_health_questions=True,
     )
 
@@ -238,17 +240,17 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
 
     # Triage step added for MMR
     SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.MMR
+        schools[0], Programme.MMR_MMRV
     )
     SessionsOverviewPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).click_programme_tab(Programme.MMR)
+    SessionsPatientPage(page).click_programme_tab(Programme.MMR_MMRV)
     SessionsPatientPage(page).triage_mmr_patient(ConsentOption.MMR_EITHER)
     SessionsPatientPage(page).header.click_mavis()
     DashboardPage(page).click_sessions()
 
     SessionsSearchPage(page).click_session_for_programme_group(
-        schools[0], Programme.MMR
+        schools[0], Programme.MMR_MMRV
     )
     SessionsOverviewPage(page).click_set_session_in_progress_for_today()
     SessionsOverviewPage(page).tabs.click_children_tab()
@@ -256,6 +258,6 @@ def test_recording_mmr_vaccination_e2e_with_imported_dose_one(
     SessionsChildrenPage(page).tabs.click_record_vaccinations_tab()
     SessionsRecordVaccinationsPage(page).search.search_and_click_child(child)
 
-    vaccination_record = VaccinationRecord(child, Programme.MMR, mmr_batch_name)
+    vaccination_record = VaccinationRecord(child, Programme.MMR_MMRV, mmr_batch_name)
     SessionsPatientPage(page).set_up_vaccination(vaccination_record)
     RecordVaccinationWizardPage(page).record_vaccination(vaccination_record)

--- a/tests/test_e2e_nurse_consent_mmr.py
+++ b/tests/test_e2e_nurse_consent_mmr.py
@@ -16,7 +16,7 @@ from mavis.test.pages.utils import (
 
 @pytest.fixture
 def setup_session_for_mmr(setup_session_and_batches_with_fixed_child):
-    return setup_session_and_batches_with_fixed_child(Programme.MMR)
+    return setup_session_and_batches_with_fixed_child(Programme.MMR_MMRV)
 
 
 @issue("MAV-955")
@@ -49,7 +49,7 @@ def test_e2e_nurse_consent_mmr(
     - Providing long notes gives an error
     """
     batch_names = setup_session_for_mmr
-    programme_group = Programme.MMR
+    programme_group = Programme.MMR_MMRV
 
     child = children[programme_group][0]
     school = schools[programme_group][0]
@@ -73,7 +73,7 @@ def test_e2e_nurse_consent_mmr(
 
     mmr_vaccination_record = VaccinationRecord(
         child,
-        Programme.MMR,
+        Programme.MMR_MMRV,
         batch_names[vaccine],
         consent_option,
     )

--- a/tests/test_import_offline_vaccinations.py
+++ b/tests/test_import_offline_vaccinations.py
@@ -46,7 +46,7 @@ def setup_vaccs(
             Programme.FLU,
             Programme.HPV,
             Programme.MENACWY,
-            Programme.MMR,
+            Programme.MMR_MMRV,
             Programme.TD_IPV,
         ],
         [year_group],

--- a/tests/test_online_consent_mmr.py
+++ b/tests/test_online_consent_mmr.py
@@ -16,8 +16,8 @@ from mavis.test.utils import (
 @pytest.fixture
 def url_with_mmr_session_scheduled(schedule_mmr_session_and_get_consent_url, schools):
     yield from schedule_mmr_session_and_get_consent_url(
-        schools[Programme.MMR.group][0],
-        Programme.MMR,
+        schools[Programme.MMR_MMRV.group][0],
+        Programme.MMR_MMRV,
     )
 
 
@@ -36,7 +36,7 @@ def setup_logged_in_session_with_file_upload(
     setup_logged_in_session_with_file_upload_for_programme,
 ):
     """Sets up an MMR session with class list and navigates to the session."""
-    return setup_logged_in_session_with_file_upload_for_programme(Programme.MMR)
+    return setup_logged_in_session_with_file_upload_for_programme(Programme.MMR_MMRV)
 
 
 def test_consent_refused_for_mmr_vaccination(
@@ -53,9 +53,9 @@ def test_consent_refused_for_mmr_vaccination(
     Verification:
     - Confirmation text indicates consent was refused for MMR vaccination.
     """
-    child = children[Programme.MMR][0]
+    child = children[Programme.MMR_MMRV][0]
     child.date_of_birth = generate_random_dob_for_mmr_not_mmrv()
-    schools = schools[Programme.MMR]
+    schools = schools[Programme.MMR_MMRV]
 
     OnlineConsentWizardPage(page).fill_details(child, child.parents[0], schools)
     OnlineConsentWizardPage(page).dont_agree_to_vaccination()
@@ -101,11 +101,11 @@ def test_consent_given_for_mmr_vaccination(
     - Confirmation message is shown for the correct child, vaccine, and
       health question status.
     """
-    child = children[Programme.MMR][0]
+    child = children[Programme.MMR_MMRV][0]
     child.date_of_birth = generate_random_dob_for_mmr_not_mmrv()
-    schools = schools[Programme.MMR]
+    schools = schools[Programme.MMR_MMRV]
     number_of_health_questions = len(
-        Programme.health_questions(Programme.MMR, consent_option)
+        Programme.health_questions(Programme.MMR_MMRV, consent_option)
     )
 
     OnlineConsentWizardPage(page).fill_details(child, child.parents[0], schools)
@@ -118,7 +118,7 @@ def test_consent_given_for_mmr_vaccination(
     OnlineConsentWizardPage(page).click_confirm()
     OnlineConsentWizardPage(page).check_final_consent_message(
         child,
-        programmes=[Programme.MMR],
+        programmes=[Programme.MMR_MMRV],
         yes_to_health_questions=yes_to_health_questions,
     )
 
@@ -138,7 +138,7 @@ def test_pdf_consent_form_contains_health_questions(
     Verifies that the downloadable PDF consent form includes all health questions
     that parents need to answer when giving consent for their child to be vaccinated.
     """
-    programme = Programme.MMR
+    programme = Programme.MMR_MMRV
 
     pdf_text_normalized = read_pdf_as_normalized_text(
         SessionsOverviewPage(page).download_consent_form(programme)

--- a/tests/test_online_consent_mmrv.py
+++ b/tests/test_online_consent_mmrv.py
@@ -16,8 +16,8 @@ from mavis.test.utils import assert_questions_in_pdf, read_pdf_as_normalized_tex
 def url_with_mmr_session_scheduled(schedule_mmrv_session_and_get_consent_url, schools):
     """Get consent URL for MMRV-eligible children using the MMRV link."""
     yield from schedule_mmrv_session_and_get_consent_url(
-        schools[Programme.MMR.group][0],
-        Programme.MMR,
+        schools[Programme.MMR_MMRV.group][0],
+        Programme.MMR_MMRV,
     )
 
 
@@ -36,7 +36,7 @@ def setup_logged_in_session_with_file_upload(
     setup_logged_in_session_with_file_upload_for_programme,
 ):
     """Sets up an MMRV session with class list and navigates to the session."""
-    return setup_logged_in_session_with_file_upload_for_programme(Programme.MMR)
+    return setup_logged_in_session_with_file_upload_for_programme(Programme.MMR_MMRV)
 
 
 @pytest.fixture
@@ -70,8 +70,8 @@ def test_consent_refused_for_mmrv_vaccination(
     Verification:
     - Confirmation text indicates consent was refused for MMRV vaccination.
     """
-    child = mmrv_children[Programme.MMR][0]
-    schools = schools[Programme.MMR]
+    child = mmrv_children[Programme.MMR_MMRV][0]
+    schools = schools[Programme.MMR_MMRV]
 
     OnlineConsentWizardPage(page).fill_details(child, child.parents[0], schools)
     OnlineConsentWizardPage(page).dont_agree_to_vaccination()
@@ -120,11 +120,13 @@ def test_consent_given_for_mmrv_vaccination(
       health question status.
     - MMRV-specific health questions are presented (allergic reaction to MMRV vaccine).
     """
-    child = mmrv_children[Programme.MMR][0]
-    schools = schools[Programme.MMR]
+    child = mmrv_children[Programme.MMR_MMRV][0]
+    schools = schools[Programme.MMR_MMRV]
 
     number_of_health_questions = len(
-        Programme.health_questions(Programme.MMR, consent_option, mmrv_eligibility=True)
+        Programme.health_questions(
+            Programme.MMR_MMRV, consent_option, mmrv_eligibility=True
+        )
     )
 
     OnlineConsentWizardPage(page).fill_details(child, child.parents[0], schools)
@@ -137,7 +139,7 @@ def test_consent_given_for_mmrv_vaccination(
     OnlineConsentWizardPage(page).click_confirm()
     OnlineConsentWizardPage(page).check_final_consent_message(
         child,
-        programmes=[Programme.MMR],
+        programmes=[Programme.MMR_MMRV],
         yes_to_health_questions=yes_to_health_questions,
     )
 
@@ -158,7 +160,7 @@ def test_pdf_consent_form_contains_health_questions(
     that parents need to answer when giving consent for their child to receive MMRV.
     Uses mmrv_eligibility=True to ensure MMRV-specific questions are included.
     """
-    programme = Programme.MMR
+    programme = Programme.MMR_MMRV
 
     pdf_text_normalized = read_pdf_as_normalized_text(
         SessionsOverviewPage(page).download_consent_form(programme, prefer_mmrv=True)

--- a/tests/test_record_already_vaccinated.py
+++ b/tests/test_record_already_vaccinated.py
@@ -22,7 +22,7 @@ from mavis.test.utils import get_offset_date_compact_format
         (Programme.FLU, 1),
         (Programme.HPV, 1),
         (Programme.MENACWY, 1),
-        (Programme.MMR, 2),
+        (Programme.MMR_MMRV, 2),
         (Programme.TD_IPV, 1),
     ],
     ids=lambda v: v[0],

--- a/tests/test_reporting_downloads.py
+++ b/tests/test_reporting_downloads.py
@@ -150,7 +150,7 @@ def test_verify_careplus_report_for_mmr(
     Verification:
     - Report is generated in CarePlus format for MMR.
     """
-    VaccinationReportPage(page).choose_programme(Programme.MMR)
+    VaccinationReportPage(page).choose_programme(Programme.MMR_MMRV)
     VaccinationReportPage(page).verify_report_format(
         report_format=ReportFormat.CAREPLUS,
     )
@@ -168,7 +168,7 @@ def test_verify_csv_report_for_mmr(
     Verification:
     - Report is generated in CSV format for MMR.
     """
-    VaccinationReportPage(page).choose_programme(Programme.MMR)
+    VaccinationReportPage(page).choose_programme(Programme.MMR_MMRV)
     VaccinationReportPage(page).verify_report_format(
         report_format=ReportFormat.CSV,
     )
@@ -186,7 +186,7 @@ def test_verify_systmone_report_for_mmr(
     Verification:
     - Report is generated in SystmOne format for MMR.
     """
-    VaccinationReportPage(page).choose_programme(Programme.MMR)
+    VaccinationReportPage(page).choose_programme(Programme.MMR_MMRV)
     VaccinationReportPage(page).verify_report_format(
         report_format=ReportFormat.SYSTMONE,
     )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -496,13 +496,13 @@ def test_outbreak_session(
     Verification:
     - Session is created, edited, and deleted without errors.
     """
-    school = schools[Programme.MMR][0]
-    year_group = year_groups[Programme.MMR]
+    school = schools[Programme.MMR_MMRV][0]
+    year_group = year_groups[Programme.MMR_MMRV]
 
     schedule_school_session_if_needed(
         page,
         school,
-        [Programme.MMR],
+        [Programme.MMR_MMRV],
         [year_group],
         date_offset=14,
         consent_style="Outbreak",

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -203,8 +203,8 @@ def test_site_class_list_import(
     - The import succeeds for the new school site (B).
     - The child is visible on the School Moves page.
     """
-    school = schools[Programme.MMR][0]
-    child = children[Programme.MMR][0]
+    school = schools[Programme.MMR_MMRV][0]
+    child = children[Programme.MMR_MMRV][0]
 
     new_site_name = f"{school} (Site B)"
 
@@ -228,7 +228,8 @@ def test_site_class_list_import(
     ImportRecordsWizardPage(
         page, point_of_care_file_generator
     ).upload_and_verify_output(
-        file_mapping=ClassFileMapping.FIXED_CHILD, programme_group=Programme.MMR.group
+        file_mapping=ClassFileMapping.FIXED_CHILD,
+        programme_group=Programme.MMR_MMRV.group,
     )
     TeamSchoolsPage(page).header.click_mavis()
     DashboardPage(page).click_imports()
@@ -239,7 +240,8 @@ def test_site_class_list_import(
     ImportRecordsWizardPage(
         page, point_of_care_file_generator
     ).upload_and_verify_output(
-        file_mapping=ClassFileMapping.FIXED_CHILD, programme_group=Programme.MMR.group
+        file_mapping=ClassFileMapping.FIXED_CHILD,
+        programme_group=Programme.MMR_MMRV.group,
     )
     TeamSchoolsPage(page).header.click_mavis()
     DashboardPage(page).click_school_moves()


### PR DESCRIPTION
I think this makes it clearer that it encompases both programmes, and it's likely what we'd want to do in Mavis if it was easier to rename database enum values.

This should help to avoid any ambiguity between the MMR(V) programme, and the MMR and MMRV variants which are separate concepts that we're likely to need to introduce in the future.

Related to #1082