### PR TITLE
Attempted fix for flaky test_create_child_record_from_consent_with_nhs_number test

### DIFF
--- a/mavis/test/pages/children/child_record_page.py
+++ b/mavis/test/pages/children/child_record_page.py
@@ -5,7 +5,12 @@ from playwright.sync_api import Locator, Page, expect
 from mavis.test.annotations import step
 from mavis.test.constants import Programme
 from mavis.test.pages.header_component import HeaderComponent
-from mavis.test.utils import click_secondary_navigation_item, get_todays_date
+from mavis.test.utils import (
+    click_secondary_navigation_item,
+    format_nhs_number,
+    get_todays_date,
+    reload_until_element_is_visible,
+)
 
 
 class ChildRecordPage:
@@ -50,6 +55,15 @@ class ChildRecordPage:
 
     def check_child_is_unarchived(self) -> None:
         expect(self.archive_child_record_link).to_be_visible()
+
+    def expect_nhs_number(self, nhs_number: str) -> None:
+        """Wait for the NHS number to appear, reloading if necessary.
+
+        The NHS number may be populated by a background PDS lookup after
+        record creation, so the page may initially show "Not provided".
+        """
+        formatted = format_nhs_number(nhs_number)
+        reload_until_element_is_visible(self.page, self.page.get_by_text(formatted))
 
     def _link_for_vaccination_record(self, date: datetime.date) -> Locator:
         return self.vaccinations_card.filter(

--- a/tests/test_consent_responses.py
+++ b/tests/test_consent_responses.py
@@ -30,7 +30,7 @@ from mavis.test.pages import (
     UnmatchedConsentResponsesPage,
 )
 from mavis.test.pages.utils import schedule_school_session_if_needed
-from mavis.test.utils import expect_alert_text, expect_details, format_nhs_number
+from mavis.test.utils import expect_alert_text, expect_details
 
 
 @pytest.fixture(scope="session")
@@ -206,7 +206,7 @@ def test_create_child_record_from_consent_with_nhs_number(
     DashboardPage(page).click_children()
     ChildrenSearchPage(page).search.search_for_child_name_with_all_filters(str(child))
     ChildrenSearchPage(page).search.click_child(child)
-    expect_details(page, "NHS number", format_nhs_number(child.nhs_number))
+    ChildRecordPage(page).expect_nhs_number(child.nhs_number)
     ChildRecordPage(page).click_programme(Programme.HPV)
     ChildProgrammePage(page).verify_activity_log_for_created_or_matched_child()
 


### PR DESCRIPTION
Here are the 4 runs where `test_create_child_record_from_consent_with_nhs_number` was flaky or failed:

 - https://github.com/NHSDigital/manage-vaccinations-in-schools/actions/runs/24708301926
 - https://github.com/NHSDigital/manage-vaccinations-in-schools/actions/runs/24707526889
 - https://github.com/NHSDigital/manage-vaccinations-in-schools/actions/runs/24673782359
 - https://github.com/NHSDigital/manage-vaccinations-in-schools/actions/runs/24520285738

The attempted fix is to poll for NHS number after PDS lookup in consent response test.

The PDS lookup that populates the NHS number runs as a background job after record creation. Add `ChildRecordPage.expect_nhs_number()` which polls with reload until the number appears, instead of failing on stale "Not provided" text.