### PR TITLE
Add an unstable label to flaky tests

### DIFF
--- a/.github/actions/run-end-to-end-tests/action.yml
+++ b/.github/actions/run-end-to-end-tests/action.yml
@@ -3,9 +3,6 @@ description: Execute tests
 inputs:
   tests:
     default: ''
-  github_ref:
-    default: 'main'
-    required: false
   accessibility_tests:
     default: 'false'
   reporting_tests:
@@ -14,6 +11,9 @@ inputs:
     default: 'false'
   pds_api_tests:
     default: 'false'
+  unstable_tests:
+    description: 'Configure whether to include unstable (flaky) tests'
+    default: 'exclude'
   device:
     required: true
   base_url:
@@ -76,6 +76,19 @@ runs:
             exclude="$exclude and not pds_api"
           else
             exclude="not pds_api"
+          fi
+        fi
+        if [ "${{ inputs.unstable_tests }}" = "only" ]; then
+          if [ -n "$exclude" ]; then
+            exclude="unstable and $exclude"
+          else
+            exclude="unstable"
+          fi
+        else
+          if [ -n "$exclude" ]; then
+            exclude="$exclude and not unstable"
+          else
+            exclude="not unstable"
           fi
         fi
         if [ -z "$exclude" ]; then

--- a/.github/workflows/end-to-end-tests-release.yaml
+++ b/.github/workflows/end-to-end-tests-release.yaml
@@ -182,7 +182,19 @@ jobs:
       contents: write
       id-token: write
 
-    name: End-to-End tests
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - label: main
+            unstable_tests: exclude
+            continue_on_error: false
+          - label: unstable (failure accepted)
+            unstable_tests: only
+            continue_on_error: true
+
+    continue-on-error: ${{ matrix.suite.continue_on_error }}
+    name: End-to-End tests (${{ matrix.suite.label }})
     runs-on: ubuntu-latest
 
     env:
@@ -265,7 +277,7 @@ jobs:
           imms_api_tests: ${{ steps.set-variables.outputs.fhir_api_tests }}
           pds_api_tests: ${{ steps.set-variables.outputs.fhir_api_tests }}
           reporting_tests: ${{ steps.set-variables.outputs.reporting_tests }}
-          github_ref: ${{ inputs.github_ref || github.head_ref }}
+          unstable_tests: ${{ matrix.suite.unstable_tests }}
           device: ${{ steps.set-variables.outputs.device }}
           base_url: ${{ steps.set-variables.outputs.environment }}
           screenshot_all_steps: ${{ steps.set-variables.outputs.screenshot_all_steps }}
@@ -296,14 +308,18 @@ jobs:
             ${{ steps.set-variables.outputs.jira_test_cycle_version }}
 
       - name: Configure AWS credentials
-        if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        if: >-
+          always() && steps.set-variables.outputs.deploy_report == 'true'
+          && matrix.suite.label == 'main'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole
 
       - name: Process reports
-        if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        if: >-
+          always() && steps.set-variables.outputs.deploy_report == 'true'
+          && matrix.suite.label == 'main'
         continue-on-error: true
         uses: ./.github/actions/deploy-reports
         with:

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -170,7 +170,19 @@ jobs:
       contents: write
       id-token: write
 
-    name: End-to-End tests
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - label: main
+            unstable_tests: exclude
+            continue_on_error: false
+          - label: unstable (failure accepted)
+            unstable_tests: only
+            continue_on_error: true
+
+    continue-on-error: ${{ matrix.suite.continue_on_error }}
+    name: End-to-End tests (${{ matrix.suite.label }})
     runs-on: ubuntu-latest
 
     env:
@@ -249,7 +261,7 @@ jobs:
           imms_api_tests: ${{ steps.set-variables.outputs.fhir_api_tests }}
           pds_api_tests: ${{ steps.set-variables.outputs.fhir_api_tests }}
           reporting_tests: ${{ steps.set-variables.outputs.reporting_tests }}
-          github_ref: ${{ inputs.github_ref || github.head_ref }}
+          unstable_tests: ${{ matrix.suite.unstable_tests }}
           device: ${{ steps.set-variables.outputs.device }}
           base_url: ${{ steps.set-variables.outputs.environment }}
           screenshot_all_steps: ${{ steps.set-variables.outputs.screenshot_all_steps }}
@@ -267,14 +279,18 @@ jobs:
           IMMS_API_PEM: ${{ secrets.IMMS_API_PEM }}
 
       - name: Configure AWS credentials
-        if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        if: >-
+          always() && steps.set-variables.outputs.deploy_report == 'true'
+          && matrix.suite.label == 'main'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole
 
       - name: Process reports
-        if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        if: >-
+          always() && steps.set-variables.outputs.deploy_report == 'true'
+          && matrix.suite.label == 'main'
         continue-on-error: true
         uses: ./.github/actions/deploy-reports
         with:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,31 @@ Some tests are grouped using markers. You can include/exclude groups with the
 $ pytest -m log_in
 $ pytest -m "not imms_api and not pds_api and not accessibility"
 ```
+
+#### Unstable tests
+
+Tests that are known to be flaky can be marked with `@pytest.mark.unstable`
+(or by adding `unstable` to a module-level `pytestmark`). The `unstable`
+marker is excluded from the default test run in the E2E test workflow,
+so these tests do not affect local runs or the main pipeline result unless explicitly requested:
+
+```shell
+$ pytest -m unstable          # run only the unstable tests
+$ pytest -m "not unstable"    # explicitly exclude them (the default)
+```
+
+In the End-to-End tests workflow, unstable tests run in a separate matrix
+job (`End-to-End tests (unstable (failure accepted))`) which has
+`continue-on-error: true`. This means failures in unstable tests will not
+fail the pipeline, while the main job continues to enforce stability for
+all other tests. The `run-end-to-end-tests` action accepts an
+`unstable_tests` input with values `exclude` (default) or `only` to
+control which suite is executed.
+
+Use this marker sparingly — it is intended as a temporary measure for
+genuinely flaky tests while the underlying issue is being investigated,
+not as a way to silence failures. Fixing tests with the unstable label should be a priority.
+
 #### Parallel test execution
 
 This repository uses [pytest-xdist] to run test modules in parallel. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ markers = [
   "pds_api",
   "reporting",
   "smoke",
+  "unstable",
 ]
 
 [tool.ruff]

--- a/tests/test_reporting_regression.py
+++ b/tests/test_reporting_regression.py
@@ -29,7 +29,7 @@ from mavis.test.pages import (
 )
 from mavis.test.pages.utils import schedule_school_session_if_needed
 
-pytestmark = pytest.mark.reporting
+pytestmark = [pytest.mark.reporting]
 
 _yg1, _yg2, _yg3 = random.sample(list(range(7, 12)), 3)
 _year_groups = {p.group: _yg1 for p in Programme}


### PR DESCRIPTION
- Create a label to denote which tests are unstable
- Allow tests to fail by running in a separate workflow