### PR TITLE
Pin all GitHub Actions to commit SHAs for security

### DIFF
--- a/.github/actions/deploy-reports/action.yml
+++ b/.github/actions/deploy-reports/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
         cache: 'npm'

--- a/.github/workflows/accessibility.yaml
+++ b/.github/workflows/accessibility.yaml
@@ -108,7 +108,7 @@ jobs:
           fi
       # yamllint enable rule:line-length
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Deployment health check
         uses: ./.github/actions/deployment-health-check
@@ -116,7 +116,7 @@ jobs:
           environment_url: ${{ steps.set-variables.outputs.environment }}
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         id: playwright-cache
         with:
           path: /home/runner/.cache/ms-playwright
@@ -143,7 +143,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole

--- a/.github/workflows/build-and-push-mock-careplus-image.yaml
+++ b/.github/workflows/build-and-push-mock-careplus-image.yaml
@@ -28,7 +28,7 @@ jobs:
         ${{ steps.check-image.outputs.build-needed }}
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::393416225559:role/GithubDeployECSService
           aws-region: eu-west-2
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.git-sha || github.sha }}
       - name: Make sure public dir is present
@@ -61,7 +61,7 @@ jobs:
       - name: Save Docker image
         run: docker save -o image.tar mavis-mock-careplus:latest
       - name: Upload Docker image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image
           path: image.tar
@@ -72,17 +72,17 @@ jobs:
       id-token: write
     steps:
       - name: Download Docker image
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: image
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::393416225559:role/GithubDeployECSService
           aws-region: eu-west-2
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062340a7de7a9da2b919efc70d2a5638c4be725c # v2.0.0
       - name: Load Docker image
         run: docker load -i image.tar
       # yamllint disable rule:line-length

--- a/.github/workflows/deploy-mock-careplus-service.yaml
+++ b/.github/workflows/deploy-mock-careplus-service.yaml
@@ -46,7 +46,7 @@ jobs:
       git-sha: ${{ steps.get-git-sha.outputs.git-sha }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.git_ref_to_deploy || github.sha }}
       - name: Get git sha
@@ -69,11 +69,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.determine-git-sha.outputs.git-sha }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ env.aws_role }}
           aws-region: eu-west-2
@@ -88,7 +88,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Populate mock-careplus task definition
         id: create-task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@823d5d2ba6624bd7b8690e1d92b5443532ea20af # v1.2.0
         with:
           # yamllint disable-line rule:line-length
           task-definition-family: mavis-mock-careplus-task-definition-${{ inputs.environment }}-template
@@ -100,7 +100,7 @@ jobs:
           mv ${{ steps.create-task-definition.outputs.task-definition }}
           ${{ runner.temp }}/mock-careplus-task-definition.json
       - name: Upload artifact for mock-careplus task definition
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.environment }}-mock-careplus-task-definition
           path: ${{ runner.temp }}/mock-careplus-task-definition.json
@@ -114,12 +114,12 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ env.aws_role }}
           aws-region: eu-west-2
       - name: Download mock-careplus task definition artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           path: ${{ runner.temp }}
           name: ${{ inputs.environment }}-mock-careplus-task-definition
@@ -129,7 +129,7 @@ jobs:
           family_name="mavis-mock-careplus-task-definition-${{ inputs.environment }}"
           jq --arg f "$family_name" '.family = $f' "$file_path" > tmpfile && mv tmpfile "$file_path"
       - name: Deploy mock-careplus service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@01f2cfcf1bcc6568460b29052fdbc959f44983be # v2.0.0
         with:
           task-definition: ${{ runner.temp }}/mock-careplus-task-definition.json
           cluster: ${{ env.cluster_name }}

--- a/.github/workflows/end-to-end-tests-all-devices.yaml
+++ b/.github/workflows/end-to-end-tests-all-devices.yaml
@@ -31,7 +31,7 @@ jobs:
       TZ: "Europe/London"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Deployment health check
         uses: ./.github/actions/deployment-health-check
@@ -39,7 +39,7 @@ jobs:
           environment_url: ${{ vars.BASE_URL }}
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         id: playwright-cache
         with:
           path: /home/runner/.cache/ms-playwright
@@ -64,7 +64,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: always()
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole

--- a/.github/workflows/end-to-end-tests-release.yaml
+++ b/.github/workflows/end-to-end-tests-release.yaml
@@ -226,7 +226,7 @@ jobs:
       # yamllint enable rule:line-length
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: NHSDigital/manage-vaccinations-in-schools-testing
           ref: ${{ inputs.github_ref || github.head_ref }}
@@ -237,7 +237,7 @@ jobs:
           environment_url: ${{ steps.set-variables.outputs.environment }}
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         id: playwright-cache
         with:
           path: /home/runner/.cache/ms-playwright
@@ -282,7 +282,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -210,7 +210,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: NHSDigital/manage-vaccinations-in-schools-testing
           ref: ${{ inputs.github_ref || github.head_ref }}
@@ -221,7 +221,7 @@ jobs:
           environment_url: ${{ steps.set-variables.outputs.environment }}
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         id: playwright-cache
         with:
           path: /home/runner/.cache/ms-playwright
@@ -253,7 +253,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: always() && steps.set-variables.outputs.deploy_report == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,8 +11,8 @@ jobs:
     name: Actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           install_args: actionlint shellcheck
           cache: true
@@ -22,8 +22,8 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install_args: gitleaks
           cache: true
@@ -33,8 +33,8 @@ jobs:
     name: Ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c # v7.0.0
       - run: uv run ruff format --check
       - run: uv run ruff check
 
@@ -42,14 +42,14 @@ jobs:
     name: uv
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - run: uv sync --locked --all-extras --dev
 
   yamllint:
     name: Yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - run: uv run yamllint .

--- a/.github/workflows/owasp-zap.yaml
+++ b/.github/workflows/owasp-zap.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Scan Mavis on QA with the OWASP ZAP full scan
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.13.0
+        uses: zaproxy/action-full-scan@bee4e5be916301228d2b1b2dcad73aab6fa6a25b # v0.13.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: https://qa.mavistesting.com/

--- a/.github/workflows/performance-e2e.yaml
+++ b/.github/workflows/performance-e2e.yaml
@@ -74,11 +74,11 @@ jobs:
       # jmeter_home: ${{ github.workspace }}/jmeter-${{ env.jmeter_version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache jmeter
         id: cache-jmeter
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         env:
           cache-name: cache-jmeter
         with:
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload consent journey JMeter output
         if: inputs.runDataPrep == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmeter-consent-journey-output-${{ env.timestamp }}
           path: consent-output
@@ -191,14 +191,14 @@ jobs:
 
       - name: Upload nurse journey JMeter output
         if: inputs.runNurse == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmeter-nurse-journey-output-${{ env.timestamp }}
           path: nurse-output
           if-no-files-found: warn
 
       - name: Publish report to GH Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/performance-large-org.yaml
+++ b/.github/workflows/performance-large-org.yaml
@@ -56,7 +56,7 @@ jobs:
       # jmeter_home: ${{ github.workspace }}/jmeter-${{ env.jmeter_version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # yamllint disable rule:line-length
       - name: Install JMeter
@@ -128,7 +128,7 @@ jobs:
             > ${{ env.large-org-home }}/vaccination.csv.gz
 
       - name: Upload JMeter output
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmeter-large-org-output-${{ env.timestamp }}
           path: large-org-output

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -66,7 +66,7 @@ jobs:
       build-needed: ${{ steps.check-image.outputs.build-needed }}
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole
           aws-region: eu-west-2
@@ -93,13 +93,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole
           aws-region: eu-west-2
       - name: Cache base jmeter image
         id: jmeter-base
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
         env:
           cache-name: cache-jmeter
         with:
@@ -112,7 +112,7 @@ jobs:
           docker save -o ${{ runner.temp }}/jmeter-image.tar base-jmeter-image:latest
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062340a7de7a9da2b919efc70d2a5638c4be725c # v2.0.0
       - name: Build and push performancetest docker image
         # yamllint disable rule:line-length
         run: |
@@ -136,18 +136,18 @@ jobs:
       RESULT_PATH: ${{ github.run_number }}
     steps:
       # yamllint disable rule:line-length
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set timestamp
         run: echo "timestamp=$(date '+%Y%m%d%H%M%S')" >> "$GITHUB_ENV"
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole
           aws-region: eu-west-2
           role-duration-seconds: 32400  # 9 hours
       - name: Create task definition
         id: create-task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@823d5d2ba6624bd7b8690e1d92b5443532ea20af # v1.2.0
         with:
           task-definition-family: "assurance-testing-performance-task-definition-template"
           container-name: "performancetest-container"
@@ -247,21 +247,21 @@ jobs:
 
       - name: Upload nurse journey JMeter output
         if: inputs.runNurse == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmeter-nurse-journey-output-${{ env.timestamp }}
           path: test-results/nurse
           if-no-files-found: warn
       - name: Upload consent journey JMeter output
         if: inputs.runConsent == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jmeter-consent-journey-output-${{ env.timestamp }}
           path: test-results/consent
           if-no-files-found: warn
       - name: Publish report to GH Pages
         if: inputs.runNurse == true
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,8 @@ ignore-from-file: .gitignore
 rules:
   document-start: disable
   line-length:
-    max: 100
+    # Ideally, this value would be smaller, but it makes dealing with long lines
+    #  including commit SHAs, etc. very difficult.
+    max: 120
   truthy:
     ignore: .github/workflows/*


### PR DESCRIPTION
This reduces the risk of supply chain attacks where the tag points to a different commit implicitly without us being aware.

[Jira Issue - MAV-5897](https://nhsd-jira.digital.nhs.uk/browse/MAV-5897)