### PR TITLE
Add tests for new consent refusal reason

### DIFF
--- a/mavis/test/constants.py
+++ b/mavis/test/constants.py
@@ -421,6 +421,7 @@ class ConsentRefusalReason(StrEnum):
     CONTAINS_GELATINE = "I’m concerned the vaccine contains gelatine"
     VACCINE_ALREADY_RECEIVED = "Vaccine already received"
     VACCINE_WILL_BE_GIVEN_ELSEWHERE = "Vaccine will be given elsewhere"
+    DO_NOT_WANT_VACCINATION_AT_SCHOOL = "Do not want vaccination at school"
     MEDICAL_REASONS = "Medical reasons"
     PERSONAL_CHOICE = "Personal choice"
     OTHER = "Other"
@@ -430,6 +431,7 @@ class ConsentRefusalReason(StrEnum):
         return self not in (
             ConsentRefusalReason.PERSONAL_CHOICE,
             ConsentRefusalReason.CONTAINS_GELATINE,
+            ConsentRefusalReason.DO_NOT_WANT_VACCINATION_AT_SCHOOL,
         )
 
     @property

--- a/mavis/test/pages/online_consent_wizard_page.py
+++ b/mavis/test/pages/online_consent_wizard_page.py
@@ -361,14 +361,21 @@ class OnlineConsentWizardPage:
             "For example, it may be possible to use a vaccine that "
             "does not contain gelatine"
         )
+        hint_text_community = (
+            "For example, it may be possible to vaccinate your "
+            "child in a community clinic"
+        )
 
         if refusal_reason is ConsentRefusalReason.MEDICAL_REASONS:
             expect(self.page.get_by_text(hint_text_medical)).to_be_visible()
         elif refusal_reason is ConsentRefusalReason.CONTAINS_GELATINE:
             expect(self.page.get_by_text(hint_text_gelatine)).to_be_visible()
+        elif refusal_reason is ConsentRefusalReason.DO_NOT_WANT_VACCINATION_AT_SCHOOL:
+            expect(self.page.get_by_text(hint_text_community)).to_be_visible()
         else:
             expect(self.page.get_by_text(hint_text_medical)).not_to_be_visible()
             expect(self.page.get_by_text(hint_text_gelatine)).not_to_be_visible()
+            expect(self.page.get_by_text(hint_text_community)).not_to_be_visible()
 
     @step("Click Change link for discuss options")
     def click_change_discuss_options(self) -> None:

--- a/tests/test_follow_up_requests.py
+++ b/tests/test_follow_up_requests.py
@@ -96,6 +96,7 @@ def give_online_consent_with_follow_up_request(
         ConsentRefusalReason.MEDICAL_REASONS,
         ConsentRefusalReason.PERSONAL_CHOICE,
         ConsentRefusalReason.CONTAINS_GELATINE,
+        ConsentRefusalReason.DO_NOT_WANT_VACCINATION_AT_SCHOOL,
         ConsentRefusalReason.OTHER,
     ],
     ids=lambda v: f"refusal_reason: {v}",

--- a/tests/test_nurse_consent.py
+++ b/tests/test_nurse_consent.py
@@ -4,6 +4,7 @@ from mavis.test.annotations import issue
 from mavis.test.constants import (
     MAVIS_NOTE_LENGTH_LIMIT,
     ConsentMethod,
+    ConsentRefusalReason,
     DeliverySite,
     Programme,
     Vaccine,
@@ -331,6 +332,46 @@ def test_conflicting_consent_with_gillick_consent(
     SessionsPatientSessionActivityPage(page).check_session_activity_entry(
         f"Consent given by {child!s} (Child (Gillick competent))",
     )
+
+
+def test_consent_refusal_do_not_want_vaccination_at_school(
+    setup_fixed_child,
+    page,
+    children,
+):
+    """
+    Test: Record a refusal consent with reason 'Do not want vaccination at school'.
+    Steps:
+    1. Open the session and navigate to child.
+    2. Record a verbal refusal consent with the relevant refusal reason.
+    3. Verify the consent status is "Consent refused".
+    Verification:
+    - Consent status shows "Consent refused".
+    - Refusal reason is correctly recorded.
+    """
+    child = children[Programme.HPV][0]
+
+    SessionsOverviewPage(page).tabs.click_children_tab()
+    SessionsChildrenPage(page).search.select_needs_consent()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).click_record_a_new_consent_response()
+
+    NurseConsentWizardPage(page).select_parent(child.parents[0])
+    NurseConsentWizardPage(page).select_consent_method(ConsentMethod.IN_PERSON)
+    NurseConsentWizardPage(page).click_no_they_do_not_agree()
+    NurseConsentWizardPage(page).click_continue()
+    NurseConsentWizardPage(page).click_consent_refusal_reason(
+        ConsentRefusalReason.DO_NOT_WANT_VACCINATION_AT_SCHOOL
+    )
+    NurseConsentWizardPage(page).click_continue()
+    NurseConsentWizardPage(page).click_confirm()
+
+    SessionsChildrenPage(page).search.select_has_a_refusal()
+    SessionsChildrenPage(page).search.select_consent_refused()
+    SessionsChildrenPage(page).search.search_and_click_child(child)
+    SessionsPatientPage(page).click_programme_tab(Programme.HPV)
+    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent refused")
 
 
 @pytest.mark.accessibility


### PR DESCRIPTION
Reason: do not want vaccination at school

Tests both the nurse and parent consent flows, including follow-up