### PR TITLE
Use synchronous refresh-reporting endpoint instead of sleep

### DIFF
--- a/mavis/test/pages/reports/reports_vaccinations_page.py
+++ b/mavis/test/pages/reports/reports_vaccinations_page.py
@@ -10,7 +10,6 @@ from mavis.test.pages.reports.reports_dashboard_component import (
     ReportsDashboardComponent,
 )
 from mavis.test.pages.reports.reports_tabs import ReportsTabs
-from mavis.test.utils import deliberate_sleep, reload_until_element_is_visible
 
 
 class ReportsVaccinationsPage(ReportsDashboardComponent):
@@ -33,18 +32,11 @@ class ReportsVaccinationsPage(ReportsDashboardComponent):
         self.navigate()
 
         base_url = os.getenv("BASE_URL", "PROVIDEURL")
-        refresh_reports_url = f"{base_url}/api/testing/refresh-reporting"
-        response = httpx.get(refresh_reports_url, timeout=30)
+        refresh_reports_url = f"{base_url}/api/testing/refresh-reporting?wait=true"
+        response = httpx.get(refresh_reports_url, timeout=60)
         response.raise_for_status()
 
-        deliberate_sleep(5, "the refresh endpoint doesn't tell us when it has finished")
         self.page.reload()
-
-        reload_until_element_is_visible(
-            self.page,
-            self.page.locator(".nhsuk-card__content").first,
-            seconds=15,
-        )
 
     def get_children_count(self, category: str) -> int:
         category_card = self.page.locator(

--- a/tests/test_reporting_regression.py
+++ b/tests/test_reporting_regression.py
@@ -28,7 +28,6 @@ from mavis.test.pages import (
     SessionsOverviewPage,
 )
 from mavis.test.pages.utils import schedule_school_session_if_needed
-from mavis.test.utils import deliberate_sleep
 
 pytestmark = pytest.mark.reporting
 
@@ -47,10 +46,9 @@ def _onboard_team(base_url):
 
 
 def _refresh_reporting(base_url):
-    url = urllib.parse.urljoin(base_url, "api/testing/refresh-reporting")
-    response = httpx.get(url, timeout=30)
+    url = urllib.parse.urljoin(base_url, "api/testing/refresh-reporting?wait=true")
+    response = httpx.get(url, timeout=60)
     response.raise_for_status()
-    deliberate_sleep(5, "backend reporting job has no observable completion signal")
 
 
 def _make_file_generator(onboarding, children_list):


### PR DESCRIPTION
Pass ?wait=true to the refresh-reporting API so the call blocks until the materialised view is refreshed, removing the need for deliberate_sleep(5).

Relies on https://github.com/NHSDigital/manage-vaccinations-in-schools/pull/6649