### PR TITLE
Update national reporting import format

### DIFF
--- a/mavis/test/data/import_format_details/national_reporting.txt
+++ b/mavis/test/data/import_format_details/national_reporting.txt
@@ -13,7 +13,7 @@ VACCINE_GIVEN	Required
 
 For HPV records, must be one of: Cervarix, Gardasil or Gardasil9.
 
-For flu records, must be one of: Seqirus Cell-Based Trivalent IIVc, AstraZeneca Fluenz LAIV or Viatris Quadrivalent Influvac sub - unit Tetra - QIVe.
+For flu records, must be one of: AstraZeneca Fluenz LAIV, Seqirus Cell-Based Trivalent IIVc or Viatris Quadrivalent Influvac sub - unit Tetra - QIVe.
 BATCH_NUMBER	Required
 BATCH_EXPIRY_DATE	Required, must use YYYYMMDD format.
 ANATOMICAL_SITE	Required, must be one of: left arm (lower position), left arm (upper position), left buttock, left deltoid, left lower, left lower arm, left thigh, left upper arm, nasal, right arm (lower position), right arm (upper position), right buttock, right deltoid, right lower, right lower arm, right thigh or right upper arm.

--- a/mavis/test/pages/imports/import_records_wizard_page.py
+++ b/mavis/test/pages/imports/import_records_wizard_page.py
@@ -411,9 +411,10 @@ class ImportRecordsWizardPage:
         self.page.wait_for_load_state()
         self.import_format_details_link.click()
         main_content = self.page.get_by_role("main").inner_text()
+
         for line in spec_lines:
             if line not in main_content:
-                missing_line_msg = f"Inconsistent import format details: {line}"
+                missing_line_msg = f"Missing import format details: {line}"
                 raise AssertionError(missing_line_msg)
 
         if import_format_details_mapping is ImportFormatDetails.VACCS:


### PR DESCRIPTION
The flu vaccines will always be shown in alphabetical order.

https://github.com/NHSDigital/manage-vaccinations-in-schools/pull/6597