### PR TITLE
Update `DOSE_SEQUENCE` validation message in test data file

### DIFF
--- a/mavis/test/data/vaccs/o_negative.txt
+++ b/mavis/test/data/vaccs/o_negative.txt
@@ -39,7 +39,7 @@ Row 37 CARE_SETTING: Enter a valid care setting.
 Row 38 TIME_OF_VACCINATION: Enter a time in the past.
 Row 39 REASON_NOT_VACCINATED: must be blank
 Row 41 DOSE_SEQUENCE: must be less than or equal to 6
-Row 42 DOSE_SEQUENCE: Enter a dose sequence number, for example, 1, 2 or 3. The dose sequence number cannot be greater than 6.
+Row 42 DOSE_SEQUENCE: Enter a dose sequence number, for example, 1, 2 or 3
 Row 43 DOSE_SEQUENCE: must be less than or equal to 3
 Row 44 BATCH_NUMBER: must be at most 100 characters long
 Row 45 DOSE_SEQUENCE: must be less than or equal to 2


### PR DESCRIPTION
Following a [fix](https://github.com/NHSDigital/manage-vaccinations-in-schools/pull/6560) to the MMR dose sequence validation in Mavis, simplify the test data error message so the example values now align with the maximum allowed dose sequence.