### PR TITLE
Mark unstable tests

### DIFF
--- a/tests/test_follow_up_requests.py
+++ b/tests/test_follow_up_requests.py
@@ -402,6 +402,7 @@ def test_follow_up_journey_decision_changed_record_consent(
     )
 
 
+@pytest.mark.unstable
 def test_gillick_self_consent_overrides_follow_up_requested(
     give_online_consent_with_follow_up_request,
     page,

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -1,3 +1,4 @@
+import pytest
 from playwright.sync_api import expect
 
 from mavis.test.constants import Programme
@@ -42,6 +43,7 @@ def test_team_page_lists_correct_schools(page, log_in_as_nurse, schools):
     TeamSchoolsPage(page).check_only_expected_schools_visible(schools)
 
 
+@pytest.mark.unstable
 def test_team_page_add_school_sites(page, log_in_as_nurse, schools):
     """
     Test: Verify that the user can add multiple school sites to the team.


### PR DESCRIPTION
Add `unstable` marker to tests mentioned in:
https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/issues/1139
https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/issues/1158
