### PR TITLE
Always generate test reports

### DIFF
--- a/.github/workflows/accessibility.yaml
+++ b/.github/workflows/accessibility.yaml
@@ -88,7 +88,6 @@ jobs:
               echo "environment=${env_map[qa]}"
               echo "set_feature_flags=false"
               echo "additional_feature_flags="
-              echo "deploy_report=false"
               echo "screenshot_all_steps=false"
           } >> "$GITHUB_OUTPUT"
           else
@@ -102,7 +101,6 @@ jobs:
 
               echo "set_feature_flags=${{ github.event.inputs.set_feature_flags }}"
               echo "additional_feature_flags=${{ github.event.inputs.additional_feature_flags }}"
-              echo "deploy_report=true"
               echo "screenshot_all_steps=${{ github.event.inputs.screenshot_all_steps }}"
             } >> "$GITHUB_OUTPUT"
           fi
@@ -142,14 +140,14 @@ jobs:
           IMMS_API_PEM: ${{ secrets.IMMS_API_PEM }}
 
       - name: Configure AWS credentials
-        if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        if: always()
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::393416225559:role/GitHubAssuranceTestRole
 
       - name: Process reports
-        if: always() && steps.set-variables.outputs.deploy_report == 'true'
+        if: always()
         uses: ./.github/actions/deploy-reports
         with:
           device: ${{ steps.set-variables.outputs.device }}

--- a/.github/workflows/end-to-end-tests-release.yaml
+++ b/.github/workflows/end-to-end-tests-release.yaml
@@ -220,7 +220,6 @@ jobs:
               echo "environment=${env_map[qa]}"
               echo "set_feature_flags=false"
               echo "additional_feature_flags="
-              echo "deploy_report=false"
               echo "screenshot_all_steps=false"
               echo "enable_reruns=true"
               echo "test_workers=4"
@@ -243,7 +242,6 @@ jobs:
 
               echo "set_feature_flags=${{ inputs.set_feature_flags }}"
               echo "additional_feature_flags=${{ inputs.additional_feature_flags }}"
-              echo "deploy_report=true"
               echo "screenshot_all_steps=${{ inputs.screenshot_all_steps }}"
               echo "enable_reruns=${{ inputs.enable_reruns }}"
               echo "test_workers=${{ inputs.test_workers }}"
@@ -309,8 +307,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: >-
-          always() && steps.set-variables.outputs.deploy_report == 'true'
-          && matrix.suite.label == 'main'
+          always()
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
@@ -318,8 +315,7 @@ jobs:
 
       - name: Process reports
         if: >-
-          always() && steps.set-variables.outputs.deploy_report == 'true'
-          && matrix.suite.label == 'main'
+          always()
         continue-on-error: true
         uses: ./.github/actions/deploy-reports
         with:

--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -207,7 +207,6 @@ jobs:
               echo "environment=${env_map[qa]}"
               echo "set_feature_flags=false"
               echo "additional_feature_flags="
-              echo "deploy_report=false"
               echo "screenshot_all_steps=false"
               echo "enable_reruns=true"
               echo "test_workers=4"
@@ -229,7 +228,6 @@ jobs:
 
               echo "set_feature_flags=${{ inputs.set_feature_flags }}"
               echo "additional_feature_flags=${{ inputs.additional_feature_flags }}"
-              echo "deploy_report=true"
               echo "screenshot_all_steps=${{ inputs.screenshot_all_steps }}"
               echo "enable_reruns=${{ inputs.enable_reruns }}"
               echo "test_workers=${{ inputs.test_workers }}"
@@ -280,8 +278,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: >-
-          always() && steps.set-variables.outputs.deploy_report == 'true'
-          && matrix.suite.label == 'main'
+          always()
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: eu-west-2
@@ -289,8 +286,7 @@ jobs:
 
       - name: Process reports
         if: >-
-          always() && steps.set-variables.outputs.deploy_report == 'true'
-          && matrix.suite.label == 'main'
+          always()
         continue-on-error: true
         uses: ./.github/actions/deploy-reports
         with:


### PR DESCRIPTION
It's safe to generate test reports on all runs now that they're hosted on AWS.