### PR TITLE
Update patient session page tests for new designs

### DIFF
--- a/mavis/test/constants.py
+++ b/mavis/test/constants.py
@@ -458,6 +458,18 @@ class ConsentMethod(StrEnum):
     IN_PERSON = "In person"
 
 
+class ConsentStatus(StrEnum):
+    GIVEN = "Consent given"
+    REFUSED = "Consent refused"
+    FOLLOW_UP_REQUESTED = "Follow-up requested"
+    CONFLICTS = "Conflicting consent"
+    NO_CONTACT_DETAILS = "No contact details"
+    REQUEST_SCHEDULED = "Request scheduled"
+    REQUEST_NOT_SCHEDULED = "Request not scheduled"
+    NO_RESPONSE = "No response"
+    NOT_REQUIRED = "Not required"
+
+
 class ReportFormat(StrEnum):
     CAREPLUS = "CSV for CarePlus (System C)"
     CSV = "CSV"

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -4,6 +4,7 @@ from mavis.test.annotations import step
 from mavis.test.constants import (
     MAVIS_NOTE_LENGTH_LIMIT,
     ConsentOption,
+    ConsentStatus,
     DeliverySite,
     Programme,
 )
@@ -53,7 +54,7 @@ class SessionsPatientPage:
         )
         self.notes_textbox = self.page.get_by_role("textbox", name="Notes")
         self.record_a_new_consent_response_button = self.page.get_by_role(
-            "button",
+            "link",
             name="Record a new consent response",
         )
         self.ready_for_injection_radio = self.page.locator(
@@ -239,8 +240,23 @@ class SessionsPatientPage:
             ),
         ).to_be_visible()
 
-    def expect_consent_status(self, programme: Programme, status: str) -> None:
-        expect(self.page.get_by_text(f"{programme}: {status}")).to_be_visible()
+    def expect_consent_status(self, status: ConsentStatus | str) -> None:
+        if status is ConsentStatus.GIVEN:
+            expected_text = "is ready for the vaccinator"
+        elif status is ConsentStatus.REFUSED:
+            expected_text = "refused to give consent"
+        elif status is ConsentStatus.FOLLOW_UP_REQUESTED:
+            expected_text = "would like to speak to a member of the team"
+        elif status is ConsentStatus.NO_RESPONSE:
+            expected_text = "No-one responded to our requests"
+        elif status is ConsentStatus.CONFLICTS:
+            expected_text = "You can only vaccinate if all respondents give consent"
+        else:
+            expected_text = str(status)
+        expect(self.page.get_by_text(expected_text, exact=False)).to_be_visible()
+
+    def expect_programme_status(self, status_text: str) -> None:
+        expect(self.page.get_by_text(status_text, exact=False)).to_be_visible()
 
     def expect_consent_recorded_success(self) -> None:
         expect_alert_text(self.page, "Consent recorded")

--- a/tests/test_follow_up_requests.py
+++ b/tests/test_follow_up_requests.py
@@ -3,6 +3,7 @@ import pytest
 from mavis.test.constants import (
     ConsentOption,
     ConsentRefusalReason,
+    ConsentStatus,
     Programme,
     Vaccine,
 )
@@ -182,8 +183,12 @@ def test_consent_refusal_with_follow_up_request(
 
     SessionsChildrenPage(page).click_child(child)
 
-    status = "Follow-up requested" if follow_up_requested else "Consent refused"
-    SessionsPatientPage(page).expect_consent_status(Programme.MMR_MMRV, status)
+    status = (
+        ConsentStatus.FOLLOW_UP_REQUESTED
+        if follow_up_requested
+        else ConsentStatus.REFUSED
+    )
+    SessionsPatientPage(page).expect_consent_status(status)
 
     SessionsPatientPage(page).click_session_activity_and_notes()
 
@@ -290,9 +295,7 @@ def test_follow_up_journey_decision_stands_confirm_refusal(
     SessionsChildrenPage(page).tabs.click_children_tab()
     SessionsChildrenPage(page).click_child(child)
 
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.MMR_MMRV, "Follow-up requested"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.FOLLOW_UP_REQUESTED)
 
     SessionsPatientPage(page).click_response_from_parent(parent)
     ConsentResponseDetailsPage(page).expect_follow_up_available()
@@ -306,9 +309,7 @@ def test_follow_up_journey_decision_stands_confirm_refusal(
     ConsentConfirmRefusalPage(page).expect_refusal_confirmation_success()
 
     SessionsPatientPage(page).click_back()
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.MMR_MMRV, "Consent refused"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.REFUSED)
 
     SessionsPatientPage(page).click_session_activity_and_notes()
 
@@ -377,7 +378,7 @@ def test_follow_up_journey_decision_changed_record_consent(
     SessionsPatientPage(page).expect_consent_recorded_success()
 
     SessionsChildrenPage(page).click_child(child)
-    SessionsPatientPage(page).expect_consent_status("MMR", "Consent given")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.GIVEN)
 
     SessionsPatientPage(page).verify_original_response_invalidated(
         parent, "Consent given in follow-up discussion."
@@ -434,9 +435,7 @@ def test_gillick_self_consent_overrides_follow_up_requested(
     SessionsChildrenPage(page).search.click_on_update_results()
     SessionsChildrenPage(page).click_child(child)
 
-    SessionsPatientPage(page).expect_consent_status(
-        Programme.MMR_MMRV, "Follow-up requested"
-    )
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.FOLLOW_UP_REQUESTED)
 
     SessionsPatientPage(page).click_assess_gillick_competence()
     GillickCompetencePage(page).add_gillick_competence(is_competent=True)
@@ -452,15 +451,15 @@ def test_gillick_self_consent_overrides_follow_up_requested(
 
     SessionsChildrenPage(page).search.select_due_vaccination()
     SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).expect_consent_status("MMR", "Consent given")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.GIVEN)
 
 
 @pytest.mark.parametrize(
     ("parent2_action", "expected_status"),
     [
-        ("given", "Follow-up requested"),
-        ("refused", "Conflicting consent"),
-        ("follow_up", "Follow-up requested"),
+        ("given", ConsentStatus.FOLLOW_UP_REQUESTED),
+        ("refused", ConsentStatus.CONFLICTS),
+        ("follow_up", ConsentStatus.FOLLOW_UP_REQUESTED),
     ],
     ids=[
         "parent_1_follow_up_parent_2_given",
@@ -522,14 +521,14 @@ def test_multiple_parents_with_follow_up_request(
     )
     SessionsChildrenPage(page).tabs.click_children_tab()
 
-    if expected_status == "Conflicting consent":
+    if expected_status == ConsentStatus.CONFLICTS:
         SessionsChildrenPage(page).search.select_has_a_refusal()
         SessionsChildrenPage(page).search.select_conflicting_consent()
     else:
         SessionsChildrenPage(page).search.select_needs_consent()
 
     SessionsChildrenPage(page).search.search_and_click_child(child)
-    SessionsPatientPage(page).expect_consent_status(Programme.MMR_MMRV, expected_status)
+    SessionsPatientPage(page).expect_consent_status(expected_status)
 
     if parent2_action != "follow_up":
         SessionsPatientPage(page).click_response_from_parent(child.parents[1])

--- a/tests/test_parent_consent.py
+++ b/tests/test_parent_consent.py
@@ -3,6 +3,7 @@ import pytest
 from mavis.test.constants import (
     ConsentMethod,
     ConsentRefusalReason,
+    ConsentStatus,
     DeliverySite,
     Programme,
     Vaccine,
@@ -203,7 +204,7 @@ def test_consent_refusal_do_not_want_vaccination_at_school(
     SessionsChildrenPage(page).search.select_consent_refused()
     SessionsChildrenPage(page).search.search_and_click_child(child)
     SessionsPatientPage(page).click_programme_tab(Programme.HPV)
-    SessionsPatientPage(page).expect_consent_status(Programme.HPV, "Consent refused")
+    SessionsPatientPage(page).expect_consent_status(ConsentStatus.REFUSED)
 
 
 @pytest.mark.accessibility

--- a/tests/test_self_consent.py
+++ b/tests/test_self_consent.py
@@ -5,6 +5,7 @@ from mavis.test.constants import (
     MAVIS_NOTE_LENGTH_LIMIT,
     ConsentMethod,
     ConsentOption,
+    ConsentStatus,
     Programme,
 )
 from mavis.test.data import ClassFileMapping
@@ -239,7 +240,7 @@ def test_gillick_override_conflicting_from_parent(
 
     sessions_children_page.search.search_and_click_child(child)
     sessions_patient_page.click_programme_tab(programme)
-    sessions_patient_page.expect_consent_status(programme, "Conflicting consent")
+    sessions_patient_page.expect_consent_status(ConsentStatus.CONFLICTS)
     sessions_patient_page.expect_conflicting_consent_text()
     sessions_patient_page.click_assess_gillick_competence()
     gillick_competence_page.add_gillick_competence(is_competent=True)
@@ -254,12 +255,13 @@ def test_gillick_override_conflicting_from_parent(
     sessions_patient_page.click_programme_tab(programme)
 
     if consent_option == ConsentOption.NASAL_SPRAY_OR_INJECTION:
-        consent_status = "Consent given for nasal spray"
+        programme_status = "is ready to vaccinate (nasal spray preferred)"
     elif consent_option == ConsentOption.MMR_WITHOUT_GELATINE:
-        consent_status = "Consent given for gelatine-free injection"
+        programme_status = "is ready to vaccinate (gelatine-free vaccine only)"
     else:
-        consent_status = "Consent given"
-    sessions_patient_page.expect_consent_status(programme, consent_status)
+        programme_status = "is ready to vaccinate"
+    sessions_patient_page.expect_programme_status(programme_status)
+    sessions_patient_page.expect_consent_status(ConsentStatus.GIVEN)
 
     sessions_patient_page.click_session_activity_and_notes()
     sessions_patient_session_activity_page.check_session_activity_entry(


### PR DESCRIPTION
Adds ConsentStatus enum to standardise consent status values across tests                                                                     Updates expect_consent_status method in SessionsPatientPage to map status values to actual UI text displayed in new patient session designs (e.g. "Consent given" → "is ready for the vaccinator")
Also updates page object locators for new designs