### PR TITLE
Reduce test flakiness by getting rid of unnecessary sleeps, and make it harder for them to creep back in

### DIFF
--- a/mavis/test/fixtures/onboarding.py
+++ b/mavis/test/fixtures/onboarding.py
@@ -1,5 +1,4 @@
 import random
-import time
 import urllib.parse
 
 import httpx
@@ -12,6 +11,7 @@ from mavis.test.onboarding import (
     Onboarding,
     PointOfCareOnboarding,
 )
+from mavis.test.utils import deliberate_sleep
 
 
 @pytest.fixture(scope="session")
@@ -51,7 +51,7 @@ def _create_onboarding_with_retry[T: Onboarding](
             "Onboarding request failed (attempt %s): %s", attempt, response.content
         )
         if attempt < max_attempts:
-            time.sleep(1)
+            deliberate_sleep(1, "retry backoff for onboarding API")
         else:
             response.raise_for_status()
 

--- a/mavis/test/helpers/imms_api_helper.py
+++ b/mavis/test/helpers/imms_api_helper.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from datetime import datetime
 from typing import NamedTuple
@@ -10,6 +9,7 @@ from mavis.test.constants import DeliverySite, ImmsEndpoints, Vaccine
 from mavis.test.data.file_utils import create_fhir_immunization_payload
 from mavis.test.data_models import Child, School
 from mavis.test.fixtures.fhir_api import AuthToken
+from mavis.test.utils import deliberate_sleep
 
 
 class ImmsApiVaccinationRecord(NamedTuple):
@@ -99,7 +99,7 @@ class ImmsApiHelper:
             except AssertionError:
                 if attempt == max_attempts - 1:
                     raise
-                time.sleep(3)
+                deliberate_sleep(3, "retry interval for IMMS API polling")
 
     def check_expected_and_actual_records_match(
         self,
@@ -172,7 +172,7 @@ class ImmsApiHelper:
             if attempt == max_attempts - 1:
                 msg = f"Immunization record still found for {child.nhs_number}"
                 raise AssertionError(msg)
-            time.sleep(3)
+            deliberate_sleep(3, "retry interval for IMMS API polling")
 
     def get_raw_api_response_for_child(
         self, vaccine: Vaccine, child: Child

--- a/mavis/test/helpers/pds_api_helper.py
+++ b/mavis/test/helpers/pds_api_helper.py
@@ -3,7 +3,6 @@ import random
 import uuid
 from datetime import date, datetime
 from pathlib import Path
-from time import sleep
 from typing import NamedTuple
 from zoneinfo import ZoneInfo
 
@@ -14,7 +13,7 @@ from dateutil.relativedelta import relativedelta
 from mavis.test.constants import PdsEndpoints, Relationship
 from mavis.test.data_models import Child, Parent
 from mavis.test.fixtures.fhir_api import AuthToken
-from mavis.test.utils import get_todays_date
+from mavis.test.utils import deliberate_sleep, get_todays_date
 
 
 class Patient(NamedTuple):
@@ -113,7 +112,7 @@ class PdsApiHelper:
             checked_nhs_numbers.add(child.nhs_number)
 
             if self._is_valid_child_patient(child):
-                sleep(0.5)
+                deliberate_sleep(0.5, "rate limiting between PDS API calls")
                 break
 
         return Child(

--- a/mavis/test/helpers/sidekiq_helper.py
+++ b/mavis/test/helpers/sidekiq_helper.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import httpx
 
+from mavis.test.utils import deliberate_sleep
+
 
 class SidekiqHelper:
     def __init__(self) -> None:
@@ -117,13 +119,15 @@ class SidekiqHelper:
             except TimeoutError:
                 # Polling failed, fall back to time-based wait for remaining time
                 remaining_time = max(30, min(timeout - 60, 120))
-                time.sleep(remaining_time)
+                deliberate_sleep(
+                    remaining_time, "fallback wait after Sidekiq polling failed"
+                )
         else:
             # If stats unavailable, wait for reasonable portion of timeout
             wait_time = min(
                 timeout, 60
             )  # Wait up to 60 seconds or timeout, whichever is less
-            time.sleep(wait_time)
+            deliberate_sleep(wait_time, "Sidekiq stats unavailable, waiting for job")
 
     def _poll_for_completion(self, initial_enqueued: int, timeout: int) -> None:
         """Poll Sidekiq stats for job completion within timeout period."""
@@ -132,7 +136,7 @@ class SidekiqHelper:
         poll_interval = 2  # Check every 2 seconds
 
         # Give some time for the job to be enqueued initially
-        time.sleep(1)
+        deliberate_sleep(1, "grace period before Sidekiq job polling")
 
         while time.time() - start_time < timeout:
             try:
@@ -171,7 +175,7 @@ class SidekiqHelper:
                 pass
 
             # Wait before next check
-            time.sleep(poll_interval)
+            deliberate_sleep(poll_interval, "Sidekiq polling interval")
 
         # If we reach here, job didn't complete within timeout
         msg = f"Job did not complete within {timeout} seconds"

--- a/mavis/test/pages/reports/reports_vaccinations_page.py
+++ b/mavis/test/pages/reports/reports_vaccinations_page.py
@@ -1,6 +1,5 @@
 import os
 import re
-import time
 
 import httpx
 from playwright.sync_api import Page
@@ -11,6 +10,7 @@ from mavis.test.pages.reports.reports_dashboard_component import (
     ReportsDashboardComponent,
 )
 from mavis.test.pages.reports.reports_tabs import ReportsTabs
+from mavis.test.utils import reload_until_element_is_visible
 
 
 class ReportsVaccinationsPage(ReportsDashboardComponent):
@@ -36,8 +36,11 @@ class ReportsVaccinationsPage(ReportsDashboardComponent):
         response = httpx.get(refresh_reports_url, timeout=30)
         response.raise_for_status()
 
-        time.sleep(5)
-        self.page.reload()
+        reload_until_element_is_visible(
+            self.page,
+            self.page.locator(".nhsuk-card__content").first,
+            seconds=15,
+        )
 
     def get_children_count(self, category: str) -> int:
         category_card = self.page.locator(

--- a/mavis/test/pages/search_components/base_search_component.py
+++ b/mavis/test/pages/search_components/base_search_component.py
@@ -24,3 +24,4 @@ class BaseSearchComponent:
     @step("Click on Update results")
     def click_on_update_results(self) -> None:
         self.update_results_button.click()
+        self.page.wait_for_load_state()

--- a/mavis/test/pages/sessions/nurse_consent_wizard_page.py
+++ b/mavis/test/pages/sessions/nurse_consent_wizard_page.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from mavis.test.annotations import step
 from mavis.test.constants import (
@@ -188,6 +188,7 @@ class NurseConsentWizardPage:
 
     @step("Click on Yes, they agree")
     def click_yes_they_agree(self) -> None:
+        expect(self.yes_they_agree_radio).to_be_visible()
         self.yes_they_agree_radio.check()
 
     @step("Click on No, they do not agree")
@@ -198,6 +199,7 @@ class NurseConsentWizardPage:
     def select_gillick_competent_child(self) -> None:
         self.child_gillick_competent_radio.check()
         self.click_continue()
+        self.page.wait_for_load_state()
 
     @step("Click on Yes, for the nasal spray")
     def click_yes_for_nasal_spray(self) -> None:

--- a/mavis/test/pages/sessions/sessions_children_page.py
+++ b/mavis/test/pages/sessions/sessions_children_page.py
@@ -74,10 +74,10 @@ class SessionsChildrenPage:
         additional_text: str | None = None,
     ) -> None:
         child_locator = self.search.get_patient_card_locator(child)
-        programme_status_section = child_locator.locator(f"p:has-text('{programme}')")
+        programme_status_section = child_locator.locator(
+            f"p:has-text('{programme}')", has_text=status
+        )
         reload_until_element_is_visible(self.page, programme_status_section)
-
-        expect(programme_status_section).to_contain_text(status)
         if additional_text:
             additional_text_locator = programme_status_section.get_by_text(
                 additional_text

--- a/mavis/test/pages/sessions/sessions_overview_page.py
+++ b/mavis/test/pages/sessions/sessions_overview_page.py
@@ -1,5 +1,4 @@
 import re
-import time
 from datetime import date
 from pathlib import Path
 
@@ -87,8 +86,7 @@ class SessionsOverviewPage:
     @step("Go to Edit session page")
     def schedule_or_edit_session(self) -> None:
         locator = self.schedule_sessions_link.or_(self.edit_session_link).first
-        # temporary wait to prevent page not found error
-        time.sleep(1)
+        expect(locator).to_be_visible()
         locator.click()
 
     @step("Click on Schedule sessions")

--- a/mavis/test/pages/sessions/sessions_patient_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_page.py
@@ -1,5 +1,3 @@
-import time
-
 from playwright.sync_api import Page, expect
 
 from mavis.test.annotations import step
@@ -198,8 +196,6 @@ class SessionsPatientPage:
 
     @step("Click on Record a new consent response")
     def click_record_a_new_consent_response(self) -> None:
-        # temporary wait before clicking the button to prevent errors
-        time.sleep(1)
         self.record_a_new_consent_response_button.click()
 
     @step("Go back to Record Vaccinations")
@@ -229,9 +225,6 @@ class SessionsPatientPage:
         for check in programme.pre_screening_checks(consent_option):
             locator = self.pre_screening_listitem.get_by_text(check)
             expect(locator).to_be_visible()
-
-        # need to wait for checkbox to load properly
-        time.sleep(1)
 
         expect(self.pre_screening_checkbox).to_be_editable()
         self.pre_screening_checkbox.check()

--- a/mavis/test/pages/sessions/sessions_patient_session_activity_page.py
+++ b/mavis/test/pages/sessions/sessions_patient_session_activity_page.py
@@ -45,7 +45,10 @@ class SessionsPatientSessionActivityPage:
         reload_until_element_is_visible(self.page, self.page.get_by_text(note))
 
     def check_session_activity_entry(self, text: str) -> None:
-        expect(self.page.get_by_role("heading", name=text).first).to_be_visible()
+        # Some activity entries (e.g. notification confirmations) are created by
+        # background jobs and may not appear immediately after page navigation.
+        heading = self.page.get_by_role("heading", name=text).first
+        reload_until_element_is_visible(self.page, heading)
 
     @step("Go back to Session")
     def click_back_to_session(self, location: Location) -> None:

--- a/mavis/test/utils.py
+++ b/mavis/test/utils.py
@@ -193,6 +193,11 @@ def normalize_postcode(postcode: str) -> str:
 DEFAULT_TIMEOUT_SECONDS = 30
 
 
+def deliberate_sleep(seconds: float, reason: str) -> None:  # noqa: ARG001
+    """Sleep that requires a documented reason. Use only when no better wait exists."""
+    time.sleep(seconds)
+
+
 @step("Reload page until {1} is visible", page_object=False)
 def reload_until_element_is_visible(
     page: Page, tag: Locator, seconds: int = DEFAULT_TIMEOUT_SECONDS
@@ -201,7 +206,7 @@ def reload_until_element_is_visible(
         if tag.is_visible():
             break
 
-        time.sleep(0.5)
+        deliberate_sleep(0.5, "polling interval for reload loop")
 
         page.reload()
     else:
@@ -216,7 +221,7 @@ def reload_until_element_is_not_visible(
         if not tag.is_visible():
             break
 
-        time.sleep(0.5)
+        deliberate_sleep(0.5, "polling interval for reload loop")
 
         page.reload()
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,12 @@ ignore = [
 "mavis/test/imms_api.py" = [
   "S101",     # assertions are used here, though perhaps this file could be moved
 ]
+"mavis/test/utils.py" = [
+  "TID251",   # deliberate_sleep wraps time.sleep — the one allowed call site
+]
 "utils/*" = [
   "ALL",      # small utilities can be safely ignored
 ]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"time.sleep".msg = "Use deliberate_sleep(seconds, reason) from mavis.test.utils instead."

--- a/tests/test_e2e_doubles.py
+++ b/tests/test_e2e_doubles.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from mavis.test.constants import Programme, Vaccine
@@ -15,6 +13,7 @@ from mavis.test.pages import (
     SessionsSearchPage,
     StartPage,
 )
+from mavis.test.utils import deliberate_sleep
 
 
 @pytest.fixture
@@ -117,9 +116,7 @@ def test_recording_doubles_vaccination_e2e(
         schools[0],
     )
 
-    # The button to download the offline spreadsheet prevents double clicks.
-    # We need to wait here to avoid the second click being ignored.
-    time.sleep(1)
+    deliberate_sleep(1, "download button debounce — wait_for_load_state not sufficient")
 
     SessionsOverviewPage(page).verify_offline_sheet_vaccination_row(
         td_ipv_vaccination_record,

--- a/tests/test_reporting_regression.py
+++ b/tests/test_reporting_regression.py
@@ -1,5 +1,4 @@
 import random
-import time
 import urllib.parse
 from datetime import UTC, datetime
 
@@ -29,6 +28,7 @@ from mavis.test.pages import (
     SessionsOverviewPage,
 )
 from mavis.test.pages.utils import schedule_school_session_if_needed
+from mavis.test.utils import deliberate_sleep
 
 pytestmark = pytest.mark.reporting
 
@@ -50,7 +50,7 @@ def _refresh_reporting(base_url):
     url = urllib.parse.urljoin(base_url, "api/testing/refresh-reporting")
     response = httpx.get(url, timeout=30)
     response.raise_for_status()
-    time.sleep(5)
+    deliberate_sleep(5, "backend reporting job has no observable completion signal")
 
 
 def _make_file_generator(onboarding, children_list):


### PR DESCRIPTION
* 2e49fdd6f9133df0e36f1d2d6bedf6d40c8d04c2 replaces a few sleeps and flaky parts of the page objects with more robust Playwright functionality
* 134aa959c1e064e7d1e8dedcb2e90d4521aac28f creates a wrapper for `time.sleep`, and adds a Ruff ban on `time.sleep` to prevent stray sleeps from creeping back in. You can still override the ban by using the wrapper with an explanation