### PR TITLE
Remove unneeded secret inputs from E2E test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,6 @@ jobs:
       contents: write
     with:
       git_reference_for_application_image: ${{ needs.identify-target.outputs.mavis-branch }}
-    secrets:
-      HTTP_AUTH_TOKEN_FOR_TESTS: ${{ secrets.HTTP_AUTH_TOKEN_FOR_TESTS }}
-      MAVIS_TESTING_REPO_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   ensure-run-success:
     name: Ensure end-to-end tests ran successfully

--- a/.github/workflows/end-to-end-tests-release.yaml
+++ b/.github/workflows/end-to-end-tests-release.yaml
@@ -78,9 +78,6 @@ on:
       JIRA_API_TOKEN:
         description: API token to access Jira, used to attach test results to issues
         required: true
-      MAVIS_TESTING_REPO_ACCESS_TOKEN:
-        description: Git token with access to the mavis testing repo
-        required: false
   workflow_dispatch:
     inputs:
       tests:
@@ -297,6 +294,3 @@ jobs:
         with:
           device: ${{ steps.set-variables.outputs.device }}
           environment: ${{ github.event.inputs.environment }}
-        env:
-          GITHUB_TOKEN: >-
-            ${{ secrets.MAVIS_TESTING_REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -70,9 +70,6 @@ on:
       HTTP_AUTH_TOKEN_FOR_TESTS:
         description: HTTP Basic Auth token for the environment under test
         required: true
-      MAVIS_TESTING_REPO_ACCESS_TOKEN:
-        description: Git token with access to the mavis testing repo
-        required: false
   workflow_dispatch:
     inputs:
       tests:
@@ -268,6 +265,3 @@ jobs:
         with:
           device: ${{ steps.set-variables.outputs.device }}
           environment: ${{ github.event.inputs.environment }}
-        env:
-          GITHUB_TOKEN: |-
-            ${{ secrets.MAVIS_TESTING_REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -69,7 +69,7 @@ on:
         required: false
       HTTP_AUTH_TOKEN_FOR_TESTS:
         description: HTTP Basic Auth token for the environment under test
-        required: true
+        required: false
   workflow_dispatch:
     inputs:
       tests:


### PR DESCRIPTION
`MAVIS_TESTING_REPO_ACCESS_TOKEN` is no longer required by the workflow (the repo is public).
`HTTP_AUTH_TOKEN_FOR_TESTS` was made optional, when called from MAVIS it no longer needs to be passed.