### PR TITLE
Clarify MMR historical dose sequence validation message

### DIFF
--- a/mavis/test/data/vaccs/o_negative.txt
+++ b/mavis/test/data/vaccs/o_negative.txt
@@ -22,7 +22,7 @@ Row 23 BATCH_NUMBER: Enter a batch number.
 Row 24 BATCH_EXPIRY_DATE: Enter a batch expiry date.
 Row 25 ANATOMICAL_SITE: Enter an anatomical site.
 Row 26 ANATOMICAL_SITE: Enter a anatomical site that is appropriate for the vaccine.
-Row 27 DOSE_SEQUENCE: Enter a dose sequence number, for example, 1, 2 or 3.
+Row 27 DOSE_SEQUENCE: The dose sequence number cannot be greater than 3. Enter a dose sequence number, for example, 1, 2 or 3.
 Row 28 DOSE_SEQUENCE: must be less than or equal to 3
 !Row 29 DATE_OF_VACCINATION: Enter a date for a current session
 Row 30 PERFORMING_PROFESSIONAL_EMAIL: Enter a valid email address.


### PR DESCRIPTION
Make the validation error for invalid MMR historical dose sequence values more consistent when uploading vaccination records.

Before this change, invalid values such as `3` and `2B` could show different error messages. This change updates the wording so they now both show the same message explaining that the dose sequence cannot be greater than 2.

This follows on from https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/pull/1136.
