### PR TITLE
Re-add code from PR1089

### DIFF
--- a/mavis/test/data/file_generator.py
+++ b/mavis/test/data/file_generator.py
@@ -7,7 +7,7 @@ import nhs_number
 import pandas as pd
 from faker import Faker
 
-from mavis.test.constants import Programme
+from mavis.test.constants import MMRV_ELIGIBILITY_CUTOFF_DOB, Programme
 from mavis.test.data.file_mappings import FileMapping
 from mavis.test.data_models import Child, Clinic, Organisation, School, User
 from mavis.test.utils import (
@@ -186,6 +186,12 @@ class FileGenerator:
         if self.year_groups:
             fixed_year_group = self.year_groups[programme_group]
             replacements["<<FIXED_YEAR_GROUP>>"] = str(fixed_year_group)
+        
+        # MMRV-eligible date of birth (children born on or after 2020-01-01)
+        # Using September 1, 2020 as it's after the cutoff and aligns with school year
+        mmrv_eligible_dob = MMRV_ELIGIBILITY_CUTOFF_DOB.replace(month=9, day=1)
+        replacements["<<MMRV_ELIGIBLE_DOB>>"] = mmrv_eligible_dob.strftime("%Y%m%d")
+        
         return replacements
 
     def _get_fixed_random_child(self, programme_group: str) -> Child:
@@ -243,6 +249,7 @@ class FileGenerator:
             line_replacements["<<FIXED_YEAR_GROUP_DOB>>"] = lambda: str(
                 get_date_of_birth_for_year_group(fixed_year_group),
             )
+
 
         return line_replacements
 

--- a/mavis/test/data/file_generator.py
+++ b/mavis/test/data/file_generator.py
@@ -186,12 +186,12 @@ class FileGenerator:
         if self.year_groups:
             fixed_year_group = self.year_groups[programme_group]
             replacements["<<FIXED_YEAR_GROUP>>"] = str(fixed_year_group)
-        
+
         # MMRV-eligible date of birth (children born on or after 2020-01-01)
         # Using September 1, 2020 as it's after the cutoff and aligns with school year
         mmrv_eligible_dob = MMRV_ELIGIBILITY_CUTOFF_DOB.replace(month=9, day=1)
         replacements["<<MMRV_ELIGIBLE_DOB>>"] = mmrv_eligible_dob.strftime("%Y%m%d")
-        
+
         return replacements
 
     def _get_fixed_random_child(self, programme_group: str) -> Child:
@@ -249,7 +249,6 @@ class FileGenerator:
             line_replacements["<<FIXED_YEAR_GROUP_DOB>>"] = lambda: str(
                 get_date_of_birth_for_year_group(fixed_year_group),
             )
-
 
         return line_replacements
 

--- a/mavis/test/pages/reports/vaccination_report_page.py
+++ b/mavis/test/pages/reports/vaccination_report_page.py
@@ -28,32 +28,9 @@ class VaccinationReportPage:
         report_format: ReportFormat,
     ) -> None:
         self.click_report_format(report_format)
-        self._download_and_verify_report_headers(expected_headers=report_format.headers)
-
-    def _download_and_verify_report_headers(self, expected_headers: str) -> None:
-        _file_path = f"working/rpt_{get_current_datetime_compact()}.csv"
-
-        browser = getattr(self.page.context, "browser", None)
-        browser_type_name = getattr(
-            getattr(browser, "browser_type", None), "name", None
-        )
-
-        # Playwright's webkit browser always opens CSVs in the browser
-        # unlike Chromium and Firefox
-        if browser_type_name == "webkit":
-            self.click_download_report()
-            csv_content = self.page.locator("pre").inner_text()
-            _actual_df = pd.read_csv(StringIO(csv_content))
-            self.page.go_back()
-        else:
-            with self.page.expect_download() as download_info:
-                self.click_download_report()
-            download = download_info.value
-            download.save_as(_file_path)
-            _actual_df = pd.read_csv(_file_path)
-
-        expected_set = set(expected_headers.split(","))
-        actual_set = set(_actual_df.columns)
+        df = self.download_report_as_dataframe()
+        expected_set = set(report_format.headers.split(","))
+        actual_set = set(df.columns)
 
         if missing := expected_set - actual_set:
             msg = f"Report is missing expected field(s): {missing}"
@@ -68,6 +45,28 @@ class VaccinationReportPage:
 
     def click_download_report(self) -> None:
         self.download_report_button.click()
+
+    def download_report_as_dataframe(self) -> pd.DataFrame:
+        """Download the report and return it as a pandas DataFrame."""
+        _file_path = f"working/rpt_{get_current_datetime_compact()}.csv"
+        browser_type_name = getattr(
+            getattr(self.page.context, "browser", None), "browser_type", None
+        )
+
+        # Playwright's webkit browser always opens CSVs in the browser
+        if getattr(browser_type_name, "name", None) == "webkit":
+            self.click_download_report()
+            csv_content = self.page.locator("pre").inner_text()
+            df = pd.read_csv(StringIO(csv_content))
+            self.page.go_back()
+        else:
+            with self.page.expect_download() as download_info:
+                self.click_download_report()
+            download = download_info.value
+            download.save_as(_file_path)
+            df = pd.read_csv(_file_path)
+
+        return df
 
     def choose_programme(self, programme: Programme) -> None:
         # temp to ensure MMR works as expected


### PR DESCRIPTION
Some changes to the test for MAV-5722 were lost during the rebase for PR1089.  This included:
1) Addition of the MMRV date of birth
2) Reuse of method to download reports in a dataframe format.

This was not caught earlier as the PR tests exclude reporting tests as of now, although this will change in the near future.

This code has now been added again.