### PR TITLE
Ensure dockerfile is able to run mock careplus service

### DIFF
--- a/mavis/test/mocks/careplus/Dockerfile
+++ b/mavis/test/mocks/careplus/Dockerfile
@@ -2,7 +2,12 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
-COPY mavis/ mavis/
+# Empty __init__.py stubs are needed to make `mavis.test.mocks.careplus` a
+# valid dotted package path. We cannot copy the real mavis/test/__init__.py
+# because it imports from mavis.test.fixtures, which depends on pytest.
+RUN mkdir -p mavis/test
+RUN touch mavis/__init__.py mavis/test/__init__.py
+COPY mavis/test/mocks/ mavis/test/mocks/
 
 RUN pip install --no-cache-dir defusedxml
 


### PR DESCRIPTION
Now that the mock careplus service is in `mavis.test.mocks.careplus`, we need to construct a few stub `__init__.py` files to ensure that this package is valid. This also ensures we don't need to install extra dependencies into the container (e.g. `pytest`)