### PR TITLE
Attempt to fix flakiness in the `test_reporting_regression` test

### DIFF
--- a/mavis/test/data_models.py
+++ b/mavis/test/data_models.py
@@ -66,15 +66,17 @@ class School(Location):
 
     @classmethod
     def get_from_testing_api(
-        cls, base_url: str, year_groups: dict[str, int]
+        cls, base_url: str, year_groups: dict[str, list[int]]
     ) -> "dict[str, list[School]]":
-        def _get_schools_with_year_group(year_group: int) -> list[School]:
+        def _get_schools_with_year_groups(
+            required_year_groups: list[int],
+        ) -> list[School]:
             url = urllib.parse.urljoin(base_url, "api/testing/locations")
             params = {
                 "type": "gias_school",
                 "status": "open",
                 "is_attached_to_team": "false",
-                "gias_year_groups[]": [str(year_group)],
+                "gias_year_groups[]": [str(yg) for yg in required_year_groups],
                 "site": "",
             }
 
@@ -91,8 +93,8 @@ class School(Location):
             data = response.json()
             if not data:
                 msg = (
-                    f"No schools found with year group {year_group} at {base_url}. "
-                    "Have GIAS locations been loaded? "
+                    f"No schools found with year groups {required_year_groups} "
+                    f"at {base_url}. Have GIAS locations been loaded? "
                     "Try running 'bin/mavis gias import' from the Mavis repository."
                 )
                 raise RuntimeError(msg)
@@ -112,7 +114,7 @@ class School(Location):
             ]
 
         return {
-            programme.group: _get_schools_with_year_group(year_groups[programme.group])
+            programme.group: _get_schools_with_year_groups(year_groups[programme.group])
             for programme in Programme
         }
 

--- a/mavis/test/fixtures/onboarding.py
+++ b/mavis/test/fixtures/onboarding.py
@@ -24,7 +24,8 @@ def year_groups() -> dict[str, int]:
 @pytest.fixture(scope="session")
 def point_of_care_onboarding(base_url, year_groups) -> PointOfCareOnboarding:
     onboarding_data = PointOfCareOnboarding.get_onboarding_data_for_tests(
-        base_url=base_url, year_groups=year_groups
+        base_url=base_url,
+        year_groups={k: [v] for k, v in year_groups.items()},
     )
     return _create_onboarding_with_retry(base_url, onboarding_data)
 

--- a/mavis/test/onboarding.py
+++ b/mavis/test/onboarding.py
@@ -61,7 +61,7 @@ class PointOfCareOnboarding(Onboarding):
 
     @classmethod
     def get_onboarding_data_for_tests(
-        cls, base_url: str, year_groups: dict[str, int]
+        cls, base_url: str, year_groups: dict[str, list[int]]
     ) -> "PointOfCareOnboarding":
         organisation = Organisation.generate()
         subteam = Subteam.generate()

--- a/tests/test_reporting_regression.py
+++ b/tests/test_reporting_regression.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.reporting
 
 _yg1, _yg2, _yg3 = random.sample(list(range(7, 12)), 3)
 _year_groups = {p.group: _yg1 for p in Programme}
+_school_year_groups = {p.group: [_yg1, _yg2, _yg3] for p in Programme}
 
 _setup_complete = False
 
@@ -40,7 +41,7 @@ _setup_complete = False
 def _onboard_team(base_url):
     onboarding = PointOfCareOnboarding.get_onboarding_data_for_tests(
         base_url=base_url,
-        year_groups=_year_groups,
+        year_groups=_school_year_groups,
     )
     return _create_onboarding_with_retry(base_url, onboarding)
 


### PR DESCRIPTION
`test_reporting_regression` picks three random year groups and uses them across two teams' class list uploads. Schools were fetched via `School.get_from_testing_api`, which only filtered by `_yg1` (the first year group). The returned pool included schools that didn't necessarily contain `_yg2` or `_yg3`.

When the test then tried to upload a class list to a school for `_yg2`, the wizard's year-group selection page legitimately rendered without that checkbox (the school doesn't offer that year group), and Playwright waited 30s for an element that was never going to appear. The failure cascaded across the 6 sibling tests via the shared `_setup_complete` guard.

The Mavis testing locations endpoint already supports list-based filtering. The Python helper just wasn't using it.

This change passes all required year groups so the returned school pool is constrained to schools that contain every year group the test will use.