### PR TITLE
Revert "Update test assertion for consent request message visibility"

### DIFF
--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -158,7 +158,7 @@ class SessionsPatientPage:
 
         self.click_back()
         expect_details(self.page, "Response", "Invalid")
-        expect(self.page.get_by_text("No consent request is scheduled")).to_be_visible()
+        expect(self.page.get_by_text("No requests have been sent.")).to_be_visible()
 
     @step("Click Back")
     def click_back(self) -> None:


### PR DESCRIPTION
Reverting this commit as it's related to this [PR](https://github.com/NHSDigital/manage-vaccinations-in-schools/pull/6611) which is also getting reverted.