### PR TITLE
Remove school parameter from click_vaccination_details method

### DIFF
--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -77,7 +77,7 @@ class SessionsPatientPage:
             "textbox", name="Pre-screening notes (optional)"
         )
 
-        vaccinations_card = page.get_by_role("table", name="Vaccination records")
+        vaccinations_card = page.get_by_role("table", name="Vaccination outcomes")
         self.vaccinations_card_row = vaccinations_card.get_by_role("row")
         self.withdraw_consent_link = self.page.get_by_role(
             "link", name="Withdraw consent"
@@ -259,12 +259,16 @@ class SessionsPatientPage:
             ),
         ).to_be_visible()
 
-    @step("Click on {1} vaccination details")
-    def click_vaccination_details(self, school: School) -> None:
+    @step("Click on vaccination details")
+    def click_vaccination_details(
+        self, outcome: str | None = None, index: int = 0
+    ) -> None:
         with self.page.expect_navigation():
-            self.vaccinations_card_row.filter(has_text=str(school)).get_by_role(
-                "link",
-            ).click()
+            if outcome:
+                row = self.vaccinations_card_row.filter(has_text=outcome)
+                row.get_by_role("link").nth(index).click()
+            else:
+                self.vaccinations_card_row.get_by_role("link").nth(index).click()
 
     def go_back_to_session_for_school(self, school: School) -> None:
         self.page.get_by_role("link", name=school.name).click()

--- a/tests/test_imms_api_flu.py
+++ b/tests/test_imms_api_flu.py
@@ -129,7 +129,7 @@ def test_create_edit_delete_injected_flu_vaccination_and_verify_imms_api(
     )
 
     # Step 6: Edit outcome to refused
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Synced"
     )
@@ -142,7 +142,7 @@ def test_create_edit_delete_injected_flu_vaccination_and_verify_imms_api(
 
     # Step 7: Verify deletion in IMMS API
     imms_api_helper.check_record_is_not_in_imms_api(Vaccine.SEQUIRUS, child)
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Not synced"
     )
@@ -211,7 +211,7 @@ def test_create_edit_delete_nasal_flu_vaccination_and_verify_imms_api(
     )
 
     # Step 6: Edit outcome to refused
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Synced"
     )
@@ -224,7 +224,7 @@ def test_create_edit_delete_nasal_flu_vaccination_and_verify_imms_api(
 
     # Step 7: Verify deletion in IMMS API
     imms_api_helper.check_record_is_not_in_imms_api(Vaccine.FLUENZ, child)
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).expect_vaccination_details(
         "Synced with NHS England?", "Not synced"
     )

--- a/tests/test_parent_consent.py
+++ b/tests/test_parent_consent.py
@@ -276,5 +276,5 @@ def test_accessibility(
     RecordVaccinationWizardPage(page).click_confirm_button()
     AccessibilityHelper(page).check_accessibility()
 
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     AccessibilityHelper(page).check_accessibility()

--- a/tests/test_vaccination_records.py
+++ b/tests/test_vaccination_records.py
@@ -45,7 +45,6 @@ def test_edit_vaccination_dose_to_not_given_and_bac(
     Verification:
     - Alert confirms vaccination outcome recorded as refused.
     """
-    school = schools[Programme.HPV][0]
     batch_name = setup_gardasil_batch
 
     VaccinationRecordPage(page).click_edit_vaccination_record()
@@ -55,7 +54,7 @@ def test_edit_vaccination_dose_to_not_given_and_bac(
     EditVaccinationRecordPage(page).click_save_changes()
     expect_alert_text(page, "Vaccination outcome recorded for HPV")
 
-    SessionsPatientPage(page).click_vaccination_details(school)
+    SessionsPatientPage(page).click_vaccination_details()
     VaccinationRecordPage(page).click_edit_vaccination_record()
     EditVaccinationRecordPage(page).click_change_outcome()
     EditVaccinationRecordPage(page).click_vaccinated()


### PR DESCRIPTION
In the new patient session page designs, vaccination records are displayed in a table with date links, without school information in the table rows. Remove unused school parameter from click_vaccination_details method. Add outcome and index parameters to support filtering by outcome (e.g. "Vaccinated", "Refused") and selecting specific records