### PR TITLE
Change label for unstable job

### DIFF
--- a/.github/workflows/end-to-end-tests-release.yaml
+++ b/.github/workflows/end-to-end-tests-release.yaml
@@ -189,7 +189,7 @@ jobs:
           - label: main
             unstable_tests: exclude
             continue_on_error: false
-          - label: unstable (failure accepted)
+          - label: unstable — failure accepted
             unstable_tests: only
             continue_on_error: true
 

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -177,7 +177,7 @@ jobs:
           - label: main
             unstable_tests: exclude
             continue_on_error: false
-          - label: unstable (failure accepted)
+          - label: unstable — failure accepted
             unstable_tests: only
             continue_on_error: true
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ pytest -m "not unstable"    # explicitly exclude them (the default)
 ```
 
 In the End-to-End tests workflow, unstable tests run in a separate matrix
-job (`End-to-End tests (unstable (failure accepted))`) which has
+job (`End-to-End tests (unstable — failure accepted)`) which has
 `continue-on-error: true`. This means failures in unstable tests will not
 fail the pipeline, while the main job continues to enforce stability for
 all other tests. The `run-end-to-end-tests` action accepts an


### PR DESCRIPTION
The double brackets was making me sad.

> End-to-End tests (unstable (failure accepted))