### PR TITLE
Update test assertion for consent request message visibility

### DIFF
--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -158,7 +158,7 @@ class SessionsPatientPage:
 
         self.click_back()
         expect_details(self.page, "Response", "Invalid")
-        expect(self.page.get_by_text("No requests have been sent.")).to_be_visible()
+        expect(self.page.get_by_text("No consent request is scheduled")).to_be_visible()
 
     @step("Click Back")
     def click_back(self) -> None:


### PR DESCRIPTION
Fixes a QA-reported case where a child added to a session made active today could end up with the programme status "Needs consent - No response" instead of being treated as "Needs consent - Request not scheduled"

The issue was that `status_should_be_request_not_scheduled?` only checked whether `send_consent_requests_at` was missing, and did not account for it already being in the past. That can happen when a new session is created and activated on the same day.

[Jira Issue - MAV-6059](https://nhsd-jira.digital.nhs.uk/browse/MAV-6059)