### PR TITLE
Update patient session page tests for new designs

### DIFF
--- a/mavis/test/constants.py
+++ b/mavis/test/constants.py
@@ -448,6 +448,18 @@ class ConsentMethod(StrEnum):
     IN_PERSON = "In person"
 
 
+class ConsentStatus(StrEnum):
+    GIVEN = "Consent given"
+    REFUSED = "Consent refused"
+    FOLLOW_UP_REQUESTED = "Follow-up requested"
+    CONFLICTS = "Conflicting consent"
+    NO_CONTACT_DETAILS = "No contact details"
+    REQUEST_SCHEDULED = "Request scheduled"
+    REQUEST_NOT_SCHEDULED = "Request not scheduled"
+    NO_RESPONSE = "No response"
+    NOT_REQUIRED = "Not required"
+
+
 class ReportFormat(StrEnum):
     CAREPLUS = "CSV for CarePlus (System C)"
     CSV = "CSV"

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -6,6 +6,7 @@ from mavis.test.annotations import step
 from mavis.test.constants import (
     MAVIS_NOTE_LENGTH_LIMIT,
     ConsentOption,
+    ConsentStatus,
     DeliverySite,
     Programme,
 )
@@ -44,7 +45,7 @@ class SessionsPatientPage:
         )
         self.edit_gillick_competence_link = self.page.get_by_role(
             "link",
-            name="Edit Gillick competence",
+            name="Update Gillick competence",
         )
         self.could_not_vaccinate_link = self.page.get_by_role(
             "link",
@@ -60,7 +61,7 @@ class SessionsPatientPage:
         )
         self.notes_textbox = self.page.get_by_role("textbox", name="Notes")
         self.record_a_new_consent_response_button = self.page.get_by_role(
-            "button",
+            "link",
             name="Record a new consent response",
         )
         self.ready_for_injection_radio = self.page.locator(
@@ -250,8 +251,20 @@ class SessionsPatientPage:
             ),
         ).to_be_visible()
 
-    def expect_consent_status(self, programme: Programme, status: str) -> None:
-        expect(self.page.get_by_text(f"{programme}: {status}")).to_be_visible()
+    def expect_consent_status(self, status: ConsentStatus) -> None:
+        if status is ConsentStatus.GIVEN:
+            expected_text = "is ready for the vaccinator"
+        elif status is ConsentStatus.REFUSED:
+            expected_text = "refused to give consent"
+        elif status is ConsentStatus.FOLLOW_UP_REQUESTED:
+            expected_text = "would like to speak to a member of the team"
+        elif status is ConsentStatus.NO_RESPONSE:
+            expected_text = "No-one responded to our requests"
+        elif status is ConsentStatus.CONFLICTS:
+            expected_text = "You can only vaccinate if all respondents give consent"
+        else:
+            expected_text = str(status)
+        expect(self.page.get_by_text(expected_text, exact=False)).to_be_visible()
 
     def expect_consent_recorded_success(self) -> None:
         expect_alert_text(self.page, "Consent recorded")

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -83,7 +83,7 @@ class SessionsPatientPage:
             "textbox", name="Pre-screening notes (optional)"
         )
 
-        vaccinations_card = page.get_by_role("table", name="Vaccination records")
+        vaccinations_card = page.get_by_role("table", name="Vaccination outcomes")
         self.vaccinations_card_row = vaccinations_card.get_by_role("row")
         self.withdraw_consent_link = self.page.get_by_role(
             "link", name="Withdraw consent"
@@ -276,12 +276,16 @@ class SessionsPatientPage:
             ),
         ).to_be_visible()
 
-    @step("Click on {1} vaccination details")
-    def click_vaccination_details(self, school: School) -> None:
+    @step("Click on vaccination details")
+    def click_vaccination_details(
+        self, outcome: str | None = None, index: int = 0
+    ) -> None:
         with self.page.expect_navigation():
-            self.vaccinations_card_row.filter(has_text=str(school)).get_by_role(
-                "link",
-            ).click()
+            if outcome:
+                row = self.vaccinations_card_row.filter(has_text=outcome)
+                row.get_by_role("link").nth(index).click()
+            else:
+                self.vaccinations_card_row.get_by_role("link").nth(index).click()
 
     def go_back_to_session_for_school(self, school: School) -> None:
         self.page.get_by_role("link", name=school.name).click()

--- a/tests/test_follow_up_requests.py
+++ b/tests/test_follow_up_requests.py
@@ -3,6 +3,7 @@ import pytest
 from mavis.test.constants import (
     ConsentOption,
     ConsentRefusalReason,
+    ConsentStatus,
     Programme,
     Vaccine,
 )
@@ -182,8 +183,12 @@ def test_consent_refusal_with_follow_up_request(
 
     SessionsChildrenPage(page).click_child(child)
 
-    status = "Follow-up requested" if follow_up_requested else "Consent refused"
-    SessionsPatientPage(page).expect_consent_status(Programme.MMR_MMRV, status)
+    status = (
+        ConsentStatus.FOLLOW_UP_REQUESTED
+        if follow_up_requested
+        else ConsentStatus.REFUSED
+    )
+    SessionsPatientPage(page).expect_consent_status(status)
 
     SessionsPatientPage(page).click_session_activity_and_notes()
 
@@ -290,9 +295,7 @@ def test_follow_up_journey_decision_stands_confirm_refusal(
     SessionsChildrenPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).click_child(child)
 
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.MMR_MMRV, "Follow-up requested"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.FOLLOW_UP_REQUESTED)
 
     SessionsPatientPage(page).click_response_from_parent(parent)
     ConsentResponseDetailsPage(page).expect_follow_up_available()
@@ -306,9 +309,7 @@ def test_follow_up_journey_decision_stands_confirm_refusal(
     ConsentConfirmRefusalPage(page).expect_refusal_confirmation_success()
 
     SessionsPatientPage(page).click_back()
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.MMR_MMRV, "Consent refused"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.REFUSED)
 
     SessionsPatientPage(page).click_session_activity_and_notes()
 
@@ -377,7 +378,7 @@ def test_follow_up_journey_decision_changed_record_consent(
     SessionsPatientPage(page).expect_consent_recorded_success()
 
     SessionsChildrenPage(page).click_child(child)
-    SessionsPatientPage(page).expect_consent_status("MMR", "Consent given")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.GIVEN)
 
     SessionsPatientPage(page).verify_original_response_invalidated(
         parent, "Consent given in follow-up discussion."
@@ -434,9 +435,7 @@ def test_gillick_self_consent_overrides_follow_up_requested(
     SessionsChildrenPage(page).search.click_on_update_results()
     SessionsChildrenPage(page).click_child(child)
 
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.MMR_MMRV, "Follow-up requested"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.FOLLOW_UP_REQUESTED)
 
     SessionsPatientPage(page).click_assess_gillick_competence()
     GillickCompetencePage(page).add_gillick_competence(is_competent=True)
@@ -452,15 +451,15 @@ def test_gillick_self_consent_overrides_follow_up_requested(
 
     SessionsChildrenPage(page).search.select_due_vaccination()
     SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).expect_consent_status("MMR", "Consent given")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.GIVEN)
 
 
 @pytest.mark.parametrize(
     ("parent2_action", "expected_status"),
     [
-        ("given", "Follow-up requested"),
-        ("refused", "Conflicting consent"),
-        ("follow_up", "Follow-up requested"),
+        ("given", ConsentStatus.FOLLOW_UP_REQUESTED),
+        ("refused", ConsentStatus.CONFLICTS),
+        ("follow_up", ConsentStatus.FOLLOW_UP_REQUESTED),
     ],
     ids=[
         "parent_1_follow_up_parent_2_given",
@@ -522,14 +521,14 @@ def test_multiple_parents_with_follow_up_request(
     )
     SessionsChildrenPage(page).tabs.click_children_tab()
 
-    if expected_status == "Conflicting consent":
+    if expected_status == ConsentStatus.CONFLICTS:
         SessionsChildrenPage(page).search.select_has_a_refusal()
         SessionsChildrenPage(page).search.select_conflicting_consent()
     else:
         SessionsChildrenPage(page).search.select_needs_consent()
 
     SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).expect_consent_status(Programme.MMR_MMRV, expected_status)
+    SessionsPatientPage(page).expect_consent_status(expected_status)
 
     if parent2_action != "follow_up":
         SessionsPatientPage(page).click_response_from_parent(child.parents[1])

--- a/tests/test_imms_api_flu.py
+++ b/tests/test_imms_api_flu.py
@@ -129,7 +129,7 @@ def test_create_edit_delete_injected_flu_vaccination_and_verify_imms_api(
     )
 
     # Step 6: Edit outcome to refused
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Synced"
     )
@@ -142,7 +142,7 @@ def test_create_edit_delete_injected_flu_vaccination_and_verify_imms_api(
 
     # Step 7: Verify deletion in IMMS API
     imms_api_helper.check_record_is_not_in_imms_api(Vaccine.SEQUIRUS, child)
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Not synced"
     )
@@ -211,7 +211,7 @@ def test_create_edit_delete_nasal_flu_vaccination_and_verify_imms_api(
     )
 
     # Step 6: Edit outcome to refused
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Synced"
     )
@@ -224,7 +224,7 @@ def test_create_edit_delete_nasal_flu_vaccination_and_verify_imms_api(
 
     # Step 7: Verify deletion in IMMS API
     imms_api_helper.check_record_is_not_in_imms_api(Vaccine.FLUENZ, child)
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Not synced"
     )

--- a/tests/test_nurse_consent.py
+++ b/tests/test_nurse_consent.py
@@ -443,5 +443,5 @@ def test_accessibility(
     RecordVaccinationWizardPage(page).click_confirm_button()
     AccessibilityHelper(page).check_accessibility()
 
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     AccessibilityHelper(page).check_accessibility()

--- a/tests/test_nurse_consent.py
+++ b/tests/test_nurse_consent.py
@@ -5,6 +5,7 @@ from mavis.test.constants import (
     MAVIS_NOTE_LENGTH_LIMIT,
     ConsentMethod,
     ConsentRefusalReason,
+    ConsentStatus,
     DeliverySite,
     Programme,
     Vaccine,
@@ -312,9 +313,7 @@ def test_conflicting_consent_with_gillick_consent(
 
     SessionsChildrenPage(page).search.search_and_click_child(child)
     SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.HPV, "Conflicting consent"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.CONFLICTS)
     SessionsPatientPage(page).expect_conflicting_consent_text()
     SessionsPatientPage(page).click_assess_gillick_competence()
     GillickCompetencePage(page).add_gillick_competence(is_competent=True)
@@ -327,7 +326,7 @@ def test_conflicting_consent_with_gillick_consent(
     SessionsChildrenPage(page).search.select_due_vaccination()
     SessionsChildrenPage(page).search.search_and_click_child(child)
     SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent given")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.GIVEN)
     SessionsPatientPage(page).click_session_activity_and_notes()
     SessionsPatientSessionActivityPage(page).check_session_activity_entry(
         f"Consent given by {child!s} (Child (Gillick competent))",
@@ -371,7 +370,7 @@ def test_consent_refusal_do_not_want_vaccination_at_school(
     SessionsChildrenPage(page).search.select_consent_refused()
     SessionsChildrenPage(page).search.search_and_click_child(child)
     SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent refused")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.REFUSED)
 
 
 @pytest.mark.accessibility

--- a/tests/test_vaccination_records.py
+++ b/tests/test_vaccination_records.py
@@ -45,7 +45,6 @@ def test_edit_vaccination_dose_to_not_given_and_bac(
     Verification:
     - Alert confirms vaccination outcome recorded as refused.
     """
-    school = schools[Programme.HPV][0]
     batch_name = setup_gardasil_batch
 
     VaccinationRecordPage(page).click_edit_vaccination_record()
@@ -55,7 +54,7 @@ def test_edit_vaccination_dose_to_not_given_and_bac(
     EditVaccinationRecordPage(page).click_save_changes()
     expect_alert_text(page, "Vaccination outcome recorded for HPV")
 
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).click_edit_vaccination_record()
     EditVaccinationRecordPage(page).click_change_outcome()
     EditVaccinationRecordPage(page).click_vaccinated()


### PR DESCRIPTION
Adds ConsentStatus enum to standardise consent status values across tests                                                                     Updates expect_consent_status method in SessionsPatientPage to map status values to actual UI text displayed in new patient session designs (e.g. "Consent given" → "is ready for the vaccinator")
Also updates page object locators for new designs