### PR TITLE
Use new Sidekiq schedule name in IMMS sync test to fix it

### DIFF
--- a/tests/test_imms_api_sync.py
+++ b/tests/test_imms_api_sync.py
@@ -78,7 +78,7 @@ def test_create_imms_record_then_verify_on_children_page(
     vaccination_time = vaccination_date.replace(
         hour=10, minute=30, second=0, microsecond=0
     )
-    sidekiq_job_name = "enqueue_vaccinations_search_in_nhs_job"
+    sidekiq_job_name = "EnqueueVaccinationsSearchInNHSJob"
 
     # Create vaccination record via IMMS API
     imms_api_helper.create_vaccination_record(


### PR DESCRIPTION
The Mavis app repo PR #6690 (commit [dd7edc9f8](https://github.com/NHSDigital/manage-vaccinations-in-schools/commit/dd7edc9f8) "Use job names as schedule names") renamed every Sidekiq schedule key in `config/sidekiq.yml` from snake_case to CamelCase job class names.

This test still referenced the old key `enqueue_vaccinations_search_in_nhs_job`. After the rename, Sidekiq Scheduler's `/recurring-jobs/{name}/enqueue` endpoint silently no-ops on unknown names, so the sync job never ran. The test then waited and asserted on the UI, which still showed "Needs consent" because Mavis had no record of the IMMS-created vaccination.