### PR TITLE
Drop the outcome step from the already had flow

### DIFF
--- a/tests/test_record_already_vaccinated.py
+++ b/tests/test_record_already_vaccinated.py
@@ -91,9 +91,6 @@ def test_eligible(
         record_vaccination_wizard_page.fill_time_of_vaccination("00", "01")
         record_vaccination_wizard_page.click_continue_button()
 
-        record_vaccination_wizard_page.choose_outcome_vaccinated()
-        record_vaccination_wizard_page.click_continue_button()
-
         record_vaccination_wizard_page.fill_vaccination_notes("Test notes")
         record_vaccination_wizard_page.click_confirm_button()
 


### PR DESCRIPTION
The outcome should always be _vaccinated_ so there is no need to ask this question (and it may cause issues if the user changes the default answer)

Updates the E2E tests to work with
https://github.com/NHSDigital/manage-vaccinations-in-schools/pull/6613

Jira-Issue: MAV-6544