### PR TITLE
Move merge log entries to child record page

### DIFF
--- a/mavis/test/pages/children/child_record_page.py
+++ b/mavis/test/pages/children/child_record_page.py
@@ -61,6 +61,17 @@ class ChildRecordPage:
     def click_vaccination_record(self, date: datetime.date | None = None) -> None:
         self._click_vaccination_record(date or get_todays_date())
 
+    @step("Checking for '{1}' in the activity log")
+    def expect_activity_log_entry(
+        self, heading_name: str, *, unique: bool = False
+    ) -> None:
+        heading = self.page.get_by_role("heading", name=heading_name)
+
+        if unique:
+            expect(heading).to_be_visible()
+        else:
+            expect(heading.first).to_be_visible()
+
     @step("Click on {1} vaccination record")
     def _click_vaccination_record(self, date: datetime.date) -> None:
         self.page.wait_for_load_state()

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -198,10 +198,7 @@ def test_merge_child_records_does_not_crash(
     DashboardPage(page).click_children()
     ChildrenSearchPage(page).search.search_for_child_name_with_all_filters(str(child2))
     ChildrenSearchPage(page).search.click_child(child2)
-    ChildRecordPage(page).click_programme(Programme.HPV)
-    ChildProgrammePage(page).expect_activity_log_entry(
-        "Child record merged", unique=True
-    )
+    ChildRecordPage(page).expect_activity_log_entry("Child record merged", unique=True)
 
 
 @issue("MAV-909", "MAV-1716")


### PR DESCRIPTION
Generic entries are moved to the the Child record tab in a separate activity log.