### PR TITLE
Fix call to `get_onboarding_data_for_tests`

### DIFF
--- a/tests/test_reporting_regression.py
+++ b/tests/test_reporting_regression.py
@@ -42,7 +42,6 @@ def _onboard_team(base_url):
     onboarding = PointOfCareOnboarding.get_onboarding_data_for_tests(
         base_url=base_url,
         year_groups=_year_groups,
-        programmes=["flu"],
     )
     return _create_onboarding_with_retry(base_url, onboarding)
 


### PR DESCRIPTION
The `programmes` argument was removed in 95c215f26fc22327c8153331eee0fd7221942f85.